### PR TITLE
project: more JDK11 compatibility updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ different systems together using scenarios and plugins created by users.
 
 Dependencies:
 - [Git](https://git-scm.com/) 2.18+
-- [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- [Java 8](https://adoptopenjdk.net/)
 - [Docker Community Edition](https://www.docker.com/community-edition)
 - (Optional) [NodeJS and NPM](https://nodejs.org/en/download/) (Node 10 or greater)
 
@@ -49,6 +49,16 @@ Start the console in dev mode by running:
 npm run start
 ```
 
+### Java 11
+
+Use the `jdk11` profile:
+
+```
+./mvnw clean install -DskipTests -Pdocker -Pjdk11
+```
+
+This command builds binaries and Docker images using JDK 11.
+
 ### Integration tests
 
 #### Prerequisites
@@ -59,8 +69,8 @@ Prerequisites:
 - Docker, listening on `tcp://127.0.0.1:2375`;
 - Ansible 2.6.0+ must be installed and available in `$PATH`.
   See [the official documentation](http://docs.ansible.com/ansible/intro_installation.html);
-- `requests` python module is required. It can be installed using `pip install requests`
-or a system package manager;
+- `requests` python module is required. It can be installed by using `pip install requests`
+  or the system package manager;
 - Java must be available in `$PATH` as `java`;
 - [Chrome WebDriver](http://chromedriver.chromium.org/) available in `$PATH`.
 

--- a/agent/src/assembly/start.sh
+++ b/agent/src/assembly/start.sh
@@ -14,6 +14,9 @@ if [[ -z "${CONCORD_CFG_FILE}" ]]; then
 fi
 echo "CONCORD_CFG_FILE: ${CONCORD_CFG_FILE}"
 
+echo "Using $(which java)"
+java -version
+
 exec java \
 -Xmx256m \
 -server \

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -42,6 +42,28 @@
             <artifactId>commons-compress</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- JDK9+ compatibility -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -52,10 +74,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
         </dependency>
     </dependencies>
 

--- a/docker-images/base/oss/Dockerfile
+++ b/docker-images/base/oss/Dockerfile
@@ -4,12 +4,12 @@ MAINTAINER "Ivan Bodrov" <ibodrov@walmartlabs.com>
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ARG jdk_version=1.8.0
-ENV JAVA_HOME /usr/lib/jvm/java-$jdk_version
+ENV JAVA_HOME /usr/lib/jvm/java-${jdk_version}
 
 # requires Git >= 2.3
 RUN yum -y --enablerepo=extras install epel-release && \
     yum -y update && \
-    yum -y install yum-utils java-$jdk_version-openjdk-devel which libtool-ltdl strace python2 python2-pip git coreutils-single && \
+    yum -y install yum-utils java-${jdk_version}-openjdk-devel which libtool-ltdl strace python2 python2-pip git coreutils-single && \
     yum clean all
 
 RUN alternatives --set python /usr/bin/python2

--- a/docker-images/pom.xml
+++ b/docker-images/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -83,6 +84,15 @@
             </activation>
             <properties>
                 <docker.skip>false</docker.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <jdk.version>11</jdk.version>
             </properties>
         </profile>
     </profiles>

--- a/docker-images/server/oss/Dockerfile
+++ b/docker-images/server/oss/Dockerfile
@@ -9,6 +9,9 @@ EXPOSE 8001
 ADD --chown=concord:concord target/dist/server.tar.gz /opt/concord/server/
 ADD --chown=concord:concord target/dist/console.tar.gz /opt/concord/console/
 
+RUN mkdir -p /opt/concord/server/logs && \
+    chown -R concord:concord /opt/concord/server/logs
+
 USER concord
 
 ENV BASE_RESOURCE_PATH /opt/concord/console/

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <scm.connection>scm:git:https://github.com/walmartlabs/concord.git</scm.connection>
 
         <docker.plugin.version>0.30.0</docker.plugin.version>
-        <jooq.version>3.12.1</jooq.version>
+        <jooq.version>3.13.4</jooq.version>
         <liquibase.version>3.5.1</liquibase.version> <!-- the newer versions (up to 3.5.3) have incorrect mappings for PG's blob/bytea -->
         <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
         <node.version>10.11.0</node.version>

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/Main.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/Main.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.*;
+import com.google.inject.Module;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/InjectorFactory.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/InjectorFactory.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.runtime.v2.runner;
  */
 
 import com.google.inject.*;
+import com.google.inject.Module;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
 import com.walmartlabs.concord.runtime.common.injector.InjectorUtils;
 import com.walmartlabs.concord.runtime.common.injector.InstanceId;

--- a/server/dist/src/assembly/start.sh
+++ b/server/dist/src/assembly/start.sh
@@ -25,6 +25,9 @@ if [[ -z "${CONCORD_TMP_DIR}" ]]; then
     export CONCORD_TMP_DIR="/tmp"
 fi
 
+echo "Using $(which java)"
+java -version
+
 exec java \
 ${CONCORD_JAVA_OPTS} \
 -Dfile.encoding=UTF-8 \

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -39,7 +39,7 @@
         <gson.fire.version>1.8.3</gson.fire.version>
         <gson.version>2.8.6</gson.version>
         <guava.version>25.1-jre</guava.version>
-        <guice.version>4.2.2</guice.version>
+        <guice.version>4.2.3</guice.version>
         <hibernate.validator.version>6.1.5.Final</hibernate.validator.version>
         <hikaricp.version>3.4.2</hikaricp.version>
         <http.request.version>6.0</http.request.version>
@@ -59,7 +59,7 @@
         <jaxb.version>2.3.0.1</jaxb.version>
         <jetty.version>9.4.26.v20200117</jetty.version>
         <jgit.version>5.2.0.201812061821-r</jgit.version> <!-- updating requires some changes in how the auth is set up in ITs -->
-        <jooq.version>3.12.3</jooq.version>
+        <jooq.version>3.13.4</jooq.version>
         <jsch.version>0.1.55</jsch.version>
         <json.smart.version>2.3</json.smart.version>
         <jsqlparser.version>3.1</jsqlparser.version>


### PR DESCRIPTION
- add `jdk11` Maven profile;
- fix `Module` imports;
- update JOOQ and Guice versions to get rid of `Illegal reflective access by...` warnings;
- print out path to Java and the current Java version in the Agent's and the Server's start.sh scripts. Useful for debugging.

All tests seems to be happy when I run them locally
```
$ ./mvnw clean install -Pit -Pdocker -Pjdk11
```

cc @brig 