### PR TITLE
concord-server: remove kafka-event-sink from dist

### DIFF
--- a/server/dist/pom.xml
+++ b/server/dist/pom.xml
@@ -40,10 +40,6 @@
             <groupId>com.walmartlabs.concord.server.plugins</groupId>
             <artifactId>oidc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.walmartlabs.concord.server.plugins</groupId>
-            <artifactId>kafka-event-sink</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
It was erroneously added in ce3899aec648b89062315e9797ad9ea4c00018d1
cc @brig 