### PR TITLE
ansible: fix invalid type of `ignore_error` param in ansible event

### DIFF
--- a/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_events.py
+++ b/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_events.py
@@ -284,7 +284,7 @@ class CallbackModule(CallbackBase):
             'phase': "post",
             'duration': self._task_duration(task_correlation_id),
             'result': self.cleanup_results(result._result),
-            'ignore_errors': ignore_errors
+            'ignore_errors': isinstance(ignore_errors, bool) and ignore_errors
         }
 
         self.handle_event(data)

--- a/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/AnsibleEvent.java
+++ b/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/AnsibleEvent.java
@@ -79,6 +79,10 @@ public class AnsibleEvent extends AbstractAnsibleEvent {
     }
 
     public boolean ignoreErrors() {
-        return MapUtils.getBoolean(e.payload(), "ignore_errors", false);
+        Object value = e.payload().get("ignore_errors");
+        if (value instanceof Boolean) {
+            return (boolean) value;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
example ansible step:
```
      uri:
        url: 'http://host/'
        method: POST
        body_format: json
        body: "{{ undefined_variable }}"
      ignore_errors: '{{ ignore | default("true") }}'   # saved as is in event
```