### PR TITLE
concord-agent: option to keep workDir after the process ends

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/Agent.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Agent.java
@@ -40,6 +40,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
@@ -124,7 +125,7 @@ public class Agent {
             try {
                 jobRequest = take(queueClient);
             } catch (Exception e) {
-                log.warn("run -> error while fetching a job: {}", e.getMessage());
+                log.error("run -> error while fetching a job: {}", e.getMessage(), e);
 
                 workersAvailable.release();
 

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
@@ -28,8 +28,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 
-import static com.walmartlabs.concord.agent.cfg.Utils.getDir;
-import static com.walmartlabs.concord.agent.cfg.Utils.getStringOrDefault;
+import static com.walmartlabs.concord.agent.cfg.Utils.*;
 
 public abstract class AbstractRunnerConfiguration {
 
@@ -39,6 +38,7 @@ public abstract class AbstractRunnerConfiguration {
     private final List<String> jvmParams;
     private final String mainClass;
     private final boolean securityManagerEnabled;
+    private final Path persistentWorkDir;
 
     public AbstractRunnerConfiguration(String prefix, Config cfg) {
         String path = getStringOrDefault(cfg, prefix + ".path", () -> {
@@ -52,11 +52,12 @@ public abstract class AbstractRunnerConfiguration {
         });
 
         this.path = Paths.get(path);
-        this.cfgDir = getDir(cfg, prefix + ".cfgDir");
+        this.cfgDir = getOrCreatePath(cfg, prefix + ".cfgDir");
         this.javaCmd = cfg.getString(prefix + ".javaCmd");
         this.jvmParams = cfg.getStringList(prefix + ".jvmParams");
         this.mainClass = cfg.getString(prefix + ".mainClass");
         this.securityManagerEnabled = cfg.getBoolean(prefix + ".securityManagerEnabled");
+        this.persistentWorkDir = getOptionalAbsolutePath(cfg, prefix + ".persistentWorkDir");
     }
 
     public Path getPath() {
@@ -84,4 +85,8 @@ public abstract class AbstractRunnerConfiguration {
     }
 
     public abstract String getRuntimeName();
+
+    public Path getPersistentWorkDir() {
+        return persistentWorkDir;
+    }
 }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.walmartlabs.concord.agent.cfg.Utils.getDir;
+import static com.walmartlabs.concord.agent.cfg.Utils.getOrCreatePath;
 import static com.walmartlabs.concord.agent.cfg.Utils.getStringOrDefault;
 
 @Named
@@ -63,11 +63,11 @@ public class AgentConfiguration {
         this.capabilities = cfg.hasPath("capabilities") ? cfg.getObject("capabilities").unwrapped() : null;
         log.info("Using the capabilities: {}", this.capabilities);
 
-        this.dependencyCacheDir = getDir(cfg, "dependencyCacheDir");
-        this.dependencyListsDir = getDir(cfg, "dependencyListsDir");
-        this.payloadDir = getDir(cfg, "payloadDir");
+        this.dependencyCacheDir = getOrCreatePath(cfg, "dependencyCacheDir");
+        this.dependencyListsDir = getOrCreatePath(cfg, "dependencyListsDir");
+        this.payloadDir = getOrCreatePath(cfg, "payloadDir");
 
-        this.logDir = getDir(cfg, "logDir");
+        this.logDir = getOrCreatePath(cfg, "logDir");
         this.logMaxDelay = cfg.getDuration("logMaxDelay", TimeUnit.MILLISECONDS);
 
         this.workersCount = cfg.getInt("workersCount");

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/RepositoryCacheConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/RepositoryCacheConfiguration.java
@@ -28,7 +28,7 @@ import javax.inject.Singleton;
 import java.nio.file.Path;
 import java.time.Duration;
 
-import static com.walmartlabs.concord.agent.cfg.Utils.getDir;
+import static com.walmartlabs.concord.agent.cfg.Utils.getOrCreatePath;
 
 @Named
 @Singleton
@@ -42,11 +42,11 @@ public class RepositoryCacheConfiguration {
 
     @Inject
     public RepositoryCacheConfiguration(Config cfg) {
-        this.cacheDir = getDir(cfg, "repositoryCache.cacheDir");
+        this.cacheDir = getOrCreatePath(cfg, "repositoryCache.cacheDir");
         this.lockTimeout = cfg.getDuration("repositoryCache.lockTimeout");
         this.lockCount = cfg.getInt("repositoryCache.lockCount");
         this.maxAge = cfg.getDuration("repositoryCache.maxAge");
-        this.infoDir = getDir(cfg, "repositoryCache.cacheInfoDir");
+        this.infoDir = getOrCreatePath(cfg, "repositoryCache.cacheInfoDir");
     }
 
     public Path getCacheDir() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/Utils.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/Utils.java
@@ -38,7 +38,24 @@ public final class Utils {
         return defaultValueSupplier.get();
     }
 
-    public static Path getDir(Config cfg, String key) {
+    public static Path getOptionalAbsolutePath(Config cfg, String key) {
+        if (!cfg.hasPath(key)) {
+            return null;
+        }
+
+        String s = cfg.getString(key).trim();
+        if (s.isEmpty()) {
+            return null;
+        }
+
+        if (!s.startsWith("/")) {
+            throw new IllegalArgumentException(key + " must be an absolute path, got: " + s);
+        }
+
+        return Paths.get(s);
+    }
+
+    public static Path getOrCreatePath(Config cfg, String key) {
         try {
             if (!cfg.hasPath(key)) {
                 return IOUtils.createTempDir(key);

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
@@ -120,6 +120,7 @@ public class JobExecutorFactory {
                     .maxHeartbeatInterval(serverCfg.getMaxNoHeartbeatInterval())
                     .segmentedLogs(segmentedLogs)
                     .logDir(agentCfg.getLogDir())
+                    .persistentWorkDir(runnerCfg.getPersistentWorkDir())
                     .build();
 
             JobExecutor delegate = new RunnerJobExecutor(runnerExecutorCfg, dependencyManager, defaultDependencies, attachmentsUploader, processPool, processLogFactory, executor);

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -14,8 +14,9 @@ concord-agent {
     # directory to store process dependency lists
     dependencyListsDir = "dependencyLists"
 
-    # directory to store the process payload
+    # base directory to store the process payload
     # created automatically if not specified
+    # the actual payload is stored in "${payloadDir}/${randomName}"
     payloadDir = "payload"
 
     # directory to store the process logs
@@ -161,6 +162,11 @@ concord-agent {
             "-XX:+HeapDumpOnOutOfMemoryError",
             "-XX:HeapDumpPath=/tmp"
         ]
+
+        # if set, the Agent copies all process files into a persistentWorkDir's subdirectory
+        # after the process ends (regardless of the status)
+        # should not be used in production environments
+        # persistentWorkDir = /path/to/dir
     }
 
     # the default v1 runtime configuration

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretManager.java
@@ -269,7 +269,7 @@ public class SecretManager {
     public void update(String orgName, String secretName, SecretUpdateRequest req) {
         SecretEntry e;
 
-        if(req.id() == null) {
+        if (req.id() == null) {
             OrganizationEntry org = orgManager.assertAccess(null, orgName, false);
             e = assertAccess(org.getId(), null, secretName, ResourceAccessLevel.OWNER, true);
         } else {
@@ -362,6 +362,7 @@ public class SecretManager {
         if (projectName != null && projectName.trim().isEmpty()) {
             // empty project name is same as null project
             effectiveProjectId = null;
+            projectName = null;
         }
 
         if (effectiveProjectId != null || projectName != null) {


### PR DESCRIPTION
A new configuration option:
```
concord-agent {
  runner {
    persistentWorkDir = "/path/to/dir"
  }
}
```

If specified, Agent will copy all files from the process' working directory
into a subdirectory of `persistentWorkDir` after the process ends (regardless
of the status).

This feature is planned to be used in testcontainers-concord to allow test authors
to inspect the process ${workDir}.

All copied files will be readable by all users (i.e. it sets `0644`
permissions for files and `755` for directories). Should *not* be used in production.