### PR TITLE
runtime-v2, concord-client: rename SecretParams#name to secretName, throw ApiException

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -186,6 +186,12 @@
                             <item>
                                 <code>java.method.removed</code>
                             </item>
+                            <item>
+                                <code>java.method.exception.checkedAdded</code>
+                            </item>
+                            <item>
+                                <code>java.method.exception.checkedRemoved</code>
+                            </item>
                         </revapi.ignore>
                     </analysisConfiguration>
                 </configuration>

--- a/client/src/main/java/com/walmartlabs/concord/client/ClientUtils.java
+++ b/client/src/main/java/com/walmartlabs/concord/client/ClientUtils.java
@@ -62,7 +62,7 @@ public final class ClientUtils {
             } catch (ApiException e) {
                 exception = e;
 
-                log.error("call error: '{}'", getErrorMessage(e));
+                log.warn("call error: '{}'", getErrorMessage(e));
 
                 if (e.getCode() >= 400 && e.getCode() < 500) {
                     break;

--- a/client/src/main/java/com/walmartlabs/concord/client/SecretClient.java
+++ b/client/src/main/java/com/walmartlabs/concord/client/SecretClient.java
@@ -162,7 +162,7 @@ public class SecretClient {
     /**
      * Creates a new Concord secret.
      */
-    public SecretOperationResponse createSecret(CreateSecretRequest secretRequest) throws IOException {
+    public SecretOperationResponse createSecret(CreateSecretRequest secretRequest) throws ApiException {
         String path = "/api/v1/org/" + secretRequest.org() + "/secret";
 
         Map<String, Object> params = new HashMap<>();
@@ -200,25 +200,25 @@ public class SecretClient {
             throw new IllegalArgumentException("Secret data, a key pair or username/password must be specified.");
         }
 
-        try {
-            ApiResponse<SecretOperationResponse> response = ClientUtils.withRetry(retryCount, retryInterval,
-                    () -> ClientUtils.postData(apiClient, path, params, SecretOperationResponse.class));
-            return response.getData();
-        } catch (ApiException e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        ApiResponse<SecretOperationResponse> response = ClientUtils.withRetry(retryCount, retryInterval,
+                () -> ClientUtils.postData(apiClient, path, params, SecretOperationResponse.class));
+        return response.getData();
     }
 
-    private static byte[] readFile(Path file) throws IOException {
+    private static byte[] readFile(Path file) {
         if (file == null) {
             return null;
         }
 
         if (Files.notExists(file)) {
-            throw new RuntimeException("File '" + file + "' not found");
+            throw new IllegalArgumentException("File '" + file + "' not found");
         }
 
-        return Files.readAllBytes(file);
+        try {
+            return Files.readAllBytes(file);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while reading " + file + ": " + e.getMessage());
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/tasks/crypto/src/main/java/com/walmartlabs/concord/plugins/crypto/CryptoTaskV2.java
+++ b/plugins/tasks/crypto/src/main/java/com/walmartlabs/concord/plugins/crypto/CryptoTaskV2.java
@@ -125,7 +125,7 @@ public class CryptoTaskV2 implements Task {
     private SecretCreationResult createSecret(TaskParams in) throws Exception {
         SecretService.SecretParams secret = SecretService.SecretParams.builder()
                 .orgName(in.orgOrDefault(processOrg))
-                .name(in.secretName())
+                .secretName(in.secretName())
                 .generatePassword(in.generatePassword())
                 .storePassword(in.storePassword())
                 .visibility(in.visibility() != null ? SecretService.SecretParams.Visibility.valueOf(in.visibility()) : null)

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultSecretService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultSecretService.java
@@ -144,7 +144,7 @@ public class DefaultSecretService implements SecretService {
         SecretParams.Visibility visibility = secret.visibility();
         return CreateSecretRequest.builder()
                 .org(secret.orgName())
-                .name(secret.name())
+                .name(secret.secretName())
                 .generatePassword(secret.generatePassword())
                 .storePassword(secret.storePassword())
                 .visibility(visibility != null ? SecretEntry.VisibilityEnum.fromValue(visibility.name()) : null)

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/SecretService.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/SecretService.java
@@ -72,7 +72,7 @@ public interface SecretService {
         @Nullable
         String project();
 
-        String name();
+        String secretName();
 
         @Nullable
         String storePassword();


### PR DESCRIPTION
Rename `SecretParams#name()` to `secretName()` for consistency.
Throw ApiException instead of RuntimeException to allow access to the status code/response headers.