### PR TITLE
concord-server: support for added/removed/modified files in github push trigger conditions

### DIFF
--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/githubTests/repos/v2/files/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/githubTests/repos/v2/files/concord.yml
@@ -1,0 +1,16 @@
+flows:
+  onPush:
+    - log: "onPush: ${event}"
+
+triggers:
+  - github:
+      entryPoint: "onPush"
+      version: 2
+      conditions:
+        type: "push"
+        githubOrg: "devtools"
+        githubRepo: "concord"
+        branch: "master"
+        files:
+          modified:
+            - "concord.yml"

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Constants.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Constants.java
@@ -24,16 +24,11 @@ public final class Constants {
 
     public static final String EVENT_SOURCE = "github";
 
-    public static final String DEFAULT_EVENT_TYPE = "push";
-
-    public static final String AUTHOR_KEY = "author";
     public static final String COMMIT_ID_KEY = "commitId";
     public static final String IGNORE_EMPTY_PUSH_KEY = "ignoreEmptyPush";
-    public static final String ORG_NAME_KEY = "org";
     public static final String ORGANIZATION_KEY = "organization";
     public static final String PAYLOAD_KEY = "payload";
     public static final String PROJECT_ID_KEY = "projectId";
-    public static final String PROJECT_NAME_KEY = "project";
     public static final String PULL_REQUEST_EVENT = "pull_request";
     public static final String PUSH_EVENT = "push";
     public static final String REPO_BRANCH_KEY = "branch";
@@ -44,6 +39,7 @@ public final class Constants {
     public static final String TYPE_KEY = "type";
     public static final String UNKNOWN_REPO_KEY = "unknownRepo";
     public static final String VERSION_KEY = "version";
+    public static final String FILES_KEY = "files";
 
     public static final String GITHUB_ORG_KEY = "githubOrg";
     public static final String GITHUB_REPO_KEY = "githubRepo";

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
@@ -126,6 +126,9 @@ public class GithubTriggerV2Processor implements GithubTriggerProcessor {
         result.put(STATUS_KEY, payload.getAction());
         result.put(PAYLOAD_KEY, payload.raw());
 
+        // files
+        result.put(FILES_KEY, payload.getFiles());
+
         // match only with v2 triggers
         result.put(VERSION_KEY, VERSION_ID);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Payload.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Payload.java
@@ -25,6 +25,8 @@ import com.walmartlabs.concord.sdk.MapUtils;
 
 import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.walmartlabs.concord.server.events.github.Constants.*;
 
@@ -142,6 +144,26 @@ public class Payload {
             default:
                 return null;
         }
+    }
+
+    public Map<String, List<String>> getFiles() {
+        if (!eventName.toLowerCase().equals(PUSH_EVENT)) {
+            return Collections.emptyMap();
+        }
+
+        List<Map<String, Object>> commits = MapUtils.getList(data, "commits", Collections.emptyList());
+        Map<String, List<String>> files = new HashMap<>();
+        for (Map<String, Object> c : commits) {
+            appendList(c, "added", files);
+            appendList(c, "removed", files);
+            appendList(c, "modified", files);
+        }
+        return files;
+    }
+
+    private static void appendList(Map<String, Object> c, String name, Map<String, List<String>> result) {
+        List<String> value = MapUtils.getList(c, name, Collections.emptyList());
+        result.compute(name, (k, v) -> (v == null) ? value : Stream.concat(v.stream(), value.stream()).collect(Collectors.toList()));
     }
 
     public String getSender() {


### PR DESCRIPTION
trigger definition:
```
  - github:
      entryPoint: "onPush"
      version: 2
      conditions:
        type: "push"
        ...
        files:
          modified:
            - "concord.yml"
          added:
            - "new.*"
          removed:
            - ....
```