### PR TITLE
runtime-v2: fix "retry" triggering successful commands twice

### DIFF
--- a/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/v2/AnsibleTaskV2.java
+++ b/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/v2/AnsibleTaskV2.java
@@ -23,10 +23,7 @@ package com.walmartlabs.concord.plugins.ansible.v2;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.plugins.ansible.*;
 import com.walmartlabs.concord.plugins.ansible.secrets.AnsibleSecretService;
-import com.walmartlabs.concord.runtime.v2.sdk.Context;
-import com.walmartlabs.concord.runtime.v2.sdk.Task;
-import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
-import com.walmartlabs.concord.runtime.v2.sdk.Variables;
+import com.walmartlabs.concord.runtime.v2.sdk.*;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -73,7 +70,7 @@ public class AnsibleTaskV2 implements Task {
                 .sessionToken(context.processConfiguration().processInfo().sessionToken())
                 .eventCorrelationId(context.execution().correlationId())
                 .orgName(context.projectInfo() != null ? context.projectInfo().orgName() : null)
-                .retryCount((Integer) context.execution().state().peekFrame(context.execution().currentThreadId()).getLocal("__retry_attempNo")) // TODO provide a SDK method for this
+                .retryCount(ContextUtils.getCurrentRetryAttemptNumber(context))
                 .build();
 
         TaskResult result = task.run(ctx, runner);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/RetryWrapper.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/RetryWrapper.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.runtime.v2.model.Step;
 import com.walmartlabs.concord.runtime.v2.runner.context.ContextFactory;
 import com.walmartlabs.concord.runtime.v2.runner.el.EvalContextFactory;
 import com.walmartlabs.concord.runtime.v2.runner.el.ExpressionEvaluator;
+import com.walmartlabs.concord.runtime.v2.sdk.Constants;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.*;
@@ -46,7 +47,6 @@ public class RetryWrapper implements Command {
 
     private static final Logger log = LoggerFactory.getLogger(RetryWrapper.class);
 
-    private static final String RETRY_ATTEMPT_NUMBER = "__retry_attemptNo";
     private static final String RETRY_CFG = "__retry_cfg";
 
     private final Command cmd;
@@ -85,7 +85,7 @@ public class RetryWrapper implements Command {
             delay = ee.eval(EvalContextFactory.global(ctx), retry.delayExpression(), Long.class);
         }
 
-        inner.setLocal(RETRY_ATTEMPT_NUMBER, 0);
+        inner.setLocal(Constants.Runtime.RETRY_ATTEMPT_NUMBER, 0);
         inner.setLocal(RETRY_CFG, Retry.builder().from(retry)
                 .times(times)
                 .delay(delay)
@@ -117,7 +117,7 @@ public class RetryWrapper implements Command {
             frame.pop();
 
             Retry retry = (Retry) frame.getLocal(RETRY_CFG);
-            int attemptNo = (int) frame.getLocal(RETRY_ATTEMPT_NUMBER);
+            int attemptNo = (int) frame.getLocal(Constants.Runtime.RETRY_ATTEMPT_NUMBER);
             Throwable lastError = (Throwable) frame.getLocal(Frame.LAST_EXCEPTION_KEY);
 
             if (attemptNo >= retry.times()) {
@@ -141,7 +141,7 @@ public class RetryWrapper implements Command {
             // set the same exception handler for the next attempt
             frame.setExceptionHandler(this);
             // update the attempt number
-            frame.setLocal(RETRY_ATTEMPT_NUMBER, attemptNo + 1);
+            frame.setLocal(Constants.Runtime.RETRY_ATTEMPT_NUMBER, attemptNo + 1);
 
             // override the task's "in" if needed
             if (retry.input() != null) {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -714,6 +714,7 @@ public class MainTest {
         byte[] log = run();
         assertLog(log, ".*faultyOnceTask: fail.*");
         assertLog(log, ".*faultyOnceTask: ok.*");
+        assertLog(log, ".*neverFailTask: ok.*");
     }
 
     private void deploy(String resource) throws URISyntaxException, IOException {
@@ -946,6 +947,19 @@ public class MainTest {
             }
 
             log.info("faultyOnceTask: ok");
+            return TaskResult.success();
+        }
+    }
+
+    @Named("neverFailTask")
+    @SuppressWarnings("unused")
+    static class NeverFailTask implements Task {
+
+        private static final Logger log = LoggerFactory.getLogger(NeverFailTask.class);
+
+        @Override
+        public TaskResult execute(Variables input) {
+            log.info("neverFailTask: ok");
             return TaskResult.success();
         }
     }

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/retry/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/retry/concord.yml
@@ -1,6 +1,13 @@
 flows:
   default:
+    # should trigger twice
     - task: faultyOnceTask
+      retry:
+        times: 3
+        delay: 1
+
+    # should trigger once
+    - task: neverFailTask
       retry:
         times: 3
         delay: 1

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Constants.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Constants.java
@@ -1,0 +1,40 @@
+package com.walmartlabs.concord.runtime.v2.sdk;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public final class Constants {
+
+    public static final class Runtime {
+
+        /**
+         * A frame-local variable which contains the current "retry" attempt number.
+         * Zero indicates the first attempt to execute a command.
+         * Not defined outside of "retry" blocks.
+         */
+        public static final String RETRY_ATTEMPT_NUMBER = "__retry_attemptNo";
+
+        private Runtime() {
+        }
+    }
+
+    private Constants() {
+    }
+}

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ContextUtils.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ContextUtils.java
@@ -1,0 +1,58 @@
+package com.walmartlabs.concord.runtime.v2.sdk;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.svm.Frame;
+import com.walmartlabs.concord.svm.State;
+import com.walmartlabs.concord.svm.ThreadId;
+
+import java.io.Serializable;
+
+public final class ContextUtils {
+
+    /**
+     * Returns the current "retry" attempt number (if applicable).
+     *
+     * @see Constants.Runtime#RETRY_ATTEMPT_NUMBER
+     */
+    public static Integer getCurrentRetryAttemptNumber(Context ctx) {
+        Execution execution = ctx.execution();
+
+        State state = execution.state();
+        ThreadId threadId = execution.currentThreadId();
+        Frame frame = state.peekFrame(threadId);
+
+        Serializable value = frame.getLocal(Constants.Runtime.RETRY_ATTEMPT_NUMBER);
+        if (value == null) {
+            return null;
+        }
+
+        if (!(value instanceof Integer)) {
+            throw new IllegalStateException(String.format("%s is expected to be a number, got: %s. This is most likely a bug",
+                    Constants.Runtime.RETRY_ATTEMPT_NUMBER, value.getClass()));
+        }
+
+        return (Integer) value;
+    }
+
+    private ContextUtils() {
+    }
+}


### PR DESCRIPTION
RetryWrapper was incorrectly adding NextRetry command to the stack
instead of using it as the frame's exception handler.