### PR TITLE
docker-images: remove dumb-init from the base image

### DIFF
--- a/docker-images/ansible/oss/Dockerfile
+++ b/docker-images/ansible/oss/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
     libffi-devel \
     libxml2-devel \
     libxslt-devel \
+    make \
     openssh-clients \
     openssl-devel \
     python2-devel \

--- a/docker-images/ansible/oss/Dockerfile
+++ b/docker-images/ansible/oss/Dockerfile
@@ -14,6 +14,8 @@ RUN yum -y install \
     krb5-libs \
     krb5-workstation \
     libffi-devel \
+    libxml2-devel \
+    libxslt-devel \
     openssh-clients \
     openssl-devel \
     python2-devel \

--- a/docker-images/base/oss/Dockerfile
+++ b/docker-images/base/oss/Dockerfile
@@ -1,8 +1,6 @@
 FROM library/centos:8
 MAINTAINER "Ivan Bodrov" <ibodrov@walmartlabs.com>
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
 ARG jdk_version=1.8.0
 ENV JAVA_HOME /usr/lib/jvm/java-${jdk_version}
 
@@ -18,6 +16,6 @@ RUN yum -y --enablerepo=extras install epel-release && \
 RUN alternatives --set python /usr/bin/python2
 RUN alternatives --install /usr/bin/pip pip /usr/bin/pip2 0
 
-RUN pip install --upgrade --ignore-installed pip==19.3.1 setuptools && pip install dumb-init
+RUN pip install --upgrade --ignore-installed pip==19.3.1 setuptools
 
 RUN groupadd -g 456 concord && useradd --no-log-init -u 456 -g concord -m -s /sbin/nologin concord


### PR DESCRIPTION
Starting from 1.13, Docker ships its own mini-init.
We don't need dumb-init anymore.

As a bonus, the change allows us to build Concord Docker images on aarch64 :-)