### PR TITLE
concord-agent: add CONCORD_JAVA_OPTS to the start script

### DIFF
--- a/agent/src/assembly/start.sh
+++ b/agent/src/assembly/start.sh
@@ -9,6 +9,11 @@ if [[ -z "${CONCORD_TMP_DIR}" ]]; then
     export CONCORD_TMP_DIR="/tmp"
 fi
 
+if [[ -z "${CONCORD_JAVA_OPTS}" ]]; then
+    CONCORD_JAVA_OPTS="-Xmx256m"
+fi
+echo "CONCORD_JAVA_OPTS: ${CONCORD_JAVA_OPTS}"
+
 if [[ -z "${CONCORD_CFG_FILE}" ]]; then
     CONCORD_CFG_FILE="${BASE_DIR}/default.conf"
 fi
@@ -18,8 +23,7 @@ echo "Using $(which java)"
 java -version
 
 exec java \
--Xmx256m \
--server \
+${CONCORD_JAVA_OPTS} \
 -Dfile.encoding=UTF-8 \
 -Djava.net.preferIPv4Stack=true \
 -Djava.security.egd=file:/dev/./urandom \


### PR DESCRIPTION
Similar to the Server's start.sh. Useful for Java 11's `-XX:+UseContainerSupport`.

cc @brig 