### PR TITLE
runtime-v2: expression support in the checkpoint step

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/compiler/CheckpointCompiler.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/compiler/CheckpointCompiler.java
@@ -37,6 +37,6 @@ public class CheckpointCompiler implements StepCompiler<Checkpoint> {
 
     @Override
     public Command compile(CompilerContext context, Checkpoint step) {
-        return new CheckpointCommand(step.getName());
+        return new CheckpointCommand(step);
     }
 }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -45,6 +45,7 @@ import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskV2Provider;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.svm.ExecutionListener;
+import com.walmartlabs.concord.svm.Runtime;
 import org.immutables.value.Value;
 import org.junit.After;
 import org.junit.Before;
@@ -715,6 +716,18 @@ public class MainTest {
         assertLog(log, ".*faultyOnceTask: fail.*");
         assertLog(log, ".*faultyOnceTask: ok.*");
         assertLog(log, ".*neverFailTask: ok.*");
+    }
+
+    @Test
+    public void testCheckpointExpr() throws Exception {
+        deploy("checkpointExpr");
+
+        save(ProcessConfiguration.builder()
+                .putArguments("x", 123)
+                .build());
+
+        run();
+        verify(checkpointService, times(1)).create(eq("test_123"), any(Runtime.class), any(ProcessSnapshot.class));
     }
 
     private void deploy(String resource) throws URISyntaxException, IOException {

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointExpr/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointExpr/concord.yml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - checkpoint: "test_${x}"


### PR DESCRIPTION
Eval expressions in checkpoint names, just like we do it in v1.