### PR TITLE
concord-imports: add support for "dir" imports

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ImportConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ImportConfiguration.java
@@ -1,10 +1,10 @@
-package com.walmartlabs.concord.server.cfg;
+package com.walmartlabs.concord.agent.cfg;
 
 /*-
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2018 Walmart Inc.
+ * Copyright (C) 2017 - 2020 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,33 +20,24 @@ package com.walmartlabs.concord.server.cfg;
  * =====
  */
 
-import com.walmartlabs.ollie.config.Config;
+import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Named
 @Singleton
 public class ImportConfiguration {
 
-    @Inject
-    @Config("imports.src")
-    private String src;
-
     private final Set<String> disabledProcessors;
 
     @Inject
-    public ImportConfiguration(@Config("imports.disabledProcessors") List<String> disabledProcessors) {
-        this.disabledProcessors = Collections.unmodifiableSet(new HashSet<>(disabledProcessors));
-    }
-
-    public String getSrc() {
-        return src;
+    public ImportConfiguration(Config cfg) {
+        this.disabledProcessors = Collections.unmodifiableSet(new HashSet<>(cfg.getStringList("imports.disabledProcessors")));
     }
 
     public Set<String> getDisabledProcessors() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
@@ -21,7 +21,9 @@ package com.walmartlabs.concord.agent.guice;
  */
 
 import com.walmartlabs.concord.agent.RepositoryManager;
+import com.walmartlabs.concord.agent.cfg.ImportConfiguration;
 import com.walmartlabs.concord.imports.ImportManagerFactory;
+import com.walmartlabs.concord.imports.RepositoryExporter;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -34,15 +36,20 @@ public class AgentImportManagerProvider implements Provider<AgentImportManager> 
     private final ImportManagerFactory factory;
 
     @Inject
-    public AgentImportManagerProvider(RepositoryManager repositoryManager, AgentDependencyManager dependencyManager) {
-        this.factory = new ImportManagerFactory(dependencyManager, (entry, workDir) -> {
+    public AgentImportManagerProvider(ImportConfiguration cfg, RepositoryManager repositoryManager, AgentDependencyManager dependencyManager) {
+        RepositoryExporter exporter = (entry, workDir) -> {
             Path dst = workDir;
+
+            String entryDest = entry.dest();
             if (entry.dest() != null) {
-                dst = dst.resolve(entry.dest());
+                dst = dst.resolve(entryDest);
             }
+
             repositoryManager.export(entry.url(), entry.version(), null, entry.path(), dst, entry.secret(), entry.exclude());
             return null;
-        });
+        };
+
+        this.factory = new ImportManagerFactory(dependencyManager, exporter, cfg.getDisabledProcessors(), null);
     }
 
     @Override

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -134,6 +134,17 @@ concord-agent {
         sshTimeout = "10 minutes"
     }
 
+    imports {
+        # base git url for imports
+        src = ""
+
+        # list of disabled import processors
+        # e.g. "dir" is useful for local development, but potentially a security issue
+        disabledProcessors = [
+            "dir"
+        ]
+    }
+
     runner {
         # directory to store process configuration files
         cfgDir = null

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -29,7 +29,6 @@ import com.walmartlabs.concord.imports.ImportManager;
 import com.walmartlabs.concord.imports.ImportManagerFactory;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinitionUtils;
 import com.walmartlabs.concord.process.loader.v2.ProcessDefinitionV2;
-import com.walmartlabs.concord.runtime.common.StateManager;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
 import com.walmartlabs.concord.runtime.v2.ProjectLoaderV2;
 import com.walmartlabs.concord.runtime.v2.model.ProcessConfiguration;
@@ -128,7 +127,9 @@ public class Run implements Callable<Integer> {
         }
 
         DependencyManager dependencyManager = initDependencyManager();
-        ImportManager importManager = new ImportManagerFactory(dependencyManager, new CliRepositoryExporter(repoCacheDir), verbose ? new CliImportsListener() : null)
+        ImportManager importManager = new ImportManagerFactory(dependencyManager,
+                new CliRepositoryExporter(repoCacheDir), Collections.emptySet(),
+                verbose ? new CliImportsListener() : null)
                 .create();
 
         ProjectLoaderV2.Result loadResult;

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliImportsNormalizer.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliImportsNormalizer.java
@@ -73,6 +73,9 @@ public class CliImportsNormalizer implements ImportsNormalizer {
                 Import.GitDefinition src = (Import.GitDefinition) i;
                 return normalize(src);
             }
+            case Import.DirectoryDefinition.TYPE: {
+                return i;
+            }
             default: {
                 throw new IllegalArgumentException("Unsupported import type: '" + i.type() + "'");
             }

--- a/imports/src/main/java/com/walmartlabs/concord/imports/DefaultImportManager.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/DefaultImportManager.java
@@ -26,18 +26,21 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DefaultImportManager implements ImportManager {
 
     private final Map<String, ImportProcessor<Import>> processors;
+    private final Set<String> disabledProcessors;
     private final ImportsListener listener;
 
-
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public DefaultImportManager(List<ImportProcessor> processors, ImportsListener listener) {
+    public DefaultImportManager(List<ImportProcessor> processors, Set<String> disabledProcessors, ImportsListener listener) {
         this.processors = processors.stream().collect(Collectors.toMap(ImportProcessor::type, o -> o));
-        this.listener = listener != null ? listener : new ImportsListener() {};
+        this.disabledProcessors = disabledProcessors;
+        this.listener = listener != null ? listener : new ImportsListener() {
+        };
     }
 
     @Override
@@ -64,10 +67,14 @@ public class DefaultImportManager implements ImportManager {
     }
 
     private ImportProcessor<Import> assertProcessor(String type) {
+        if (disabledProcessors.contains(type)) {
+            throw new RuntimeException("Disabled import type: " + type);
+        }
+
         ImportProcessor<Import> p = processors.get(type);
         if (p != null) {
             return p;
         }
-        throw new RuntimeException("Unknown import type: '" + type + "'");
+        throw new RuntimeException("Unknown import type: " + type);
     }
 }

--- a/imports/src/main/java/com/walmartlabs/concord/imports/DirectoryProcessor.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/DirectoryProcessor.java
@@ -1,0 +1,76 @@
+package com.walmartlabs.concord.imports;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.imports.Import.DirectoryDefinition;
+import com.walmartlabs.concord.repository.LastModifiedSnapshot;
+import com.walmartlabs.concord.repository.Snapshot;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+
+public class DirectoryProcessor implements ImportProcessor<DirectoryDefinition> {
+
+    @Override
+    public String type() {
+        return DirectoryDefinition.TYPE;
+    }
+
+    @Override
+    public Snapshot process(DirectoryDefinition importEntry, Path workDir) throws Exception {
+        String entrySrc = importEntry.src();
+
+        Path src;
+        if (entrySrc.startsWith("/")) {
+            src = Paths.get(entrySrc);
+        } else {
+            src = workDir.resolve(entrySrc).normalize();
+        }
+
+        if (!Files.exists(src) || !Files.isDirectory(src)) {
+            throw new IllegalArgumentException("Can't import '" + src + "': the specified path doesn't exist or not a directory.");
+        }
+
+        if (workDir.startsWith(src)) {
+            throw new IllegalArgumentException("Only external directories are allowed in imports. " +
+                    "To include resources from directories located in the process' working directory use the 'resources' configuration block.");
+        }
+
+        Path dest = workDir;
+
+        String entryDest = importEntry.dest();
+        if (entryDest != null) {
+            dest = workDir.resolve(entryDest);
+        }
+
+        if (!Files.exists(dest)) {
+            Files.createDirectories(dest);
+        }
+
+        LastModifiedSnapshot snapshot = new LastModifiedSnapshot();
+        IOUtils.copy(src, dest, Collections.emptyList(), snapshot, StandardCopyOption.REPLACE_EXISTING);
+        return snapshot;
+    }
+}

--- a/imports/src/main/java/com/walmartlabs/concord/imports/Import.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/Import.java
@@ -42,6 +42,8 @@ import java.util.List;
         @Type(value = ImmutableGitDefinition.class, name = Import.GitDefinition.TYPE),
         @Type(value = Import.MvnDefinition.class, name = Import.MvnDefinition.TYPE),
         @Type(value = ImmutableMvnDefinition.class, name = Import.MvnDefinition.TYPE),
+        @Type(value = Import.DirectoryDefinition.class, name = Import.DirectoryDefinition.TYPE),
+        @Type(value = ImmutableDirectoryDefinition.class, name = Import.DirectoryDefinition.TYPE),
 })
 public interface Import extends Serializable {
 
@@ -82,7 +84,7 @@ public interface Import extends Serializable {
 
         @Override
         default String type() {
-            return "git";
+            return TYPE;
         }
 
         static ImmutableGitDefinition.Builder builder() {
@@ -105,11 +107,34 @@ public interface Import extends Serializable {
 
         @Override
         default String type() {
-            return "mvn";
+            return TYPE;
         }
 
         static ImmutableMvnDefinition.Builder builder() {
             return ImmutableMvnDefinition.builder();
+        }
+    }
+
+    @Value.Immutable
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonSerialize(as = ImmutableDirectoryDefinition.class)
+    @JsonDeserialize(as = ImmutableDirectoryDefinition.class)
+    interface DirectoryDefinition extends Import {
+
+        String TYPE = "dir";
+
+        String src();
+
+        @Nullable
+        String dest();
+
+        @Override
+        default String type() {
+            return TYPE;
+        }
+
+        static ImmutableDirectoryDefinition.Builder builder() {
+            return ImmutableDirectoryDefinition.builder();
         }
     }
 

--- a/imports/src/main/java/com/walmartlabs/concord/imports/ImportManagerFactory.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/ImportManagerFactory.java
@@ -24,28 +24,27 @@ import com.walmartlabs.concord.dependencymanager.DependencyManager;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class ImportManagerFactory {
 
     private final DependencyManager dependencyManager;
     private final RepositoryExporter repositoryExporter;
+    private final Set<String> disabledProcessors;
     private final ImportsListener listener;
 
-    public ImportManagerFactory(DependencyManager dependencyManager, RepositoryExporter repositoryExporter) {
-        this(dependencyManager, repositoryExporter, null);
-    }
-
-    public ImportManagerFactory(DependencyManager dependencyManager, RepositoryExporter repositoryExporter, ImportsListener listener) {
+    public ImportManagerFactory(DependencyManager dependencyManager, RepositoryExporter repositoryExporter, Set<String> disabledProcessors, ImportsListener listener) {
         this.dependencyManager = dependencyManager;
         this.repositoryExporter = repositoryExporter;
+        this.disabledProcessors = disabledProcessors;
         this.listener = listener;
     }
 
-    @SuppressWarnings("rawtypes")
     public ImportManager create() {
         List<ImportProcessor> processors = new ArrayList<>();
         processors.add(new RepositoryProcessor(repositoryExporter));
         processors.add(new MvnProcessor(dependencyManager));
-        return new DefaultImportManager(processors, listener);
+        processors.add(new DirectoryProcessor());
+        return new DefaultImportManager(processors, disabledProcessors, listener);
     }
 }

--- a/imports/src/main/java/com/walmartlabs/concord/imports/MvnProcessor.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/MvnProcessor.java
@@ -41,7 +41,7 @@ public class MvnProcessor implements ImportProcessor<MvnDefinition> {
 
     @Override
     public String type() {
-        return "mvn";
+        return MvnDefinition.TYPE;
     }
 
     @Override

--- a/imports/src/main/java/com/walmartlabs/concord/imports/RepositoryProcessor.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/RepositoryProcessor.java
@@ -35,7 +35,7 @@ public class RepositoryProcessor implements ImportProcessor<GitDefinition> {
 
     @Override
     public String type() {
-        return "git";
+        return GitDefinition.TYPE;
     }
 
     @Override

--- a/imports/src/main/java/com/walmartlabs/concord/imports/package-info.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/package-info.java
@@ -1,0 +1,24 @@
+@Value.Style(jdkOnly = true)
+package com.walmartlabs.concord.imports;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.immutables.value.Value;

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -32,6 +32,10 @@ public final class ConcordConfiguration {
 
     private static final Path sharedDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve("concord-it");
 
+    public static Path sharedDir() {
+        return sharedDir;
+    }
+
     static {
         if (Files.notExists(sharedDir)) {
             try {

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
@@ -1,0 +1,69 @@
+package com.walmartlabs.concord.it.runtime.v2;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.Payload;
+import ca.ibodrov.concord.testcontainers.junit4.ConcordRule;
+import com.walmartlabs.concord.client.ProcessEntry;
+import com.walmartlabs.concord.common.Posix;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.walmartlabs.concord.it.common.ITUtils.randomString;
+
+public class ImportsIT {
+
+    @Rule
+    public final ConcordRule concord = ConcordConfiguration.configure()
+            .extraConfigurationSupplier(() -> "concord-server { imports { disabledProcessors = [] } }\n" +
+                    "concord-agent { imports { disabledProcessors = [] } }");
+
+    @Test
+    public void testDir() throws Exception {
+        Path tmpDir = Files.createTempDirectory(ConcordConfiguration.sharedDir(), "test");
+        Files.setPosixFilePermissions(tmpDir, Posix.posix(0755));
+
+        Path src = Paths.get(ImportsIT.class.getResource("dirImport/other.concord.yml").toURI());
+        Path dst = tmpDir.resolve("other.concord.yml");
+        Files.copy(src, dst);
+        Files.setPosixFilePermissions(dst, Posix.posix(0644));
+
+        String name = "name_" + randomString();
+        Payload payload = new Payload()
+                .arg("name", name)
+                .concordYml("configuration:\n" +
+                        "  runtime: concord-v2\n" +
+                        "imports:\n" +
+                        "  - dir:\n" +
+                        "      src: " + dst.getParent().toAbsolutePath() + "\n" +
+                        "      dest: concord");
+
+        ConcordProcess proc = concord.processes().start(payload);
+        proc.waitForStatus(ProcessEntry.StatusEnum.FINISHED);
+
+        proc.assertLog(".*Hello, " + name + ".*");
+    }
+}

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SmtpIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SmtpIT.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.it.runtime.v2;
  */
 
 import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.ContainerListener;
 import ca.ibodrov.concord.testcontainers.ContainerType;
 import ca.ibodrov.concord.testcontainers.Payload;
 import ca.ibodrov.concord.testcontainers.junit4.ConcordRule;
@@ -43,10 +44,13 @@ public class SmtpIT {
 
     @Rule
     public final ConcordRule concord = ConcordConfiguration.configure()
-            .containerListener(name -> {
-                // use container listener to expose the SMTP server's port right before the container starts
-                if (name == ContainerType.AGENT) {
-                    Testcontainers.exposeHostPorts(mailServer.getSmtp().getPort());
+            .containerListener(new ContainerListener() {
+                @Override
+                public void beforeStart(ContainerType type) {
+                    // use container listener to expose the SMTP server's port right before the container starts
+                    if (type == ContainerType.AGENT) {
+                        Testcontainers.exposeHostPorts(mailServer.getSmtp().getPort());
+                    }
                 }
             });
 

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/TemplateIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/TemplateIT.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.it.runtime.v2;
  */
 
 import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.ContainerListener;
 import ca.ibodrov.concord.testcontainers.ContainerType;
 import ca.ibodrov.concord.testcontainers.junit4.ConcordRule;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -62,9 +63,12 @@ public class TemplateIT {
     @ClassRule
     public static final ConcordRule concord = ConcordConfiguration
             .configure()
-            .containerListener(name -> {
-                if (name == ContainerType.SERVER) {
-                    Testcontainers.exposeHostPorts(rule.port());
+            .containerListener(new ContainerListener() {
+                @Override
+                public void beforeStart(ContainerType type) {
+                    if (type == ContainerType.SERVER) {
+                        Testcontainers.exposeHostPorts(rule.port());
+                    }
                 }
             });
 

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/dirImport/other.concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/dirImport/other.concord.yml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - log: "Hello, ${name}!"

--- a/repository/src/main/java/com/walmartlabs/concord/repository/Snapshot.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/Snapshot.java
@@ -31,6 +31,20 @@ import java.nio.file.attribute.BasicFileAttributes;
  */
 public interface Snapshot {
 
+    static Snapshot includeAll() {
+        return new Snapshot() {
+            @Override
+            public boolean isModified(Path path, BasicFileAttributes attrs) {
+                return true;
+            }
+
+            @Override
+            public boolean contains(Path path) {
+                return true;
+            }
+        };
+    }
+
     boolean isModified(Path path, BasicFileAttributes attrs);
 
     boolean contains(Path path);

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ImportsGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ImportsGrammar.java
@@ -71,16 +71,28 @@ public final class ImportsGrammar {
                                     optional("dest", stringVal.map(o::dest))))
                             .map(ImmutableMvnDefinition.Builder::build));
 
+    private static final Parser<Atom, Import.DirectoryDefinition> dirImport =
+            betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
+                    with(ImmutableDirectoryDefinition::builder,
+                            o -> options(
+                                    mandatory("src", stringVal.map(o::src)),
+                                    optional("dest", stringVal.map(o::dest))))
+                            .map(ImmutableDirectoryDefinition.Builder::build));
+
     private static final Parser<Atom, Import.GitDefinition> gitImportVal =
             orError(gitImport, YamlValueType.GIT_IMPORT);
 
     private static final Parser<Atom, Import.MvnDefinition> mvnImportVal =
             orError(mvnImport, YamlValueType.MVN_IMPORT);
 
+    private static final Parser<Atom, Import.DirectoryDefinition> dirImportVal =
+            orError(dirImport, YamlValueType.DIR_IMPORT);
+
     private static final Parser<Atom, Import> importDef =
             betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
                     choice(
                             satisfyField("git", atom -> gitImportVal),
+                            satisfyField("dir", atom -> dirImportVal),
                             choice(satisfyField("mvn", atom -> mvnImportVal),
                                     satisfyToken(JsonToken.FIELD_NAME).bind(a -> {
                                         throw UnknownOptionException.builder()

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
@@ -75,6 +75,7 @@ public final class YamlValueType<T> {
     public static final YamlValueType<Import> IMPORT = type("IMPORT");
     public static final YamlValueType<Import.GitDefinition> GIT_IMPORT = type("GIT_IMPORT");
     public static final YamlValueType<Import.MvnDefinition> MVN_IMPORT = type("MVN_IMPORT");
+    public static final YamlValueType<Import.DirectoryDefinition> DIR_IMPORT = type("DIR_IMPORT");
     public static final YamlValueType<Import.SecretDefinition> IMPORT_SECRET = type("IMPORT_SECRET");
     public static final YamlValueType<Map<String, List<Step>>> FLOWS = type("FLOWS");
     public static final YamlValueType<KV<String, List<Step>>> FLOW = type("FLOW");

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -185,7 +185,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertNull(errorStep.getOptions());
 
         // withItems
-        assertEquals("a", ((List<String>)t.getOptions().withItems().value()).get(0));
+        assertEquals("a", ((List<String>) t.getOptions().withItems().value()).get(0));
 
         // meta
         assertMeta(t.getOptions());
@@ -235,11 +235,11 @@ public class YamlOkParserTest extends AbstractParserTest {
         Imports imports = pd.imports();
         assertNotNull(imports);
 
-        assertEquals(3, imports.items().size());
+        assertEquals(4, imports.items().size());
 
         Import i = imports.items().get(0);
         assertEquals("git", i.type());
-        Import.GitDefinition g = (Import.GitDefinition)i;
+        Import.GitDefinition g = (Import.GitDefinition) i;
         assertEquals("https://github.com/me/my_private_repo.git", g.url());
         assertEquals("test", g.name());
         assertEquals("1.2.3", g.version());
@@ -250,6 +250,7 @@ public class YamlOkParserTest extends AbstractParserTest {
 
         assertEquals("git", imports.items().get(1).type());
         assertEquals("mvn", imports.items().get(2).type());
+        assertEquals("dir", imports.items().get(3).type());
     }
 
     // Configuration Definition Test

--- a/runtime/v2/model/src/test/resources/007.yml
+++ b/runtime/v2/model/src/test/resources/007.yml
@@ -16,3 +16,6 @@ imports:
   - mvn:
       url: "mvn://groupId:artifactId:version"
       dest: "/dest"
+  - dir:
+      src: "/some/path"
+      dest: "/dest"

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -246,6 +246,12 @@ concord-server {
     imports {
         # base git url for imports
         src = ""
+
+        # list of disabled import processors
+        # e.g. "dir" is useful for local development, but potentially a security issue
+        disabledProcessors = [
+            "dir"
+        ]
     }
 
     # secrets and encrypted values

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ImportManagerProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ImportManagerProvider.java
@@ -29,6 +29,7 @@ import com.walmartlabs.concord.imports.RepositoryExporter;
 import com.walmartlabs.concord.repository.Repository;
 import com.walmartlabs.concord.repository.Snapshot;
 import com.walmartlabs.concord.sdk.Secret;
+import com.walmartlabs.concord.server.cfg.ImportConfiguration;
 import com.walmartlabs.concord.server.org.OrganizationDao;
 import com.walmartlabs.concord.server.org.secret.SecretManager;
 import com.walmartlabs.concord.server.repository.RepositoryManager;
@@ -48,10 +49,11 @@ public class ImportManagerProvider implements Provider<ImportManager> {
     public ImportManagerProvider(DependencyManager dependencyManager,
                                  OrganizationDao organizationDao,
                                  SecretManager secretManager,
-                                 RepositoryManager repositoryManager) {
+                                 RepositoryManager repositoryManager,
+                                 ImportConfiguration cfg) {
 
-        this.factory = new ImportManagerFactory(dependencyManager,
-                new RepositoryExporterImpl(organizationDao, secretManager, repositoryManager));
+        RepositoryExporterImpl exporter = new RepositoryExporterImpl(organizationDao, secretManager, repositoryManager);
+        this.factory = new ImportManagerFactory(dependencyManager, exporter, cfg.getDisabledProcessors(), null);
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ImportsNormalizerFactory.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ImportsNormalizerFactory.java
@@ -79,6 +79,9 @@ public class ImportsNormalizerFactory {
                 Import.GitDefinition src = (Import.GitDefinition) i;
                 return normalize(ctx, src);
             }
+            case Import.DirectoryDefinition.TYPE: {
+                return i;
+            }
             default: {
                 throw new IllegalArgumentException("Unsupported import type: '" + i.type() + "'");
             }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/StateImportingProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/StateImportingProcessor.java
@@ -58,6 +58,9 @@ public class StateImportingProcessor implements PayloadProcessor {
         return chain.process(payload);
     }
 
+    /**
+     * Return {@code true} for each {@code p} that must be included into the process state.
+     */
     private boolean filter(Path p, BasicFileAttributes attrs, List<Snapshot> snapshots, Path workDir) {
         // those files we need to store in the DB regardless of whether they are from a repository or not
         // e.g. custom forms: we need those files in the DB in order to serve custom form files
@@ -77,7 +80,7 @@ public class StateImportingProcessor implements PayloadProcessor {
 
         if (snapshots != null) {
             ListIterator<Snapshot> it = snapshots.listIterator(snapshots.size());
-            while(it.hasPrevious()) {
+            while (it.hasPrevious()) {
                 Snapshot s = it.previous();
                 if (s.contains(p)) {
                     return s.isModified(p, attrs);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/ClasspathRepositoryProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/ClasspathRepositoryProvider.java
@@ -35,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 
 public class ClasspathRepositoryProvider implements RepositoryProvider {
@@ -76,19 +75,7 @@ public class ClasspathRepositoryProvider implements RepositoryProvider {
     @Override
     public Snapshot export(Path src, Path dst, List<String> ignorePatterns) throws IOException {
         IOUtils.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
-
-        return new Snapshot() {
-
-            @Override
-            public boolean isModified(Path path, BasicFileAttributes attrs) {
-                return true;
-            }
-
-            @Override
-            public boolean contains(Path path) {
-                return true;
-            }
-        };
+        return Snapshot.includeAll();
     }
 
     @Override

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -99,7 +99,7 @@
         <sshd.version>1.6.0</sshd.version>
         <swagger.version>1.5.20</swagger.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
-        <testcontainers.concord.version>0.0.25</testcontainers.concord.version>
+        <testcontainers.concord.version>0.0.28</testcontainers.concord.version>
         <testcontainers.version>1.13.0</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <wiremock.version>2.26.1</wiremock.version>


### PR DESCRIPTION
Allows importing of local (external to ${workDir}) directories.
Add Server/Agent configuration parameter to disable the `dir` importer by default.

Example:
```yaml
imports:
  - dir:
      src: "/home/user/concord_stuff"
```

I'll add an IT once testcontainers-concord supports custom Server/Agent configurations in the `DOCKER` mode (https://github.com/concord-workflow/testcontainers-concord/issues/19)