### PR TITLE
concord-agent, it: change bindings to allow testcontainers-concord LOCAL mode

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/Worker.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Worker.java
@@ -21,12 +21,12 @@ package com.walmartlabs.concord.agent;
  */
 
 import com.walmartlabs.concord.agent.executors.JobExecutor;
+import com.walmartlabs.concord.agent.guice.AgentImportManager;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
 import com.walmartlabs.concord.agent.remote.ProcessStatusUpdater;
 import com.walmartlabs.concord.client.ProcessEntry.StatusEnum;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.imports.Import.SecretDefinition;
-import com.walmartlabs.concord.imports.ImportManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class Worker implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(Worker.class);
 
     private final RepositoryManager repositoryManager;
-    private final ImportManager importManager;
+    private final AgentImportManager importManager;
     private final JobExecutor executor;
     private final CompletionCallback completionCallback;
     private final StateFetcher stateFetcher;
@@ -52,7 +52,7 @@ public class Worker implements Runnable {
 
     @Inject
     public Worker(RepositoryManager repositoryManager,
-                  ImportManager importManager,
+                  AgentImportManager importManager,
                   JobExecutor executor,
                   CompletionCallback completionCallback,
                   StateFetcher stateFetcher,

--- a/agent/src/main/java/com/walmartlabs/concord/agent/WorkerFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/WorkerFactory.java
@@ -22,16 +22,16 @@ package com.walmartlabs.concord.agent;
 
 import com.walmartlabs.concord.agent.executors.JobExecutor;
 import com.walmartlabs.concord.agent.executors.JobExecutorFactory;
+import com.walmartlabs.concord.agent.guice.AgentImportManager;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
 import com.walmartlabs.concord.agent.remote.ProcessStatusUpdater;
-import com.walmartlabs.concord.imports.ImportManager;
 
 import javax.inject.Inject;
 
 public class WorkerFactory {
 
     private final RepositoryManager repositoryManager;
-    private final ImportManager importManager;
+    private final AgentImportManager importManager;
     private final JobExecutorFactory jobExecutorFactory;
     private final StateFetcher stateFetcher;
     private final ProcessStatusUpdater statusUpdater;
@@ -39,7 +39,7 @@ public class WorkerFactory {
 
     @Inject
     public WorkerFactory(RepositoryManager repositoryManager,
-                         ImportManager importManager,
+                         AgentImportManager importManager,
                          JobExecutorFactory jobExecutorFactory,
                          StateFetcher stateFetcher,
                          ProcessStatusUpdater statusUpdater,

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
@@ -26,6 +26,7 @@ import com.walmartlabs.concord.agent.cfg.*;
 import com.walmartlabs.concord.agent.executors.runner.DefaultDependencies;
 import com.walmartlabs.concord.agent.executors.runner.ProcessPool;
 import com.walmartlabs.concord.agent.executors.runner.RunnerJobExecutor;
+import com.walmartlabs.concord.agent.guice.AgentDependencyManager;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
 import com.walmartlabs.concord.agent.logging.ProcessLogFactory;
 import com.walmartlabs.concord.agent.remote.AttachmentsUploader;
@@ -49,7 +50,7 @@ public class JobExecutorFactory {
     private final RunnerV1Configuration runnerV1Cfg;
     private final RunnerV2Configuration runnerV2Cfg;
 
-    private final DependencyManager dependencyManager;
+    private final AgentDependencyManager dependencyManager;
     private final DefaultDependencies defaultDependencies;
     private final ProcessPool processPool;
     private final ProcessLog processLog;
@@ -64,7 +65,7 @@ public class JobExecutorFactory {
                               DockerConfiguration dockerCfg,
                               RunnerV1Configuration runnerV1Cfg,
                               RunnerV2Configuration runnerV2Cfg,
-                              DependencyManager dependencyManager,
+                              AgentDependencyManager dependencyManager,
                               DefaultDependencies defaultDependencies,
                               ProcessPool processPool,
                               ProcessLog processLog,

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
@@ -33,6 +33,7 @@ import com.walmartlabs.concord.agent.JobInstance;
 import com.walmartlabs.concord.agent.Utils;
 import com.walmartlabs.concord.agent.executors.JobExecutor;
 import com.walmartlabs.concord.agent.executors.runner.ProcessPool.ProcessEntry;
+import com.walmartlabs.concord.agent.guice.AgentDependencyManager;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
 import com.walmartlabs.concord.agent.logging.ProcessLogFactory;
 import com.walmartlabs.concord.agent.remote.AttachmentsUploader;
@@ -71,7 +72,7 @@ public class RunnerJobExecutor implements JobExecutor {
 
     private static final Logger log = LoggerFactory.getLogger(RunnerJobExecutor.class);
 
-    protected final DependencyManager dependencyManager;
+    protected final AgentDependencyManager dependencyManager;
 
     private final RunnerJobExecutorConfiguration cfg;
     private final DefaultDependencies defaultDependencies;
@@ -83,7 +84,7 @@ public class RunnerJobExecutor implements JobExecutor {
     private final ObjectMapper objectMapper;
 
     public RunnerJobExecutor(RunnerJobExecutorConfiguration cfg,
-                             DependencyManager dependencyManager,
+                             AgentDependencyManager dependencyManager,
                              DefaultDependencies defaultDependencies,
                              AttachmentsUploader attachmentsUploader,
                              ProcessPool processPool,

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManager.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManager.java
@@ -1,0 +1,37 @@
+package com.walmartlabs.concord.agent.guice;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.dependencymanager.DependencyManager;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A wrapper type to avoid clashes with the Server's instance of a {@link DependencyManager}.
+ * TODO replace with a common Guice module
+ */
+public class AgentDependencyManager extends DependencyManager {
+
+    public AgentDependencyManager(Path cacheDir) throws IOException {
+        super(cacheDir);
+    }
+}

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManagerProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManagerProvider.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.agent;
+package com.walmartlabs.concord.agent.guice;
 
 /*-
  * *****
@@ -21,29 +21,26 @@ package com.walmartlabs.concord.agent;
  */
 
 import com.walmartlabs.concord.agent.cfg.AgentConfiguration;
-import com.walmartlabs.concord.dependencymanager.DependencyManager;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.io.IOException;
 
-@Named
 @Singleton
-public class DependencyManagerProvider implements Provider<DependencyManager> {
+public class AgentDependencyManagerProvider implements Provider<AgentDependencyManager> {
 
     private final AgentConfiguration cfg;
 
     @Inject
-    public DependencyManagerProvider(AgentConfiguration cfg) {
+    public AgentDependencyManagerProvider(AgentConfiguration cfg) {
         this.cfg = cfg;
     }
 
     @Override
-    public DependencyManager get() {
+    public AgentDependencyManager get() {
         try {
-            return new DependencyManager(cfg.getDependencyCacheDir());
+            return new AgentDependencyManager(cfg.getDependencyCacheDir());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManager.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManager.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.agent.guice;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.imports.ImportManager;
+import com.walmartlabs.concord.imports.Imports;
+import com.walmartlabs.concord.repository.Snapshot;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * A wrapper type to avoid clashes with the Server's instance of a {@link ImportManager}.
+ * TODO replace with a common Guice module
+ */
+public class AgentImportManager implements ImportManager {
+
+    private final ImportManager delegate;
+
+    public AgentImportManager(ImportManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<Snapshot> process(Imports imports, Path dest) throws Exception {
+        return delegate.process(imports, dest);
+    }
+}

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.agent;
+package com.walmartlabs.concord.agent.guice;
 
 /*-
  * *****
@@ -20,8 +20,8 @@ package com.walmartlabs.concord.agent;
  * =====
  */
 
+import com.walmartlabs.concord.agent.RepositoryManager;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
-import com.walmartlabs.concord.imports.ImportManager;
 import com.walmartlabs.concord.imports.ImportManagerFactory;
 
 import javax.inject.Inject;
@@ -30,12 +30,12 @@ import javax.inject.Singleton;
 import java.nio.file.Path;
 
 @Singleton
-public class ImportManagerProvider implements Provider<ImportManager> {
+public class AgentImportManagerProvider implements Provider<AgentImportManager> {
 
     private final ImportManagerFactory factory;
 
     @Inject
-    public ImportManagerProvider(RepositoryManager repositoryManager, DependencyManager dependencyManager) {
+    public AgentImportManagerProvider(RepositoryManager repositoryManager, DependencyManager dependencyManager) {
         this.factory = new ImportManagerFactory(dependencyManager, (entry, workDir) -> {
             Path dst = workDir;
             if (entry.dest() != null) {
@@ -47,7 +47,7 @@ public class ImportManagerProvider implements Provider<ImportManager> {
     }
 
     @Override
-    public ImportManager get() {
-        return factory.create();
+    public AgentImportManager get() {
+        return new AgentImportManager(factory.create());
     }
 }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
@@ -21,7 +21,6 @@ package com.walmartlabs.concord.agent.guice;
  */
 
 import com.walmartlabs.concord.agent.RepositoryManager;
-import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.imports.ImportManagerFactory;
 
 import javax.inject.Inject;
@@ -35,7 +34,7 @@ public class AgentImportManagerProvider implements Provider<AgentImportManager> 
     private final ImportManagerFactory factory;
 
     @Inject
-    public AgentImportManagerProvider(RepositoryManager repositoryManager, DependencyManager dependencyManager) {
+    public AgentImportManagerProvider(RepositoryManager repositoryManager, AgentDependencyManager dependencyManager) {
         this.factory = new ImportManagerFactory(dependencyManager, (entry, workDir) -> {
             Path dst = workDir;
             if (entry.dest() != null) {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/WorkerModule.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/WorkerModule.java
@@ -25,8 +25,6 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.agent.DefaultStateFetcher;
-import com.walmartlabs.concord.agent.DependencyManagerProvider;
-import com.walmartlabs.concord.agent.ImportManagerProvider;
 import com.walmartlabs.concord.agent.StateFetcher;
 import com.walmartlabs.concord.agent.logging.LogAppender;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
@@ -37,7 +35,6 @@ import com.walmartlabs.concord.agent.remote.ProcessStatusUpdater;
 import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.SecretClient;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
-import com.walmartlabs.concord.imports.ImportManager;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -89,7 +86,7 @@ public class WorkerModule extends AbstractModule {
         bind(StateFetcher.class).to(DefaultStateFetcher.class);
         bind(LogAppender.class).to(RemoteLogAppender.class);
 
-        bind(ImportManager.class).toProvider(ImportManagerProvider.class);
-        bind(DependencyManager.class).toProvider(DependencyManagerProvider.class);
+        bind(AgentImportManager.class).toProvider(AgentImportManagerProvider.class);
+        bind(AgentDependencyManager.class).toProvider(AgentDependencyManagerProvider.class);
     }
 }

--- a/it/compat/README.md
+++ b/it/compat/README.md
@@ -1,1 +1,1 @@
-# Integration Tests for Ensuring Backward Compatibility
+# Integration Tests to Ensure Backward Compatibility

--- a/it/compat/pom.xml
+++ b/it/compat/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,6 +51,23 @@
             <artifactId>concord-client</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- LOCAL mode support -->
+        <dependency>
+            <groupId>com.walmartlabs.concord.server</groupId>
+            <artifactId>concord-server-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.server</groupId>
+            <artifactId>concord-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord</groupId>
+            <artifactId>concord-agent</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -88,6 +106,33 @@
                         <agent.image>${prev.agent.image}</agent.image>
                     </systemProperties>
                 </configuration>
+            </plugin>
+
+            <!-- LOCAL mode support -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-runner-jar</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.walmartlabs.concord.runtime.v1</groupId>
+                                    <artifactId>concord-runtime-impl-v1</artifactId>
+                                    <classifier>jar-with-dependencies</classifier>
+                                    <destFileName>runner-v1.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/it/compat/src/test/java/com/walmartlabs/concord/it/compat/ITConstants.java
+++ b/it/compat/src/test/java/com/walmartlabs/concord/it/compat/ITConstants.java
@@ -1,0 +1,29 @@
+package com.walmartlabs.concord.it.compat;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public final class ITConstants {
+
+    public static final long DEFAULT_TEST_TIMEOUT = 120000;
+
+    private ITConstants() {
+    }
+}

--- a/it/compat/src/test/java/com/walmartlabs/concord/it/compat/LocalModeIT.java
+++ b/it/compat/src/test/java/com/walmartlabs/concord/it/compat/LocalModeIT.java
@@ -1,0 +1,54 @@
+package com.walmartlabs.concord.it.compat;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.Concord;
+import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.Payload;
+import ca.ibodrov.concord.testcontainers.junit4.ConcordRule;
+import com.walmartlabs.concord.client.ProcessEntry;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.walmartlabs.concord.it.compat.ITConstants.DEFAULT_TEST_TIMEOUT;
+
+/**
+ * Runs the current versions of the Server and the Agent in testcontainer-concord's LOCAL mode.
+ */
+public class LocalModeIT {
+
+    @Rule
+    public ConcordRule concord = new ConcordRule()
+            .mode(Concord.Mode.LOCAL);
+
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void test() throws Exception {
+        String concordYml = "flows:\n" +
+                "  default:\n" +
+                "    - log: \"Hello!\"\n";
+
+        ConcordProcess proc = concord.processes().start(new Payload()
+                .concordYml(concordYml));
+
+        proc.waitForStatus(ProcessEntry.StatusEnum.FINISHED);
+        proc.assertLog(".*Hello!.*");
+    }
+}

--- a/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
+++ b/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
@@ -28,9 +28,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.images.PullPolicy;
 
-public class CompatIT {
+import static com.walmartlabs.concord.it.compat.ITConstants.DEFAULT_TEST_TIMEOUT;
 
-    private static final long DEFAULT_TEST_TIMEOUT = 120000;
+/**
+ * Runs an older version of the Agent with the current version of the Server.
+ */
+public class OldAgentIT {
 
     @Rule
     public final ConcordRule concord = new ConcordRule()


### PR DESCRIPTION
1.60.0 broke the `LOCAL` mode in testcontainers-concord:
```
1) A binding to com.walmartlabs.concord.imports.ImportManager was already configured at org.eclipse.sisu.wire.LocatorWiring.
  at com.walmartlabs.concord.agent.guice.WorkerModule.configure(WorkerModule.java:92)
2) A binding to com.walmartlabs.concord.dependencymanager.DependencyManager was already configured at org.eclipse.sisu.wire.LocatorWiring.
  at com.walmartlabs.concord.agent.guice.WorkerModule.configure(WorkerModule.java:93)
```

When running in the same VM both the Agent and the Server were trying to bind the same interfaces.

This PR:
- creates wrapper types for the Agent's `ImportManager` and `DependencyManager`. This way both the Server's and the Agent's instances can co-exist in the same Injector;
- adds a test for the LOCAL mode;
- renames `CompatIT` to `OldAgentIT`.

cc @brig 