### PR TITLE
server: configurable out variables mode for project

### DIFF
--- a/console2/src/api/org/project/index.ts
+++ b/console2/src/api/org/project/index.ts
@@ -55,6 +55,14 @@ export enum RawPayloadMode {
     EVERYONE = 'EVERYONE'
 }
 
+export enum OutVariablesMode {
+    DISABLED = 'DISABLED',
+    OWNERS = 'OWNERS',
+    TEAM_MEMBERS = 'TEAM_MEMBERS',
+    ORG_MEMBERS = 'ORG_MEMBERS',
+    EVERYONE = 'EVERYONE'
+}
+
 export interface ProjectEntry {
     id: ConcordId;
     name: ConcordKey;
@@ -72,6 +80,8 @@ export interface ProjectEntry {
     rawPayloadMode: RawPayloadMode;
 
     meta?: ProjectEntryMeta;
+
+    outVariablesMode: OutVariablesMode;
 }
 
 export interface NewProjectEntry {
@@ -88,6 +98,7 @@ export interface UpdateProjectEntry {
     description?: string;
     visibility?: ProjectVisibility;
     rawPayloadMode?: RawPayloadMode;
+    outVariablesMode?: OutVariablesMode;
 }
 
 export interface PaginatedProjectEntries {

--- a/console2/src/components/organisms/ProjectActivity/ProjectSettings.tsx
+++ b/console2/src/components/organisms/ProjectActivity/ProjectSettings.tsx
@@ -27,6 +27,7 @@ import {
     ProjectOrganizationChangeActivity,
     ProjectOwnerChangeActivity,
     ProjectRawPayloadModeActivity,
+    ProjectOutVariablesModeActivity,
     ProjectRenameActivity,
     RequestErrorActivity
 } from '../index';
@@ -73,6 +74,17 @@ const ProjectSettings = ({ orgName, projectName, forceRefresh }: ExternalProps) 
                         orgName={orgName}
                         projectId={data.id}
                         initialValue={data.rawPayloadMode}
+                    />
+                )}
+            </Segment>
+
+            <Segment disabled={isLoading}>
+                <Header as="h4">Allow out variable names in request</Header>
+                {data && (
+                    <ProjectOutVariablesModeActivity
+                        orgName={orgName}
+                        projectId={data.id}
+                        initialValue={data.outVariablesMode}
                     />
                 )}
             </Segment>

--- a/console2/src/components/organisms/ProjectOutVariablesModeActivity/index.tsx
+++ b/console2/src/components/organisms/ProjectOutVariablesModeActivity/index.tsx
@@ -33,7 +33,7 @@ export interface Props {
 const getDescription = (m: OutVariablesMode): string => {
     switch (m) {
         case OutVariablesMode.DISABLED:
-            return 'Sending custom out variable names is disabled. Only variables defined in concord.yml can be used to get out variables.';
+            return 'Sending custom out variable names is disabled. Only out variables defined in concord.yml can be used.';
         case OutVariablesMode.OWNERS:
             return "Only the project's owner and team members with OWNER privileges can specify custom out variable names.";
         case OutVariablesMode.TEAM_MEMBERS:

--- a/console2/src/components/organisms/ProjectOutVariablesModeActivity/index.tsx
+++ b/console2/src/components/organisms/ProjectOutVariablesModeActivity/index.tsx
@@ -1,0 +1,106 @@
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { Form } from 'semantic-ui-react';
+import { ConcordId, ConcordKey, RequestError } from '../../../api/common';
+import {createOrUpdate as apiCreateOrUpdate, OutVariablesMode} from '../../../api/org/project';
+import { RequestErrorActivity } from '../index';
+
+export interface Props {
+    orgName: ConcordKey;
+    projectId: ConcordId;
+    initialValue?: OutVariablesMode;
+}
+
+const getDescription = (m: OutVariablesMode): string => {
+    switch (m) {
+        case OutVariablesMode.DISABLED:
+            return 'Sending custom out variable names is disabled. Only variables defined in concord.yml can be used to get out variables.';
+        case OutVariablesMode.OWNERS:
+            return "Only the project's owner and team members with OWNER privileges can specify custom out variable names.";
+        case OutVariablesMode.TEAM_MEMBERS:
+            return "Only the members of the teams assigned to the project's can specify custom out variable names.";
+        case OutVariablesMode.ORG_MEMBERS:
+            return "Only the project's organization members can specify custom out variable names.";
+        case OutVariablesMode.EVERYONE:
+            return 'Everyone can can specify custom out variable names. This is the least secure option.';
+        default:
+            return `Unknown raw payload mode: ${m}`;
+    }
+};
+
+export default ({ orgName, projectId, initialValue = OutVariablesMode.DISABLED }: Props) => {
+    const [value, setValue] = useState(initialValue);
+    const [updating, setUpdating] = useState(false);
+    const [error, setError] = useState<RequestError>();
+
+    const didMountRef = useRef(false);
+    // TODO react-hooks/exhaustive-deps warning
+    useEffect(() => {
+        const update = async () => {
+            if (!didMountRef.current) {
+                didMountRef.current = true;
+                return;
+            }
+
+            try {
+                setUpdating(true);
+                await apiCreateOrUpdate(orgName, {
+                    id: projectId,
+                    outVariablesMode: value
+                });
+            } catch (e) {
+                setError(e);
+            } finally {
+                setUpdating(false);
+            }
+        };
+
+        update();
+    }, [orgName, projectId, value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <>
+            {error && <RequestErrorActivity error={error} />}
+            <Form loading={updating}>
+                <Form.Group>
+                    <Form.Dropdown
+                        selection={true}
+                        value={value}
+                        onChange={(ev, data) => setValue(data.value as OutVariablesMode)}
+                        options={[
+                            { value: OutVariablesMode.DISABLED, text: 'Disabled', icon: 'lock' },
+                            { value: OutVariablesMode.OWNERS, text: 'Only owners' },
+                            { value: OutVariablesMode.TEAM_MEMBERS, text: 'Only team members' },
+                            {
+                                value: OutVariablesMode.ORG_MEMBERS,
+                                text: 'Only organization members'
+                            },
+                            { value: OutVariablesMode.EVERYONE, text: 'Everyone', icon: 'lock open' }
+                        ]}
+                    />
+
+                    <p>{getDescription(value)}</p>
+                </Form.Group>
+            </Form>
+        </>
+    );
+};

--- a/console2/src/components/organisms/index.ts
+++ b/console2/src/components/organisms/index.ts
@@ -64,6 +64,7 @@ export { default as ProjectActivity } from './ProjectActivity';
 export { default as ProjectDeleteActivity } from './ProjectDeleteActivity';
 export { default as ProjectDropdown } from './ProjectDropdown';
 export { default as ProjectListActivity } from './ProjectListActivity';
+export { default as ProjectOutVariablesModeActivity } from './ProjectOutVariablesModeActivity';
 export { default as ProjectOrganizationChangeActivity } from './ProjectOrganizationChangeActivity';
 export { default as ProjectOwnerChangeActivity } from './ProjectOwnerChangeActivity';
 export { default as ProjectRawPayloadModeActivity } from './ProjectRawPayloadModeActivity';

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
@@ -1,0 +1,62 @@
+package com.walmartlabs.concord.it.server;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2018 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.ApiException;
+import com.walmartlabs.concord.client.ProjectEntry;
+import com.walmartlabs.concord.client.ProjectsApi;
+import com.walmartlabs.concord.client.StartProcessResponse;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.walmartlabs.concord.it.common.ITUtils.archive;
+import static org.junit.Assert.fail;
+
+public class OutVariablesProjectIT extends AbstractServerIT {
+
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void testReject() throws Exception {
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+
+        String orgName = "Default";
+        String projectName = "project_" + System.currentTimeMillis();
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setName(projectName));
+
+        // ---
+
+        byte[] payload = archive(ProcessIT.class.getResource("example").toURI());
+
+        try {
+            Map<String, Object> input = new HashMap<>();
+            input.put("org", orgName);
+            input.put("project", projectName);
+            input.put("archive", payload);
+            input.put("out", "x,y,z");
+            start(input);
+            fail("should fail");
+        } catch (ApiException e) {
+        }
+    }
+}

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -89,5 +89,6 @@
     <include file="v1.57.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.58.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.60.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.66.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.66.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.66.0.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="1650000" author="ybrigo@gmail.com">
+        <sql>
+            create type out_variables_mode as enum ('DISABLED', 'OWNERS', 'TEAM_MEMBERS', 'ORG_MEMBERS', 'EVERYONE')
+        </sql>
+
+        <addColumn tableName="PROJECTS">
+            <column name="OUT_VARIABLES_MODE" type="out_variables_mode" defaultValue="DISABLED">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectEntry.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectEntry.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.walmartlabs.concord.common.validation.ConcordKey;
+import com.walmartlabs.concord.server.jooq.enums.OutVariablesMode;
 import com.walmartlabs.concord.server.jooq.enums.RawPayloadMode;
 import com.walmartlabs.concord.server.org.EntityOwner;
 
@@ -41,7 +42,7 @@ public class ProjectEntry implements Serializable {
 
     public static ProjectEntry replace(ProjectEntry e, Map<String, RepositoryEntry> repos) {
         return new ProjectEntry(e.id, e.name, e.description, e.orgId, e.orgName, repos,
-                e.cfg, e.visibility, e.owner, e.acceptsRawPayload, e.rawPayloadMode, e.meta);
+                e.cfg, e.visibility, e.owner, e.acceptsRawPayload, e.rawPayloadMode, e.meta, e.outVariablesMode);
     }
 
     private final UUID id;
@@ -75,22 +76,24 @@ public class ProjectEntry implements Serializable {
 
     private final RawPayloadMode rawPayloadMode;
 
+    private final OutVariablesMode outVariablesMode;
+
     private final Map<String, Object> meta;
 
     public ProjectEntry(String name) {
-        this(null, name, null, null, null, null, null, null, null, false, RawPayloadMode.DISABLED, null);
+        this(null, name, null, null, null, null, null, null, null, false, RawPayloadMode.DISABLED, null, OutVariablesMode.DISABLED);
     }
 
     public ProjectEntry(String name, ProjectVisibility visibility) {
-        this(null, name, null, null, null, null, null, visibility, null, false, RawPayloadMode.DISABLED, null);
+        this(null, name, null, null, null, null, null, visibility, null, false, RawPayloadMode.DISABLED, null, OutVariablesMode.DISABLED);
     }
 
     public ProjectEntry(String name, Map<String, RepositoryEntry> repositories) {
-        this(null, name, null, null, null, repositories, null, null, null, false, RawPayloadMode.DISABLED, null);
+        this(null, name, null, null, null, repositories, null, null, null, false, RawPayloadMode.DISABLED, null, OutVariablesMode.DISABLED);
     }
 
     public ProjectEntry(String name, UUID id) {
-        this(id, name, null, null, null, null, null, null, null, false, RawPayloadMode.DISABLED, null);
+        this(id, name, null, null, null, null, null, null, null, false, RawPayloadMode.DISABLED, null, OutVariablesMode.DISABLED);
     }
 
     @JsonCreator
@@ -105,7 +108,8 @@ public class ProjectEntry implements Serializable {
                         @JsonProperty("owner") EntityOwner owner,
                         @JsonProperty("acceptsRawPayload") Boolean acceptsRawPayload,
                         @JsonProperty("rawPayloadMode") RawPayloadMode rawPayloadMode,
-                        @JsonProperty("meta") Map<String, Object> meta) {
+                        @JsonProperty("meta") Map<String, Object> meta,
+                        @JsonProperty("outVariablesMode") OutVariablesMode outVariablesMode) {
 
         this.id = id;
         this.name = name;
@@ -119,6 +123,7 @@ public class ProjectEntry implements Serializable {
         this.acceptsRawPayload = acceptsRawPayload;
         this.rawPayloadMode = rawPayloadMode;
         this.meta = meta;
+        this.outVariablesMode = outVariablesMode;
     }
 
     public UUID getId() {
@@ -170,6 +175,10 @@ public class ProjectEntry implements Serializable {
         return rawPayloadMode;
     }
 
+    public OutVariablesMode getOutVariablesMode() {
+        return outVariablesMode;
+    }
+
     public Map<String, Object> getMeta() {
         return meta;
     }
@@ -189,6 +198,7 @@ public class ProjectEntry implements Serializable {
                 ", acceptsRawPayload=" + acceptsRawPayload +
                 ", rawPayloadMode=" + rawPayloadMode +
                 ", meta=" + meta +
+                ", outVariablesMode=" + outVariablesMode +
                 '}';
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectManager.java
@@ -112,7 +112,7 @@ public class ProjectManager {
             }
 
             UUID pId = projectDao.insert(tx, orgId, entry.getName(), entry.getDescription(), owner.getId(), entry.getCfg(),
-                    entry.getVisibility(), rawPayloadMode, encryptedKey, entry.getMeta());
+                    entry.getVisibility(), rawPayloadMode, encryptedKey, entry.getMeta(), entry.getOutVariablesMode());
 
             if (repos != null) {
                 repos.forEach((k, v) -> projectRepositoryManager.insert(tx, orgId, orgName, pId, entry.getName(), v, false));
@@ -178,7 +178,7 @@ public class ProjectManager {
              }
 
             projectDao.update(tx, orgIdUpdate, projectId, entry.getVisibility(), entry.getName(),
-                    entry.getDescription(), entry.getCfg(), rawPayloadMode, updatedOwnerId, entry.getMeta());
+                    entry.getDescription(), entry.getCfg(), rawPayloadMode, updatedOwnerId, entry.getMeta(), entry.getOutVariablesMode());
 
             if (repos != null) {
                 repositoryDao.deleteAll(tx, projectId);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/NewProcessPipeline.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/NewProcessPipeline.java
@@ -41,6 +41,7 @@ public class NewProcessPipeline extends Pipeline {
                 LoggingMDCProcessor.class,
                 AuthorizationProcessor.class,
                 AssertWorkspaceArchiveProcessor.class,
+                AssertOutVariablesProcessor.class,
                 RequestParametersProcessor.class,
                 PayloadStoreProcessor.class,
                 SecuritySubjectProcessor.class,

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AssertOutVariablesProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AssertOutVariablesProcessor.java
@@ -1,0 +1,105 @@
+package com.walmartlabs.concord.server.process.pipelines.processors;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2018 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.jooq.enums.OutVariablesMode;
+import com.walmartlabs.concord.server.org.ResourceAccessLevel;
+import com.walmartlabs.concord.server.org.project.ProjectAccessManager;
+import com.walmartlabs.concord.server.org.project.ProjectDao;
+import com.walmartlabs.concord.server.org.project.ProjectEntry;
+import com.walmartlabs.concord.server.process.Payload;
+import com.walmartlabs.concord.server.process.ProcessException;
+import com.walmartlabs.concord.server.user.UserManager;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.Response.Status;
+import java.util.UUID;
+
+@Named
+public class AssertOutVariablesProcessor implements PayloadProcessor {
+
+    private final ProjectDao projectDao;
+    private final ProjectAccessManager projectAccessManager;
+    private final UserManager userManager;
+
+    @Inject
+    public AssertOutVariablesProcessor(ProjectDao projectDao,
+                                       ProjectAccessManager projectAccessManager,
+                                       UserManager userManager) {
+
+        this.projectDao = projectDao;
+        this.projectAccessManager = projectAccessManager;
+        this.userManager = userManager;
+    }
+
+    @Override
+    public Payload process(Chain chain, Payload payload) {
+        if (payload.getHeader(Payload.OUT_EXPRESSIONS) == null) {
+            return chain.process(payload);
+        }
+
+        assertOutVariables(payload);
+
+        return chain.process(payload);
+    }
+
+    private void assertOutVariables(Payload payload) {
+        if (!isOutVariablesAllowed(payload)) {
+            throw new ProcessException(payload.getProcessKey(),
+                    "The project is not accepting custom out variables: " + payload.getHeader(Payload.PROJECT_ID),
+                    Status.BAD_REQUEST);
+        }
+    }
+
+    private boolean isOutVariablesAllowed(Payload payload) {
+        UUID projectId = payload.getHeader(Payload.PROJECT_ID);
+        if (projectId == null) {
+            return true;
+        }
+
+        ProjectEntry p = projectDao.get(projectId);
+        if (p == null) {
+            throw new ProcessException(payload.getProcessKey(), "Project not found: " + projectId);
+        }
+
+        OutVariablesMode m = p.getOutVariablesMode();
+        switch (m) {
+            case DISABLED: {
+                return false;
+            }
+            case OWNERS: {
+                return projectAccessManager.hasAccess(p, ResourceAccessLevel.OWNER, false);
+            }
+            case TEAM_MEMBERS: {
+                return projectAccessManager.isTeamMember(p.getId());
+            }
+            case ORG_MEMBERS: {
+                return userManager.isInOrganization(p.getOrgId());
+            }
+            case EVERYONE: {
+                return true;
+            }
+            default:
+                throw new IllegalArgumentException("Unsupported out variables mode: " + m);
+        }
+    }
+}

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessorTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessorTest.java
@@ -82,7 +82,7 @@ public class ConfigurationProcessorTest {
         prjCfg.put("a", "a-prj");
         prjCfg.put("project", "prj-value");
 
-        ProjectEntry projectEntry = new ProjectEntry(prjId, null, null, null, null, null, prjCfg, null, null, null, null, null);
+        ProjectEntry projectEntry = new ProjectEntry(prjId, null, null, null, null, null, prjCfg, null, null, null, null, null, null);
 
         Map<String, Object> processCfgPolicy = new HashMap<>();
         processCfgPolicy.put("a", "a-process-cfg-policy");
@@ -144,7 +144,7 @@ public class ConfigurationProcessorTest {
         prjCfg.put("a", "a-prj");
         prjCfg.put("project", "prj-value");
 
-        ProjectEntry projectEntry = new ProjectEntry(prjId, null, null, null, null, null, prjCfg, null, null, null, null, null);
+        ProjectEntry projectEntry = new ProjectEntry(prjId, null, null, null, null, null, prjCfg, null, null, null, null, null, null);
 
         // ---
         when(orgDao.getConfiguration(eq(orgId))).thenReturn(orgCfg);

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/security/secret/SecretDaoTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/security/secret/SecretDaoTest.java
@@ -50,7 +50,7 @@ public class SecretDaoTest extends AbstractDaoTest {
         String projectName = "project#" + System.currentTimeMillis();
 
         ProjectDao projectDao = new ProjectDao(getConfiguration(), new ConcordObjectMapper(TestObjectMapper.INSTANCE));
-        UUID projectId = projectDao.insert(orgId, projectName, "test", null, null, null, null, new byte[0], null);
+        UUID projectId = projectDao.insert(orgId, projectName, "test", null, null, null, null, new byte[0], null, null);
 
         String secretName = "secret#" + System.currentTimeMillis();
         SecretDao secretDao = new SecretDao(getConfiguration());

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/template/ProjectDaoTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/template/ProjectDaoTest.java
@@ -48,18 +48,18 @@ public class ProjectDaoTest extends AbstractDaoTest {
     private RepositoryDao repositoryDao;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         repositoryDao = new RepositoryDao(getConfiguration(), new ConcordObjectMapper(TestObjectMapper.INSTANCE));
         projectDao = new ProjectDao(getConfiguration(), new ConcordObjectMapper(TestObjectMapper.INSTANCE));
     }
 
     @Test
-    public void testInsertDelete() throws Exception {
+    public void testInsertDelete() {
         UUID orgId = OrganizationManager.DEFAULT_ORG_ID;
 
         Map<String, Object> cfg = ImmutableMap.of("a", "a-v");
         String projectName = "project#" + System.currentTimeMillis();
-        UUID projectId = projectDao.insert(orgId, projectName, "test", null, cfg, null, null, new byte[0], null);
+        UUID projectId = projectDao.insert(orgId, projectName, "test", null, cfg, null, null, new byte[0], null, null);
 
         // ---
         Map<String, Object> actualCfg = projectDao.getConfiguration(projectId);
@@ -80,7 +80,7 @@ public class ProjectDaoTest extends AbstractDaoTest {
 
         // ---
         Map<String, Object> newCfg2 = ImmutableMap.of("a2", "a2-v");
-        tx(tx -> projectDao.update(tx, orgId, projectId, ProjectVisibility.PRIVATE, projectName, "new-description", newCfg2, null, null,null));
+        tx(tx -> projectDao.update(tx, orgId, projectId, ProjectVisibility.PRIVATE, projectName, "new-description", newCfg2, null, null,null, null));
 
         actualCfg = projectDao.getConfiguration(projectId);
         assertEquals(newCfg2, actualCfg);
@@ -99,7 +99,7 @@ public class ProjectDaoTest extends AbstractDaoTest {
     }
 
     @Test
-    public void testList() throws Exception {
+    public void testList() {
         UUID orgId = OrganizationManager.DEFAULT_ORG_ID;
 
         assertEquals(0, projectDao.list(null, null, PROJECTS.PROJECT_NAME, true, 0, -1, null).size());
@@ -110,9 +110,9 @@ public class ProjectDaoTest extends AbstractDaoTest {
         String bName = "bProject#" + System.currentTimeMillis();
         String cName = "cProject#" + System.currentTimeMillis();
 
-        projectDao.insert(orgId, aName, "test", null, null, null, null, new byte[0], null);
-        projectDao.insert(orgId, bName, "test", null, null, null, null, new byte[0], null);
-        projectDao.insert(orgId, cName, "test", null, null, null, null, new byte[0], null);
+        projectDao.insert(orgId, aName, "test", null, null, null, null, new byte[0], null, null);
+        projectDao.insert(orgId, bName, "test", null, null, null, null, new byte[0], null, null);
+        projectDao.insert(orgId, cName, "test", null, null, null, null, new byte[0], null, null);
 
         // ---
 


### PR DESCRIPTION
<img width="1168" alt="Screenshot 2020-09-09 at 17 00 20" src="https://user-images.githubusercontent.com/980726/92608384-f74d4b00-f2bd-11ea-8dc0-c38c7d196e6e.png">

out variables restrictions:

- DISABLED (default): 'Sending custom out variable names is disabled. Only out variables defined in concord.yml can be used.';
- OWNERS: "Only the project's owner and team members with OWNER privileges can specify custom out variable names.";
- TEAM_MEMBERS: "Only the members of the teams assigned to the project's can specify custom out variable names.";
- ORG_MEMBERS: "Only the project's organization members can specify custom out variable names.";
- EVERYONE: 'Everyone can can specify custom out variable names. This is the least secure option.';