### PR TITLE
concord-server: allow POSTing JSON store data

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreDataResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreDataResource.java
@@ -112,6 +112,21 @@ public class JsonStoreDataResource implements Resource {
     }
 
     /**
+     * Same as {@link #data(String, String, String, Object)}.
+     */
+    @POST
+    @Path("/{orgName}/jsonstore/{storeName}/item/{itemPath:.*}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public GenericOperationResult update(@ApiParam @PathParam("orgName") String orgName,
+                                         @ApiParam @PathParam("storeName") String storeName,
+                                         @ApiParam @PathParam("itemPath") String itemPath,
+                                         @ApiParam Object data) {
+
+        return data(orgName, storeName, itemPath, data);
+    }
+
+    /**
      * Remove an item from a store.
      *
      * @param orgName   organization's name


### PR DESCRIPTION
Allow both PUT and POST methods to add/update data in JSON stores.
Fixes compatibility with the Terraform plugin's `concord` backend
in the v2 version of the task (TF wants to POST state updates).