### PR TITLE
Fix secret list offset parameter

### DIFF
--- a/console2/src/api/org/secret/index.ts
+++ b/console2/src/api/org/secret/index.ts
@@ -117,7 +117,7 @@ export const list = async (
     limit: number,
     filter?: string
 ): Promise<PaginatedSecretEntries> => {
-    const offsetParam = offset * limit;
+    const offsetParam = offset > 0 && limit > 0 ? offset * limit : offset;
     const limitParam = limit > 0 ? limit + 1 : limit;
 
     const data: SecretEntry[] = await fetchJson(


### PR DESCRIPTION
Only multiply the offset by limit if both values are positive.

Fixes the usage here:
https://github.com/walmartlabs/concord/blob/434327a1f4b91ff1314441534678fa2d387ad14b/console2/src/components/organisms/SecretDropdown/index.tsx#L97

Currently the above usage offset becomes 1, hiding the first (and possibly only) item in the list.