### PR TITLE
runtime-v2: add missing EventConfiguration fields to the grammar

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
@@ -42,7 +42,7 @@ public final class ConfigurationGrammar {
                             .map(ImmutableExclusiveModeConfiguration.Builder::build));
 
     public static final Parser<Atom, ExclusiveModeConfiguration> exclusiveVal =
-        orError(exclusive, YamlValueType.EXCLUSIVE_MODE);
+            orError(exclusive, YamlValueType.EXCLUSIVE_MODE);
 
     private static final Parser<Atom, EventConfiguration> events =
             betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
@@ -50,9 +50,12 @@ public final class ConfigurationGrammar {
                             o -> options(
                                     optional("recordTaskInVars", booleanVal.map(o::recordTaskInVars)),
                                     optional("truncateInVars", booleanVal.map(o::truncateInVars)),
-                                    optional("inVarsBlacklist", stringArrayVal.map(o::inVarsBlacklist)),
+                                    optional("truncateMaxStringLength", intVal.map(o::truncateMaxStringLength)),
+                                    optional("truncateMaxArrayLength", intVal.map(o::truncateMaxArrayLength)),
+                                    optional("truncateMaxDepth", intVal.map(o::truncateMaxDepth)),
                                     optional("recordTaskOutVars", booleanVal.map(o::recordTaskOutVars)),
                                     optional("truncateOutVars", booleanVal.map(o::truncateOutVars)),
+                                    optional("inVarsBlacklist", stringArrayVal.map(o::inVarsBlacklist)),
                                     optional("outVarsBlacklist", stringArrayVal.map(o::outVarsBlacklist))))
                             .map(ImmutableEventConfiguration.Builder::build));
 

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1949,7 +1949,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1318() throws Exception {
         String msg =
-                "(018.yml): Error @ line: 23, col: 11. Unknown options: ['trash' [NULL] @ line: 23, col: 11], expected: [recordTaskInVars, truncateInVars, inVarsBlacklist, recordTaskOutVars, truncateOutVars, outVarsBlacklist]. Remove invalid options and/or fix indentation\n" +
+                "(018.yml): Error @ line: 26, col: 11. Unknown options: ['trash' [NULL] @ line: 26, col: 11], expected: [recordTaskInVars, truncateInVars, truncateMaxStringLength, truncateMaxArrayLength, truncateMaxDepth, recordTaskOutVars, truncateOutVars, inVarsBlacklist, outVarsBlacklist]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'events' @ line: 14, col: 3\n" +
                         "\t\t'configuration' @ line: 1, col: 1";

--- a/runtime/v2/model/src/test/resources/errors/configuration/018.yml
+++ b/runtime/v2/model/src/test/resources/errors/configuration/018.yml
@@ -20,4 +20,7 @@ configuration:
     recordTaskOutVars: true
     outVarsBlacklist:
       - "FOO"
+    truncateMaxStringLength: 128
+    truncateMaxArrayLength: 8
+    truncateMaxDepth: 5
     trash:


### PR DESCRIPTION
Add truncateMaxStringLength, truncateMaxArrayLength and truncateMaxDepth to the grammar.