### PR TITLE
runtime-v2: actually working checkpoints

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -195,6 +195,7 @@ public class ProcessIT {
         proc.assertLog(".*#1.*x=123.*");
         proc.assertLog(".*#2.*y=234.*");
         proc.assertLog(".*#3.*y=345.*");
+        proc.assertLog(".*same workDir: true.*");
 
         // ---
 
@@ -228,6 +229,7 @@ public class ProcessIT {
 
         proc.assertLog(".*#1.*x=123.*");
         proc.assertLogAtLeast(".*#3.*y=345.*", 2);
+        proc.assertLog(".*same workDir: false.*");
     }
 
     @Test(timeout = DEFAULT_TEST_TIMEOUT)

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -252,6 +252,6 @@ public class ProcessIT {
         proc.restoreCheckpoint(checkpoints.get(1).getId());
         proc.expectStatus(ProcessEntry.StatusEnum.FINISHED);
 
-        proc.assertLogAtLeast(".*#4.*y=345.*", 2);
+        proc.assertLogAtLeast(".*#4.*z=345.*", 2);
     }
 }

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
@@ -1,0 +1,17 @@
+configuration:
+  runtime: "concord-v2"
+  arguments:
+    aVar:
+      x: 123
+
+flows:
+  default:
+    - log: "#1 ${aVar}"
+    - checkpoint: "first"
+    - set:
+        aVar.y: 234
+    - log: "#2 ${aVar}"
+    - checkpoint: "second"
+    - set:
+        aVar.y: 345
+    - log: "#3 ${aVar}"

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
@@ -6,12 +6,23 @@ configuration:
 
 flows:
   default:
-    - log: "#1 ${aVar}"
+    - log: "#1 ${aVar}" # {x=123}
+
+    - set:
+        oldWorkDir: "${workDir}"
+
     - checkpoint: "first"
+
     - set:
         aVar.y: 234
-    - log: "#2 ${aVar}"
+
+    - log: "#2 ${aVar}" # {x=123, y=234}
+
     - checkpoint: "second"
+
     - set:
         aVar.y: 345
-    - log: "#3 ${aVar}"
+
+    - log: "#3 ${aVar}" # ${x=123, y=345}
+
+    - log: "same workDir: ${workDir == oldWorkDir}" # 'true' first time, 'false' after restoring a checkpoint

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
@@ -1,0 +1,25 @@
+configuration:
+  runtime: "concord-v2"
+  arguments:
+    aVar:
+      x: 123
+
+flows:
+  default:
+    - log: "#1 ${aVar}"
+
+    - parallel:
+        - block:
+            - set:
+                aVar.y: 234
+            - log: "#2 ${aVar}"
+            - checkpoint: "first"
+        - block:
+            - set:
+                aVar.y: 345
+            - log: "#3 ${aVar}"
+            - checkpoint: "second"
+
+    - checkpoint: "third"
+
+    - log: "#4 ${aVar}"

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
@@ -16,7 +16,7 @@ flows:
             - checkpoint: "first"
         - block:
             - set:
-                aVar.y: 345
+                aVar.z: 345
             - log: "#3 ${aVar}"
             - checkpoint: "second"
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -144,7 +144,7 @@ public class Main {
                 break;
             }
             case RESTART_FROM_A_CHECKPOINT: {
-                snapshot = restart(runner, snapshot);
+                snapshot = restart(runner, snapshot, processArgs);
                 break;
             }
         }
@@ -194,8 +194,9 @@ public class Main {
         return runner.start(processDefinition, cfg.entryPoint(), args);
     }
 
-    private static ProcessSnapshot restart(Runner runner, ProcessSnapshot snapshot) throws Exception {
-        return runner.resume(snapshot);
+    private static ProcessSnapshot restart(Runner runner, ProcessSnapshot snapshot, Map<String, Object> args) throws Exception {
+
+        return runner.resume(snapshot, args);
     }
 
     private static ProcessSnapshot resume(Runner runner, ProcessConfiguration cfg,

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -116,7 +116,7 @@ public class Main {
 
         String segmentedLogDir = runnerCfg.logging().segmentedLogDir();
         if (segmentedLogDir != null) {
-            LoggingConfigurator.configure(assertNotNull(processCfg.instanceId()), segmentedLogDir);
+            LoggingConfigurator.configure(Objects.requireNonNull(processCfg.instanceId()), segmentedLogDir);
         }
 
         if (processCfg.debug()) {
@@ -167,7 +167,7 @@ public class Main {
         Map<String, Object> m = new LinkedHashMap<>(cfg.arguments());
 
         // save the current process ID as an argument, flows and plugins expect it to be a string value
-        m.put(Constants.Context.TX_ID_KEY, assertNotNull(cfg.instanceId()).toString());
+        m.put(Constants.Context.TX_ID_KEY, Objects.requireNonNull(cfg.instanceId()).toString());
 
         m.put(Constants.Context.WORK_DIR_KEY, workDir.getValue().toAbsolutePath().toString());
 
@@ -234,11 +234,6 @@ public class Main {
         }
 
         return events;
-    }
-
-    private static <T> T assertNotNull(T object) {
-        assert object != null;
-        return object;
     }
 
     private static Mode currentMode(ProcessSnapshot snapshot, Set<String> events) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Runner.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Runner.java
@@ -105,6 +105,23 @@ public class Runner {
                 .build();
     }
 
+    public ProcessSnapshot resume(ProcessSnapshot snapshot) throws Exception {
+        statusCallback.onRunning(instanceId.getValue());
+        log.debug("resume -> running...");
+
+        State state = snapshot.vmState();
+
+        VM vm = createVM(snapshot.processDefinition());
+        vm.start(state);
+
+        log.debug("resume -> done");
+
+        return ProcessSnapshot.builder()
+                .from(snapshot)
+                .vmState(state)
+                .build();
+    }
+
     private VM createVM(ProcessDefinition processDefinition) {
         Collection<ExecutionListener> listeners = new ArrayList<>();
         listeners.add(new SynchronizationServiceListener(synchronizationService));

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Runner.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Runner.java
@@ -105,13 +105,16 @@ public class Runner {
                 .build();
     }
 
-    public ProcessSnapshot resume(ProcessSnapshot snapshot) throws Exception {
+    public ProcessSnapshot resume(ProcessSnapshot snapshot, Map<String, Object> input) throws Exception {
         statusCallback.onRunning(instanceId.getValue());
         log.debug("resume -> running...");
 
         State state = snapshot.vmState();
 
         VM vm = createVM(snapshot.processDefinition());
+        // update the global variables using the input map by running a special command
+        vm.run(state, new UpdateLocalsCommand(input));
+        // continue as usual
         vm.start(state);
 
         log.debug("resume -> done");

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/TestCheckpointService.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/TestCheckpointService.java
@@ -1,0 +1,58 @@
+package com.walmartlabs.concord.runtime.v2.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.runner.checkpoints.CheckpointService;
+import com.walmartlabs.concord.svm.Runtime;
+
+import java.io.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TestCheckpointService implements CheckpointService {
+
+    private final Map<String, Serializable> checkpoints = new ConcurrentHashMap<>();
+
+    @Override
+    public void create(String name, Runtime runtime, ProcessSnapshot snapshot) {
+        // roundtrip through the serialization to create a copy
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(snapshot);
+            }
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+                snapshot = (ProcessSnapshot) ois.readObject();
+            }
+        } catch (ClassNotFoundException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        checkpoints.put(name, snapshot);
+    }
+
+    public Map<String, Serializable> getCheckpoints() {
+        return Collections.unmodifiableMap(checkpoints);
+    }
+}

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointRestore/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointRestore/concord.yml
@@ -1,0 +1,19 @@
+flows:
+  default:
+    - log: "#1 ${aVar}" # {x=123}
+
+    - checkpoint: "first"
+
+    - set:
+        aVar.y: 234
+
+    - log: "#2 ${aVar}" # {x=123, y=234}
+
+    - checkpoint: "second"
+
+    - set:
+        aVar.y: 345
+
+    - expr: "${aVar.x = aVar.x + 1}"
+
+    - log: "#3 ${aVar}" # {x=123, y=345}

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -99,7 +99,7 @@
         <sshd.version>1.6.0</sshd.version>
         <swagger.version>1.5.20</swagger.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
-        <testcontainers.concord.version>0.0.28</testcontainers.concord.version>
+        <testcontainers.concord.version>0.0.31</testcontainers.concord.version>
         <testcontainers.version>1.13.0</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <wiremock.version>2.26.1</wiremock.version>


### PR DESCRIPTION
Update the runner v2 to actually support checkpoints.
The previous implementation expected a checkpoint to have an eventRef associated with it.
Which was the case in v1, but not in v2. In v2 we can directly feed a ProcessSnapshot instance to the runtime.

Update the runner v2 and add some tests.