### PR TITLE
concord-server: apply jdkOnly to all Immutables in the module

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogEntry.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogEntry.java
@@ -33,7 +33,6 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 
 @Value.Immutable
-@Value.Style(jdkOnly = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonSerialize(as = ImmutableAuditLogEntry.class)
 @JsonDeserialize(as = ImmutableAuditLogEntry.class)

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/package-info.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/package-info.java
@@ -1,4 +1,5 @@
-package com.walmartlabs.concord.server.events;
+@Value.Style(jdkOnly = true)
+package com.walmartlabs.concord.server;
 
 /*-
  * *****
@@ -20,33 +21,4 @@ package com.walmartlabs.concord.server.events;
  * =====
  */
 
-import com.walmartlabs.concord.common.AllowNulls;
-import com.walmartlabs.concord.server.user.UserEntry;
 import org.immutables.value.Value;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.function.Supplier;
-
-@Value.Immutable
-public interface Event {
-
-    String id();
-
-    String name();
-
-    @Value.Default
-    default Supplier<UserEntry> initiator() {
-        return () -> null;
-    }
-
-    @AllowNulls
-    @Value.Default
-    default Map<String, Object> attributes() {
-        return Collections.emptyMap();
-    }
-
-    static ImmutableEvent.Builder builder() {
-        return ImmutableEvent.builder();
-    }
-}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/NewProcessEvent.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/NewProcessEvent.java
@@ -29,7 +29,6 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 
 @Value.Immutable
-@Value.Style(jdkOnly = true)
 public interface NewProcessEvent {
 
     ProcessKey processKey();

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/ProcessEventEntry.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/ProcessEventEntry.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.UUID;
 
 @Value.Immutable
-@Value.Style(jdkOnly = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonSerialize(as = ImmutableProcessEventEntry.class)
 @JsonDeserialize(as = ImmutableProcessEventEntry.class)


### PR DESCRIPTION
Use a package-level `@Value.Style(jdkOnly = true)` annotation instead of individually marking each interface/class.