### PR TITLE
runtime-v2: assume "retry.delay" is in seconds

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Retry.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Retry.java
@@ -25,17 +25,18 @@ import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Map;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true)
 public interface Retry extends Serializable {
 
+    long serialVersionUID = 1L;
+
     int DEFAULT_RETRY_TIMES = 1;
 
-    long DEFAULT_RETRY_DELAY = 5000;
-
-    long serialVersionUID = 1L;
+    Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(5);
 
     @Value.Default
     default int times() {
@@ -43,7 +44,7 @@ public interface Retry extends Serializable {
     }
 
     @Value.Default
-    default long delay() {
+    default Duration delay() {
         return DEFAULT_RETRY_DELAY;
     }
 

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
@@ -27,7 +27,7 @@ import com.walmartlabs.concord.runtime.v2.model.ImmutableFlowCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.WithItems;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.CommonGrammar.retryVal;
+import static com.walmartlabs.concord.runtime.v2.parser.RetryGrammar.retryVal;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.with;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/RetryGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/RetryGrammar.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.parser;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,8 @@ import com.walmartlabs.concord.runtime.v2.model.ImmutableRetry;
 import com.walmartlabs.concord.runtime.v2.model.Retry;
 import io.takari.parc.Parser;
 
+import java.time.Duration;
+
 import static com.walmartlabs.concord.runtime.v2.parser.ExpressionGrammar.expression;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.*;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;
@@ -33,14 +35,14 @@ import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.mapVal;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.maybeInt;
 import static io.takari.parc.Combinators.or;
 
-public final class CommonGrammar {
+public final class RetryGrammar {
 
     private static final Parser<Atom, Retry> retry =
             betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
                     with(Retry::builder,
                             o -> options(
                                     optional("times", orError(or(maybeInt.map(o::times), expression.map(o::timesExpression)), YamlValueType.RETRY_TIMES)),
-                                    optional("delay", orError(or(maybeInt.map(o::delay), expression.map(o::delayExpression)), YamlValueType.RETRY_DELAY)),
+                                    optional("delay", orError(or(maybeInt.map(i -> o.delay(Duration.ofSeconds(i))), expression.map(o::delayExpression)), YamlValueType.RETRY_DELAY)),
                                     optional("in", mapVal.map(o::input))
                             ))
                             .map(ImmutableRetry.Builder::build));
@@ -48,6 +50,6 @@ public final class CommonGrammar {
     public static final Parser<Atom, Retry> retryVal =
             orError(retry, YamlValueType.RETRY);
 
-    private CommonGrammar() {
+    private RetryGrammar() {
     }
 }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
@@ -26,7 +26,7 @@ import com.walmartlabs.concord.runtime.v2.model.ScriptCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.WithItems;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.CommonGrammar.retryVal;
+import static com.walmartlabs.concord.runtime.v2.parser.RetryGrammar.retryVal;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.satisfyField;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.with;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
@@ -27,7 +27,7 @@ import com.walmartlabs.concord.runtime.v2.model.TaskCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.WithItems;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.CommonGrammar.retryVal;
+import static com.walmartlabs.concord.runtime.v2.parser.RetryGrammar.retryVal;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.with;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -65,7 +65,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         // retry
         assertNotNull(t.getOptions().retry());
         assertEquals(1, t.getOptions().retry().times());
-        assertEquals(2, t.getOptions().retry().delay());
+        assertEquals(Duration.ofSeconds(2), t.getOptions().retry().delay());
         Map<String, Object> retryInput = new HashMap<>();
         retryInput.put("k", "retry-1");
         retryInput.put("k2", "retry-2");
@@ -106,7 +106,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         // retry
         assertNotNull(t.getOptions().retry());
         assertEquals(1, t.getOptions().retry().times());
-        assertEquals(2, t.getOptions().retry().delay());
+        assertEquals(Duration.ofSeconds(2), t.getOptions().retry().delay());
         Map<String, Object> retryInput = new HashMap<>();
         retryInput.put("k", "retry-1");
         retryInput.put("k2", "retry-2");
@@ -371,7 +371,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         // retry
         assertNotNull(t.getOptions().retry());
         assertEquals(1, t.getOptions().retry().times());
-        assertEquals(2, t.getOptions().retry().delay());
+        assertEquals(Duration.ofSeconds(2), t.getOptions().retry().delay());
         Map<String, Object> retryInput = new HashMap<>();
         retryInput.put("k", "v");
         assertEquals(retryInput, t.getOptions().retry().input());

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/RetryWrapper.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/RetryWrapper.java
@@ -32,6 +32,7 @@ import com.walmartlabs.concord.svm.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -80,9 +81,9 @@ public class RetryWrapper implements Command {
             times = ee.eval(EvalContextFactory.global(ctx), retry.timesExpression(), Integer.class);
         }
 
-        long delay = retry.delay();
+        Duration delay = retry.delay();
         if (retry.delayExpression() != null) {
-            delay = ee.eval(EvalContextFactory.global(ctx), retry.delayExpression(), Long.class);
+            delay = Duration.ofSeconds(ee.eval(EvalContextFactory.global(ctx), retry.delayExpression(), Long.class));
         }
 
         inner.setLocal(Constants.Runtime.RETRY_ATTEMPT_NUMBER, 0);
@@ -129,11 +130,11 @@ public class RetryWrapper implements Command {
                 }
             }
 
-            long delay = retry.delay();
-            log.warn("Last error: {}. Waiting for {}ms before retry (attempt #{})", lastError, delay, attemptNo);
+            Duration delay = retry.delay();
+            log.warn("Last error: {}. Waiting for {}ms before retry (attempt #{})", lastError, delay.toMillis(), attemptNo);
 
             try {
-                Thread.sleep(delay);
+                Thread.sleep(delay.toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -713,6 +713,7 @@ public class MainTest {
 
         byte[] log = run();
         assertLog(log, ".*faultyOnceTask: fail.*");
+        assertLog(log, ".*Waiting for 1000ms.*");
         assertLog(log, ".*faultyOnceTask: ok.*");
         assertLog(log, ".*neverFailTask: ok.*");
     }


### PR DESCRIPTION
In v1 the `delay` parameter is in seconds. Make the v2 version assume the same.
Use `Duration` instead of a long value.
Rename `CommonGrammar` to `RetryGrammar` as it is the only thing there.

There's no good built-in way to format `Durations`, so I left the original log message intact.