### PR TITLE
concord-server-sdk: userId in AuditEvent is optional

### DIFF
--- a/server/sdk/pom.xml
+++ b/server/sdk/pom.xml
@@ -25,11 +25,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
@@ -37,6 +32,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Immutables -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/server/sdk/src/main/java/com/walmartlabs/concord/server/sdk/audit/AuditEvent.java
+++ b/server/sdk/src/main/java/com/walmartlabs/concord/server/sdk/audit/AuditEvent.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.walmartlabs.concord.server.sdk.AllowNulls;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -44,6 +45,7 @@ public interface AuditEvent extends Serializable {
 
     OffsetDateTime entryDate();
 
+    @Nullable
     UUID userId();
 
     String object();


### PR DESCRIPTION
It should've been `@Nullable` in the first place.