### PR TITLE
server: audit log changes in entity access

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectAccessManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectAccessManager.java
@@ -20,7 +20,6 @@ package com.walmartlabs.concord.server.org.project;
  * =====
  */
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.walmartlabs.concord.server.audit.AuditAction;
 import com.walmartlabs.concord.server.audit.AuditLog;
@@ -36,7 +35,10 @@ import org.sonatype.siesta.ValidationErrorsException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Named

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectAccessManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectAccessManager.java
@@ -20,6 +20,11 @@ package com.walmartlabs.concord.server.org.project;
  * =====
  */
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.walmartlabs.concord.server.audit.AuditAction;
+import com.walmartlabs.concord.server.audit.AuditLog;
+import com.walmartlabs.concord.server.audit.AuditObject;
 import com.walmartlabs.concord.server.org.*;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import com.walmartlabs.concord.server.security.Roles;
@@ -30,9 +35,9 @@ import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Named
 public class ProjectAccessManager {
@@ -40,17 +45,21 @@ public class ProjectAccessManager {
     private final OrganizationManager orgManager;
     private final ProjectDao projectDao;
     private final UserDao userDao;
+    private final AuditLog auditLog;
 
     @Inject
-    public ProjectAccessManager(OrganizationManager orgManager, ProjectDao projectDao, UserDao userDao) {
+    public ProjectAccessManager(OrganizationManager orgManager, ProjectDao projectDao, UserDao userDao, AuditLog auditLog) {
         this.orgManager = orgManager;
         this.projectDao = projectDao;
         this.userDao = userDao;
+        this.auditLog = auditLog;
     }
 
     public void updateAccessLevel(UUID projectId, UUID teamId, ResourceAccessLevel level) {
         assertAccess(projectId, ResourceAccessLevel.OWNER, true);
         projectDao.upsertAccessLevel(projectId, teamId, level);
+
+        addAuditLog(projectId, Collections.singletonList(new ResourceAccessEntry(teamId, null, null, level)), false);
     }
 
     public ProjectEntry assertAccess(UUID orgId, UUID projectId, String projectName, ResourceAccessLevel level, boolean orgMembersOnly) {
@@ -146,6 +155,8 @@ public class ProjectAccessManager {
                 projectDao.upsertAccessLevel(tx, projectId, e.getTeamId(), e.getLevel());
             }
         });
+
+        addAuditLog(projectId, entries, isReplace);
     }
 
     /**
@@ -155,5 +166,18 @@ public class ProjectAccessManager {
     public boolean isTeamMember(UUID projectId) {
         UserPrincipal principal = UserPrincipal.assertCurrent();
         return projectDao.hasAccessLevel(projectId, principal.getId(), ResourceAccessLevel.atLeast(ResourceAccessLevel.READER));
+    }
+
+    private void addAuditLog(UUID projectId, Collection<ResourceAccessEntry> entries, boolean isReplace) {
+        List<ImmutableMap<String, ? extends Serializable>> teams = entries.stream()
+                .map(e -> ImmutableMap.of("id", e.getTeamId(), "level", e.getLevel()))
+                .collect(Collectors.toList());
+
+        auditLog.add(AuditObject.PROJECT, AuditAction.UPDATE)
+                .field("projectId", projectId)
+                .field("access", ImmutableMap.of(
+                        "replace", isReplace,
+                        "teams", teams))
+                .log();
     }
 }


### PR DESCRIPTION
record example:
```
{
   "access":{
      "teams":[
         {
            "id":"00000000-0000-0000-0000-000000000000",
            "level":"OWNER"
         }
      ],
      "replace":true
   },
   "storeId":"d6fb4e42-f759-11ea-aec8-0242ac110002",
   "requestId":"ad4a79cc-9db2-4132-a39f-9cc7c9890b22",
   "actionSource":{
      "type":"UI"
   }
}
```