### PR TITLE
server: Remove user's LDAP groups when disabling

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
@@ -98,8 +98,9 @@ public class UserLdapGroupSynchronizer implements ScheduledTask {
         try {
             Set<String> groups = ldapManager.getGroups(u.username, u.domain);
             if (groups == null) {
-                disableUser(u);
+                ldapGroupsDao.update(u.userId, Collections.emptySet());
                 ldapGroupsDao.updateLastSyncTimestamp(u.userId);
+                disableUser(u);
             } else {
                 enableUser(u);
                 ldapGroupsDao.update(u.userId, groups);


### PR DESCRIPTION
Remove a disabled user's LDAP groups when synchronizing. Currently, disabled users show up in Teams configured with the LDAP group.