### PR TITLE
runtime-v2: support for nested "set"

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/DefaultExpressionEvaluator.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/DefaultExpressionEvaluator.java
@@ -43,6 +43,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         return initializeAll(result, expectedType);
     }
 
+    @Override
+    public void setValue(EvalContext ctx, String expr, Object value) {
+        delegate.setValue(ctx, expr, value);
+    }
+
     private static <T> T initializeAll(Object value, Class<T> expectedType) {
         if (value instanceof LazyEvalMap) {
             LazyEvalMap m = (LazyEvalMap) value;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluator.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluator.java
@@ -57,4 +57,9 @@ public interface ExpressionEvaluator {
     default <T> List<T> evalAsList(EvalContext ctx, Object value) {
         return eval(ctx, value, List.class);
     }
+
+    /**
+     * Evaluates the expression as a variable reference and sets its {@code value}.
+     */
+    void setValue(EvalContext ctx, String expr, Object value);
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/SetVariablesCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/SetVariablesCommand.java
@@ -50,6 +50,16 @@ public class SetVariablesCommand extends StepCommand<SetVariablesStep> {
         ExpressionEvaluator ee = runtime.getService(ExpressionEvaluator.class);
         Map<String, Object> vars = ee.evalAsMap(EvalContextFactory.scope(ctx), step.getVars());
 
-        vars.forEach((k, v) -> ctx.variables().set(k, v));
+        vars.forEach((k, v) -> {
+            if (isNestedVariable(k)) {
+                ee.setValue(EvalContextFactory.scope(ctx), "${" + k + "}", v);
+            } else {
+                ctx.variables().set(k, v);
+            }
+        });
+    }
+
+    private static boolean isNestedVariable(String str) {
+        return str.contains(".");
     }
 }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -685,6 +685,25 @@ public class MainTest {
         assertLog(log, ".*result.k: v.*");
     }
 
+    @Test
+    public void testNestedSet() throws Exception {
+        Map<String, Object> x = new HashMap<>();
+        x.put("z", 234);
+
+        deploy("nestedSet");
+        save(ProcessConfiguration.builder()
+                .putArguments("x", x)
+                .build());
+
+        byte[] log = run();
+        assertLog(log, ".*x: .*y=123.*");
+        assertLog(log, ".*x: .*z=234.*");
+        assertLog(log, ".*x: .*taskOut=42.*");
+
+        // TODO support for partial eval results?
+        assertLog(log, ".*x: .*taskOut2=42.*");
+    }
+
     private void deploy(String resource) throws URISyntaxException, IOException {
         Path src = Paths.get(MainTest.class.getResource(resource).toURI());
         IOUtils.copy(src, workDir);
@@ -929,7 +948,20 @@ public class MainTest {
         public TaskResult resume(ResumeEvent event) {
             log.info("RESUME: {}", event);
             return TaskResult.success()
-                    .values((Map)event.state());
+                    .values((Map) event.state());
+        }
+    }
+
+    @Named("simpleMethodTask")
+    @SuppressWarnings("unused")
+    public static class SimpleMethodTask implements Task {
+
+        public int getValue() {
+            return 42;
+        }
+
+        public int getDerivedValue(int value) {
+            return value + 42;
         }
     }
 }

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/nestedSet/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/nestedSet/concord.yml
@@ -1,0 +1,8 @@
+flows:
+  default:
+    - set:
+        x.y: 123
+        x.taskOut: "${simpleMethodTask.getValue()}"
+        x.taskOut2: "${simpleMethodTask.getDerivedValue(x.y)}"
+
+    - log: "x: ${x}"


### PR DESCRIPTION
Enhance the `set` step implementation to support nested values, e.g.
```yaml
- set:
    x.y: 123
    x.z: "${myTask.getAValue()}"
```

Doesn't support partial eval results. I.e. this isn't working:
```
- set:
    x.y: 123
    x.z: "${myTask.getDerivedValue(x.y)}"
```