### PR TITLE
runtime-v2: allow "log", "throw" and "expr" steps to have names

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/LogGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/LogGrammar.java
@@ -21,23 +21,22 @@ package com.walmartlabs.concord.runtime.v2.parser;
  */
 
 import com.walmartlabs.concord.runtime.v2.model.TaskCall;
-import com.walmartlabs.concord.runtime.v2.model.TaskCallOptions;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.satisfyField;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.simpleOptions;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.anyVal;
+import static com.walmartlabs.concord.runtime.v2.parser.TaskGrammar.optionsWithStepName;
 
 public final class LogGrammar {
 
     public static final Parser<Atom, TaskCall> logStep =
-            satisfyField("log", YamlValueType.TASK, a -> anyVal.bind(msg ->
-                    simpleOptions.map(options ->
-                            new TaskCall(a.location, "log", TaskCallOptions.builder()
+            namedStep("log", YamlValueType.TASK, (stepName, a) ->
+                    anyVal.bind(msg ->
+                            simpleOptions.map(options -> new TaskCall(a.location, "log", optionsWithStepName(stepName)
                                     .putInput("msg", msg)
-                                    .meta(options.meta())
+                                    .putAllMeta(options.meta())
                                     .build()))));
-
 
     private LogGrammar() {
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
@@ -36,7 +36,7 @@ import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.*;
 
 public final class TaskGrammar {
 
-    private static ImmutableTaskCallOptions.Builder optionsBuilder(String stepName) {
+    public static ImmutableTaskCallOptions.Builder optionsWithStepName(String stepName) {
         ImmutableTaskCallOptions.Builder result = ImmutableTaskCallOptions.builder();
         if (stepName != null) {
             result.putMeta(Constants.SEGMENT_NAME, stepName);
@@ -45,7 +45,7 @@ public final class TaskGrammar {
     }
 
     private static Parser<Atom, TaskCallOptions> taskOptions(String stepName) {
-        return with(() -> optionsBuilder(stepName),
+        return with(() -> optionsWithStepName(stepName),
                 o -> options(
                         optional("in", mapVal.map(o::input)),
                         optional("out", stringVal.map(o::out)),

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ThrowGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ThrowGrammar.java
@@ -21,22 +21,21 @@ package com.walmartlabs.concord.runtime.v2.parser;
  */
 
 import com.walmartlabs.concord.runtime.v2.model.TaskCall;
-import com.walmartlabs.concord.runtime.v2.model.TaskCallOptions;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.satisfyField;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.simpleOptions;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.anyVal;
+import static com.walmartlabs.concord.runtime.v2.parser.TaskGrammar.optionsWithStepName;
 
 public final class ThrowGrammar {
 
     public static final Parser<Atom, TaskCall> throwStep =
-            satisfyField("throw", YamlValueType.TASK, a -> anyVal.bind(e ->
+            namedStep("throw", YamlValueType.TASK, (stepName, a) -> anyVal.bind(e ->
                     simpleOptions.map(options ->
-                            new TaskCall(a.location, "throw", TaskCallOptions.builder()
+                            new TaskCall(a.location, "throw", optionsWithStepName(stepName)
                                     .putInput("exception", e)
                                     .build()))));
-
 
     private ThrowGrammar() {
     }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.runtime.v2.model.Expression;
 import com.walmartlabs.concord.runtime.v2.model.ExpressionOptions;
 import com.walmartlabs.concord.runtime.v2.runner.el.EvalContextFactory;
 import com.walmartlabs.concord.runtime.v2.runner.el.ExpressionEvaluator;
+import com.walmartlabs.concord.runtime.v2.runner.logging.SegmentedLogger;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
 import com.walmartlabs.concord.svm.Frame;
 import com.walmartlabs.concord.svm.Runtime;
@@ -74,6 +75,11 @@ public class ExpressionCommand extends StepCommand<Expression> {
 
     @Override
     protected String getSegmentName(Context ctx, Expression step) {
+        String segmentName = SegmentedLogger.getSegmentName(step);
+        if (segmentName != null) {
+            return ctx.eval(segmentName, String.class);
+        }
+
         return "expression";
     }
 }


### PR DESCRIPTION
Update the v2 grammar to support the `name` attribute for `log`, `throw` and `expr` steps.

E.g.

```yaml
- name: "two plus two"
  expr: ${2 + 2}

- name: "Throw an error"
  throw: "boom!"

- name: "Log stuff"
  log: "stuff"
```