### PR TITLE
concord-console: increase the default log segment limit to 100

### DIFF
--- a/console2/src/components/organisms/ProcessLogActivityV2/index.tsx
+++ b/console2/src/components/organisms/ProcessLogActivityV2/index.tsx
@@ -82,7 +82,7 @@ const ProcessLogActivityV2 = ({
 
     const fetchSegments = useCallback(async () => {
         // TODO: real limit/offset
-        const limit = 30;
+        const limit = 100;
         const offset = 0;
         const segments = await apiListLogSegments(instanceId, offset, limit);
         setSegments(segments.items);


### PR DESCRIPTION
Increase the log segment limit to 100 (instead of 30) to accommodate larger v2 flows.
Ultimately, we'd need a proper paging mechanism for log segments.