### PR TITLE
concord-server: non-superuser version of 1.58.0 migrations

### DIFF
--- a/server/db/pom.xml
+++ b/server/db/pom.xml
@@ -164,6 +164,9 @@
                     <password>${db.password}</password>
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                     <contexts>codegen</contexts>
+                    <expressionVariables>
+                        <superuserAvailable>true</superuserAvailable>
+                    </expressionVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.44.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.44.0.xml
@@ -6,6 +6,10 @@
 
     <!-- enable UUID generation -->
     <changeSet id="44000-init" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             CREATE EXTENSION IF NOT EXISTS "uuid-ossp"
         </sql>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.34.3.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.34.3.xml
@@ -5,6 +5,10 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="1344000" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             CREATE EXTENSION IF NOT EXISTS "pg_trgm"
         </sql>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.58.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.58.0.xml
@@ -10,6 +10,8 @@
 
             Assuming the current data is in UTC, we can change all "timestamp" columns
             and indices to "timestamp with time zone" just by updating the column's "atttypid".
+
+            Requires SUPERUSER privileges.
         -->
         <createProcedure dbms="postgresql">
             create or replace function ts_to_tstz(t text)
@@ -50,50 +52,160 @@
 
     <!-- AGENT_COMMANDS -->
     <changeSet id="1580100" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('agent_commands')
         </sql>
     </changeSet>
 
+    <changeSet id="1580100-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table AGENT_COMMANDS alter column CREATED_AT type timestamptz using CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- API_KEYS -->
     <changeSet id="1580110" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('api_keys')
         </sql>
     </changeSet>
 
+    <changeSet id="1580110-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table API_KEYS
+                alter column EXPIRED_AT type timestamptz using EXPIRED_AT at time zone 'UTC',
+                alter column LAST_NOTIFIED_AT type timestamptz using LAST_NOTIFIED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- PROCESS_QUEUE -->
     <changeSet id="1580120" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_queue')
         </sql>
     </changeSet>
 
+    <changeSet id="1580120-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_QUEUE
+                alter column CREATED_AT type timestamptz using CREATED_AT at time zone 'UTC',
+                alter column LAST_UPDATED_AT type timestamptz using LAST_UPDATED_AT at time zone 'UTC',
+                alter column START_AT type timestamptz using START_AT at time zone 'UTC',
+                alter column LAST_RUN_AT type timestamptz using LAST_RUN_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- TASKS -->
     <changeSet id="1580130" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('tasks')
         </sql>
     </changeSet>
 
+    <changeSet id="1580130-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table TASKS
+                alter column STARTED_AT type timestamptz using STARTED_AT at time zone 'UTC',
+                alter column FINISHED_AT type timestamptz using FINISHED_AT at time zone 'UTC',
+                alter column LAST_UPDATED_AT type timestamptz using LAST_UPDATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- TASK_LOCKS -->
     <changeSet id="1580140" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('task_locks')
         </sql>
     </changeSet>
 
+    <changeSet id="1580140-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table TASK_LOCKS
+                alter column LOCKED_AT type timestamptz using LOCKED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- TRIGGER_SCHEDULE -->
     <changeSet id="1580150" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('trigger_schedule')
         </sql>
     </changeSet>
 
+    <changeSet id="1580150-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table TRIGGER_SCHEDULE
+                alter column FIRE_AT type timestamptz using FIRE_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- USERS -->
     <changeSet id="1580160" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('users')
+        </sql>
+    </changeSet>
+
+    <changeSet id="1580160-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table USERS
+                alter column LAST_GROUP_SYNC_DT type timestamptz using LAST_GROUP_SYNC_DT at time zone 'UTC'
         </sql>
     </changeSet>
 
@@ -101,8 +213,25 @@
 
     <!-- AUDIT_LOG -->
     <changeSet id="1580200" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('audit_log%')
+        </sql>
+    </changeSet>
+
+    <changeSet id="1580200-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <dropView viewName="V_AUDIT_LOG"/>
+
+        <sql>
+            alter table AUDIT_LOG
+                alter column ENTRY_DATE type timestamptz using ENTRY_DATE at time zone 'UTC'
         </sql>
     </changeSet>
 
@@ -123,41 +252,123 @@
 
     <!-- PROCESS_CHECKPOINTS -->
     <changeSet id="1580210" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_checkpoints%')
         </sql>
     </changeSet>
 
+    <changeSet id="1580210-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_CHECKPOINTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC',
+                alter column CHECKPOINT_DATE type timestamptz using CHECKPOINT_DATE at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- PROCESS_EVENTS -->
     <changeSet id="1580220" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_events%')
         </sql>
     </changeSet>
 
+    <changeSet id="1580220-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_EVENTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC',
+                alter column EVENT_DATE type timestamptz using EVENT_DATE at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- PROCESS_LOG_DATA -->
     <changeSet id="1580230" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_log_data%')
         </sql>
     </changeSet>
 
+    <changeSet id="1580230-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_LOG_DATA
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- PROCESS_LOG_SEGMENTS -->
     <changeSet id="1580240" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_log_segments%')
         </sql>
     </changeSet>
 
+    <changeSet id="1580240-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_LOG_SEGMENTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC',
+                alter column SEGMENT_TS type timestamptz using SEGMENT_TS at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- PROCESS_STATE -->
     <changeSet id="1580250" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('process_state%')
         </sql>
     </changeSet>
 
+    <changeSet id="1580250-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table PROCESS_STATE
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- the rest of it -->
     <changeSet id="1580300" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             update pg_attribute
                 set atttypid = 'timestamp with time zone'::regtype

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -60,6 +60,9 @@ concord-server {
             # if empty a new random token will be generated
             # applied only once on the first DB migration
             defaultAdminToken = ""
+
+            # some migrations can be done faster if the DB user has the SUPERUSER role
+            superuserAvailable = "true"
         }
     }
 

--- a/server/plugins/ansible/db/pom.xml
+++ b/server/plugins/ansible/db/pom.xml
@@ -158,6 +158,9 @@
                     <username>${db.username}</username>
                     <password>${db.password}</password>
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
+                    <expressionVariables>
+                        <superuserAvailable>true</superuserAvailable>
+                    </expressionVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/server/plugins/ansible/db/src/main/resources/com/walmartlabs/concord/server/plugins/ansible/db/liquibase.xml
+++ b/server/plugins/ansible/db/src/main/resources/com/walmartlabs/concord/server/plugins/ansible/db/liquibase.xml
@@ -267,42 +267,122 @@
 
     <!-- ANSIBLE_HOSTS -->
     <changeSet id="ansible-1580100" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('ansible_hosts%')
         </sql>
     </changeSet>
 
+    <changeSet id="ansible-1580100-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table ANSIBLE_HOSTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- ANSIBLE_PLAY_STATS -->
     <changeSet id="ansible-1580110" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('ansible_play_stats%')
         </sql>
     </changeSet>
 
+    <changeSet id="ansible-1580110-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table ANSIBLE_PLAY_STATS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- ANSIBLE_PLAYBOOK_RESULT -->
     <changeSet id="ansible-1580120" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('ansible_playbook_result%')
         </sql>
     </changeSet>
 
+    <changeSet id="ansible-1580120-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table ANSIBLE_PLAYBOOK_RESULT
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- ANSIBLE_PLAYBOOK_STATS -->
     <changeSet id="ansible-1580130" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('ansible_playbook_stats%')
         </sql>
     </changeSet>
 
+    <changeSet id="ansible-1580130-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table ANSIBLE_PLAYBOOK_STATS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC',
+                alter column STARTED_AT type timestamptz using STARTED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- ANSIBLE_TASK_STATS -->
     <changeSet id="ansible-1580140" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('ansible_task_stats%')
+        </sql>
+    </changeSet>
+
+    <changeSet id="ansible-1580140-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table ANSIBLE_TASK_STATS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
         </sql>
     </changeSet>
 
     <!-- indices -->
 
     <changeSet id="ansible-1580200" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('idx_a_playbook_stats')
         </sql>

--- a/server/plugins/noderoster/db/pom.xml
+++ b/server/plugins/noderoster/db/pom.xml
@@ -158,6 +158,9 @@
                     <username>${db.username}</username>
                     <password>${db.password}</password>
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
+                    <expressionVariables>
+                        <superuserAvailable>true</superuserAvailable>
+                    </expressionVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/server/plugins/noderoster/db/src/main/java/com/walmartlabs/concord/server/plugins/noderoster/db/DatabaseModule.java
+++ b/server/plugins/noderoster/db/src/main/java/com/walmartlabs/concord/server/plugins/noderoster/db/DatabaseModule.java
@@ -26,9 +26,8 @@ import com.google.inject.Provides;
 import com.walmartlabs.concord.db.DataSourceUtils;
 import com.walmartlabs.concord.db.DatabaseChangeLogProvider;
 import com.walmartlabs.concord.db.DatabaseConfiguration;
+import com.walmartlabs.concord.db.MainDB;
 import org.jooq.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -37,17 +36,16 @@ import javax.sql.DataSource;
 @Named
 public class DatabaseModule extends AbstractModule {
 
-    private static final Logger log = LoggerFactory.getLogger(DatabaseModule.class);
-
     @Provides
     @NodeRosterDB
     @Singleton
     public DataSource dataSource(@NodeRosterDB DatabaseConfiguration cfg,
                                  MetricRegistry metricRegistry,
-                                 @NodeRosterDB DatabaseChangeLogProvider changeLogProvider) {
+                                 @NodeRosterDB DatabaseChangeLogProvider changeLogProvider,
+                                 @MainDB DatabaseConfiguration mainCfg) {
 
         DataSource ds = DataSourceUtils.createDataSource(cfg, "noderoster", cfg.username(), cfg.password(), metricRegistry);
-        DataSourceUtils.migrateDb(ds, changeLogProvider);
+        DataSourceUtils.migrateDb(ds, changeLogProvider, mainCfg.changeLogParameters());
         return ds;
     }
 

--- a/server/plugins/noderoster/db/src/main/resources/com/walmartlabs/concord/server/plugins/noderoster/db/liquibase.xml
+++ b/server/plugins/noderoster/db/src/main/resources/com/walmartlabs/concord/server/plugins/noderoster/db/liquibase.xml
@@ -155,8 +155,23 @@
 
     <!-- NODE_ROSTER_HOSTS -->
     <changeSet id="noderoster-1580100" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('node_roster_hosts')
+        </sql>
+    </changeSet>
+
+    <changeSet id="noderoster-1580100-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table NODE_ROSTER_HOSTS
+                alter column CREATED_AT type timestamptz using CREATED_AT at time zone 'UTC'
         </sql>
     </changeSet>
 
@@ -164,28 +179,77 @@
 
     <!-- NODE_ROSTER_HOST_ARTIFACTS -->
     <changeSet id="noderoster-1580110" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('node_roster_host_artifacts%')
         </sql>
     </changeSet>
 
+    <changeSet id="noderoster-1580110-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table NODE_ROSTER_HOST_ARTIFACTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- NODE_ROSTER_HOST_FACTS -->
     <changeSet id="noderoster-1580120" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('node_roster_host_facts%')
         </sql>
     </changeSet>
 
+    <changeSet id="noderoster-1580120-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table NODE_ROSTER_HOST_FACTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
+        </sql>
+    </changeSet>
+
     <!-- NODE_ROSTER_PROCESS_HOSTS -->
     <changeSet id="noderoster-1580130" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('node_roster_process_hosts%')
+        </sql>
+    </changeSet>
+
+    <changeSet id="noderoster-1580130-a" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="false"/>
+        </preConditions>
+
+        <sql>
+            alter table NODE_ROSTER_PROCESS_HOSTS
+                alter column INSTANCE_CREATED_AT type timestamptz using INSTANCE_CREATED_AT at time zone 'UTC'
         </sql>
     </changeSet>
 
     <!-- indices -->
 
     <changeSet id="noderoster-1580200" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             select ts_to_tstz('pk_node_roster_process_hosts')
         </sql>


### PR DESCRIPTION
Allows deployment of the schema without the SUPERUSER role.

Adds an optional mode when `SUPERUSER` is not required:
```
concord-server {
    db {
        changeLogParameters {
            superuserAvailable = "false"
        }
    }
}
```

Useful for certain managed environments where SUPERUSER is typically not available.

Docs: https://github.com/walmartlabs/concord-website/pull/27