### PR TITLE
concord-agent: use current java by default

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
@@ -53,7 +53,7 @@ public abstract class AbstractRunnerConfiguration {
 
         this.path = Paths.get(path);
         this.cfgDir = getDir(cfg, prefix + ".cfgDir");
-        this.javaCmd = cfg.getString(prefix + ".javaCmd");
+        this.javaCmd = getJavaCmd(cfg, prefix);
         this.jvmParams = cfg.getStringList(prefix + ".jvmParams");
         this.mainClass = cfg.getString(prefix + ".mainClass");
         this.securityManagerEnabled = cfg.getBoolean(prefix + ".securityManagerEnabled");
@@ -84,4 +84,22 @@ public abstract class AbstractRunnerConfiguration {
     }
 
     public abstract String getRuntimeName();
+
+    private static String getJavaCmd(Config cfg, String prefix) {
+        String path = prefix + ".javaCmd";
+
+        if (cfg.hasPath(path)) {
+            String s = cfg.getString(path);
+            if (s != null) {
+                return s;
+            }
+        }
+
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null) {
+            return javaHome + "/bin/java";
+        }
+
+        return "java";
+    }
 }

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -153,7 +153,8 @@ concord-agent {
         securityManagerEnabled = false
 
         # command to use to run the runner JAR
-        javaCmd = "java"
+        # '${java.home}/bin/java' by default
+        #javaCmd = "java"
 
         # default JVM parameters
         jvmParams = [

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
@@ -269,7 +269,7 @@ public class SecretManager {
     public void update(String orgName, String secretName, SecretUpdateRequest req) {
         SecretEntry e;
 
-        if(req.id() == null) {
+        if (req.id() == null) {
             OrganizationEntry org = orgManager.assertAccess(null, orgName, false);
             e = assertAccess(org.getId(), null, secretName, ResourceAccessLevel.OWNER, true);
         } else {
@@ -748,6 +748,7 @@ public class SecretManager {
         }
 
         if (owner.username() != null) {
+            // TODO don't assume LDAP here
             return userManager.get(owner.username(), owner.userDomain(), UserType.LDAP)
                     .orElseThrow(() -> new ConcordApplicationException("User not found: " + owner.username()));
         }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
@@ -360,8 +360,9 @@ public class SecretManager {
         }
 
         if (projectName != null && projectName.trim().isEmpty()) {
-            // empty project name is same as null project
+            // empty project name means "remove the project link"
             effectiveProjectId = null;
+            projectName = null;
         }
 
         if (effectiveProjectId != null || projectName != null) {


### PR DESCRIPTION
Use the current java (`${java.home}/bin/java`) if no `runner*.javaCmd` values provided.
Simplifies Agent configuration a little bit.