### PR TITLE
concord-server: convert dateTime fields to UTC

### DIFF
--- a/it/console/src/test/java/com/walmartlabs/concord/it/console/FormsIT.java
+++ b/it/console/src/test/java/com/walmartlabs/concord/it/console/FormsIT.java
@@ -91,10 +91,6 @@ public class FormsIT {
 
         byte[] ab = serverRule.getLog(pir.getLogFileName());
         assertLog(".*dateField=2019-09-04.*", ab);
-
-        // because the value is converted to java.util.Date it loses all TZ info
-        // so our input "01:05:00.000-04:00" is converted to "05:05:00.000" in the default server's TZ
-        // which is usually UTC
-        assertLog(".*dateTimeField=2019-09-04T05:05:00.000.*", ab);
+        assertLog(".*dateTimeField=2019-09-04T05:05:00.000Z.*", ab);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormUtils.java
@@ -47,7 +47,15 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public final class FormUtils {
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
+    /**
+     * Date/time format used to pass date and dateTime fields between the Server and the process.
+     */
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US);
+
+    /**
+     * All date/time values are converted into the default time zone.
+     */
+    private static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("UTC");
 
     public static Map<String, String> mergeErrors(List<ValidationError> errors) {
         if (errors == null || errors.isEmpty()) {
@@ -188,7 +196,7 @@ public final class FormUtils {
                     // on the process level those values are represented as java.util.Date (i.e. no TZ info retained)
                     // so we assume all Date values are in the default system TZ (which is typically UTC)
                     return ZonedDateTime.parse(s)
-                            .withZoneSameInstant(ZoneId.systemDefault())
+                            .withZoneSameInstant(DEFAULT_TIME_ZONE)
                             .format(DATE_TIME_FORMATTER);
                 }
             }
@@ -225,6 +233,8 @@ public final class FormUtils {
     }
 
     public static class ValidationException extends Exception {
+
+        private static final long serialVersionUID = 1L;
 
         private final FormField field;
         private final String input;


### PR DESCRIPTION
Before this change, the Server converted `dateTime` form fields to its default time zone.
Now we explicitly convert those values to UTC.
This fixes the issue with local testing - tests can check for a fixed value instead of trying to use the local time zone.

Shouldn't affect the production as the servers typically use UTC anyway.