### PR TITLE
concord-server: new schema option "createExtensionAvailable"

### DIFF
--- a/server/db/pom.xml
+++ b/server/db/pom.xml
@@ -166,6 +166,7 @@
                     <contexts>codegen</contexts>
                     <expressionVariables>
                         <superuserAvailable>true</superuserAvailable>
+                        <createExtensionAvailable>true</createExtensionAvailable>
                     </expressionVariables>
                 </configuration>
             </plugin>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.44.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.44.0.xml
@@ -7,7 +7,7 @@
     <!-- enable UUID generation -->
     <changeSet id="44000-init" author="ibodrov@gmail.com">
         <preConditions onFail="MARK_RAN">
-            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+            <changeLogPropertyDefined property="createExtensionAvailable" value="true"/>
         </preConditions>
 
         <sql>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.34.3.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.34.3.xml
@@ -6,7 +6,7 @@
 
     <changeSet id="1344000" author="ibodrov@gmail.com">
         <preConditions onFail="MARK_RAN">
-            <changeLogPropertyDefined property="superuserAvailable" value="true"/>
+            <changeLogPropertyDefined property="createExtensionAvailable" value="true"/>
         </preConditions>
 
         <sql>

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -63,6 +63,10 @@ concord-server {
 
             # some migrations can be done faster if the DB user has the SUPERUSER role
             superuserAvailable = "true"
+
+            # if "true", Concord will try to install required PostgreSQL extensions automatically
+            # requires "CREATE EXTENSION" privileges
+            createExtensionAvailable = "true"
         }
     }
 

--- a/server/plugins/ansible/db/pom.xml
+++ b/server/plugins/ansible/db/pom.xml
@@ -160,6 +160,7 @@
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                     <expressionVariables>
                         <superuserAvailable>true</superuserAvailable>
+                        <createExtensionAvailable>true</createExtensionAvailable>
                     </expressionVariables>
                 </configuration>
             </plugin>

--- a/server/plugins/noderoster/db/pom.xml
+++ b/server/plugins/noderoster/db/pom.xml
@@ -160,6 +160,7 @@
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                     <expressionVariables>
                         <superuserAvailable>true</superuserAvailable>
+                        <createExtensionAvailable>true</createExtensionAvailable>
                     </expressionVariables>
                 </configuration>
             </plugin>

--- a/server/plugins/noderoster/db/src/main/resources/com/walmartlabs/concord/server/plugins/noderoster/db/liquibase.xml
+++ b/server/plugins/noderoster/db/src/main/resources/com/walmartlabs/concord/server/plugins/noderoster/db/liquibase.xml
@@ -5,6 +5,10 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="noderoster-10000" author="ibodrov@gmail.com">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="createExtensionAvailable" value="true"/>
+        </preConditions>
+
         <sql>
             CREATE EXTENSION IF NOT EXISTS "uuid-ossp"
         </sql>


### PR DESCRIPTION
Gate all "CREATE EXTENSION" changesets with a new option - `createExtensionAvailable`
(default is `true`).

Allows DB schema deployment in enviroments where `SUPERUSER` is not available but
`CREATE EXTENSION` is.