### PR TITLE
concord-server: replace OrganizationManager's create and update methods with a single one

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/CreateOrganizationResponse.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/CreateOrganizationResponse.java
@@ -32,6 +32,8 @@ import java.util.UUID;
 @JsonInclude(Include.NON_NULL)
 public class CreateOrganizationResponse implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final boolean ok = true;
     private final UUID id;
     private final OperationResult result;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationDao.java
@@ -56,6 +56,11 @@ public class OrganizationDao extends AbstractDao {
     }
 
     @Override
+    protected void tx(Tx t) {
+        super.tx(t);
+    }
+
+    @Override
     public <T> T txResult(TxResult<T> t) {
         return super.txResult(t);
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationManager.java
@@ -20,6 +20,8 @@ package com.walmartlabs.concord.server.org;
  * =====
  */
 
+import com.walmartlabs.concord.server.Locks;
+import com.walmartlabs.concord.server.OperationResult;
 import com.walmartlabs.concord.server.audit.AuditAction;
 import com.walmartlabs.concord.server.audit.AuditLog;
 import com.walmartlabs.concord.server.audit.AuditObject;
@@ -41,6 +43,7 @@ import com.walmartlabs.concord.server.user.UserManager;
 import com.walmartlabs.concord.server.user.UserType;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.UnauthorizedException;
+import org.jooq.DSLContext;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
@@ -59,6 +62,7 @@ public class OrganizationManager {
     private final OrganizationDao orgDao;
     private final TeamDao teamDao;
     private final UserManager userManager;
+    private final Locks locks;
     private final AuditLog auditLog;
 
     @Inject
@@ -66,42 +70,78 @@ public class OrganizationManager {
                                OrganizationDao orgDao,
                                TeamDao teamDao,
                                UserManager userManager,
+                               Locks locks,
                                AuditLog auditLog) {
 
         this.policyManager = policyManager;
         this.orgDao = orgDao;
         this.teamDao = teamDao;
         this.userManager = userManager;
+        this.locks = locks;
         this.auditLog = auditLog;
     }
 
-    public UUID create(OrganizationEntry entry) {
+    /**
+     * Creates a new organization or updates an existing one.
+     * <p/>
+     * To update an existing organization, a {@link OrganizationEntry#getId()}
+     * value must be provided.
+     * <p/>
+     * When updating an existing organization, only non-null properties are updated.
+     * E.g. if you wish to update only the org's visibility, set only the ID and the
+     * visibility values.
+     *
+     * @apiNote the method uses DB advisory locks, it is thread-safe across the cluster.
+     */
+    public OrganizationOperationResult createOrUpdate(OrganizationEntry entry) {
+        return orgDao.txResult(tx -> {
+            // use advisory locks to avoid races
+            locks.lock(tx, "OrganizationManager#createOrUpdate");
+
+            UUID orgId = entry.getId();
+            if (orgId == null) {
+                orgId = orgDao.getId(entry.getName());
+            }
+
+            if (orgId == null) {
+                orgId = create(tx, entry);
+                return OrganizationOperationResult.builder()
+                        .orgId(orgId)
+                        .result(OperationResult.CREATED)
+                        .build();
+            } else {
+                update(tx, orgId, entry);
+                return OrganizationOperationResult.builder()
+                        .orgId(orgId)
+                        .result(OperationResult.UPDATED)
+                        .build();
+            }
+        });
+    }
+
+    private UUID create(DSLContext tx, OrganizationEntry entry) {
         assertPermission(Permission.CREATE_ORG);
 
         UserEntry owner = getOwner(entry.getOwner(), UserPrincipal.assertCurrent().getUser());
 
         policyManager.checkEntity(null, null, EntityType.ORGANIZATION, EntityAction.CREATE, owner, PolicyUtils.toMap(entry));
 
-        UUID id = orgDao.txResult(tx -> {
-            UUID orgId = orgDao.insert(entry.getName(), owner.getId(), entry.getVisibility(), entry.getMeta(), entry.getCfg());
+        UUID orgId = orgDao.insert(tx, entry.getName(), owner.getId(), entry.getVisibility(), entry.getMeta(), entry.getCfg());
 
-            // ...add the owner user to the default new as an OWNER
-            UUID teamId = teamDao.insert(tx, orgId, TeamManager.DEFAULT_TEAM_NAME, "Default team");
-            teamDao.upsertUser(tx, teamId, owner.getId(), TeamRole.OWNER);
-
-            return orgId;
-        });
+        // ...add the owner user into the default team of the new org
+        UUID teamId = teamDao.insert(tx, orgId, TeamManager.DEFAULT_TEAM_NAME, "Default team");
+        teamDao.upsertUser(tx, teamId, owner.getId(), TeamRole.OWNER);
 
         Map<String, Object> changes = DiffUtils.compare(null, entry);
         addAuditLog(AuditAction.CREATE,
-                id,
+                orgId,
                 entry.getName(),
                 changes);
 
-        return id;
+        return orgId;
     }
 
-    public void update(UUID orgId, OrganizationEntry entry) {
+    private void update(DSLContext tx, UUID orgId, OrganizationEntry entry) {
         OrganizationEntry prevEntry = assertUpdateAccess(orgId);
 
         UserEntry owner = getOwner(entry.getOwner(), null);
@@ -109,7 +149,7 @@ public class OrganizationManager {
         policyManager.checkEntity(orgId, null, EntityType.ORGANIZATION, EntityAction.UPDATE, owner, PolicyUtils.toMap(entry));
 
         UUID ownerId = owner != null ? owner.getId() : null;
-        orgDao.update(orgId, entry.getName(), ownerId, entry.getVisibility(), entry.getMeta(), entry.getCfg());
+        orgDao.update(tx, orgId, entry.getName(), ownerId, entry.getVisibility(), entry.getMeta(), entry.getCfg());
 
         OrganizationEntry newEntry = orgDao.get(orgId);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationOperationResult.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationOperationResult.java
@@ -1,0 +1,47 @@
+package com.walmartlabs.concord.server.org;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.walmartlabs.concord.server.OperationResult;
+import org.immutables.value.Value;
+
+import java.util.UUID;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableOrganizationOperationResult.class)
+@JsonDeserialize(as = ImmutableOrganizationOperationResult.class)
+public interface OrganizationOperationResult {
+
+    @Value.Default
+    default boolean ok() {
+        return true;
+    }
+
+    OperationResult result();
+
+    UUID orgId();
+
+    static ImmutableOrganizationOperationResult.Builder builder() {
+        return ImmutableOrganizationOperationResult.builder();
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/OrganizationResource.java
@@ -62,18 +62,8 @@ public class OrganizationResource implements Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public CreateOrganizationResponse createOrUpdate(@ApiParam @Valid OrganizationEntry entry) {
-        UUID orgId = entry.getId();
-        if (orgId == null) {
-            orgId = orgDao.getId(entry.getName());
-        }
-
-        if (orgId == null) {
-            orgId = orgManager.create(entry);
-            return new CreateOrganizationResponse(orgId, OperationResult.CREATED);
-        } else {
-            orgManager.update(orgId, entry);
-            return new CreateOrganizationResponse(orgId, OperationResult.UPDATED);
-        }
+        OrganizationOperationResult result = orgManager.createOrUpdate(entry);
+        return new CreateOrganizationResponse(result.orgId(), result.result());
     }
 
     @GET


### PR DESCRIPTION
Replace `OrganizationManager#create` and `#update` with a single method - `createOrUpdate`.
Use DB advisory locking to avoid data races when, for example, two requests are handled by two
different Server instances connected to the same DB.
