### PR TITLE
it: support Server timestamp format

### DIFF
--- a/it/common/pom.xml
+++ b/it/common/pom.xml
@@ -27,6 +27,14 @@
             <artifactId>concord-sdk</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/OffsetDateTimeDeserializer.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/OffsetDateTimeDeserializer.java
@@ -1,0 +1,44 @@
+package com.walmartlabs.concord.it.common;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Supports the Server's timestamp format.
+ */
+public class OffsetDateTimeDeserializer extends InstantDeserializer<OffsetDateTime> {
+
+    private static final long serialVersionUID = 1L;
+
+    public OffsetDateTimeDeserializer() {
+        super(OffsetDateTime.class, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX"),
+                OffsetDateTime::from,
+                a -> OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId),
+                a -> OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId),
+                (d, z) -> d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime())),
+                true);
+    }
+}

--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/ServerCompatModule.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/ServerCompatModule.java
@@ -1,0 +1,37 @@
+package com.walmartlabs.concord.it.common;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Jackson module to support Concord Server API types.
+ */
+public class ServerCompatModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    public ServerCompatModule() {
+        addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
+    }
+}

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ProcessMetadataIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ProcessMetadataIT.java
@@ -22,7 +22,6 @@ package com.walmartlabs.concord.it.server;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -30,6 +29,7 @@ import com.squareup.okhttp.Response;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.client.*;
 import com.walmartlabs.concord.it.common.ServerClient;
+import com.walmartlabs.concord.it.common.ServerCompatModule;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -137,7 +137,7 @@ public class ProcessMetadataIT extends AbstractServerIT {
             }
 
             ObjectMapper om = new ObjectMapper();
-            om.registerModule(new JavaTimeModule());
+            om.registerModule(new ServerCompatModule()); // to parse timestamps
             return om.readValue(resp.body().byteStream(), LIST_OF_PROCESS_ENTRIES);
         } finally {
             if (resp != null && resp.body() != null) {


### PR DESCRIPTION
Add a Jackson module to support the Server API's timestamp format (`yyyy-MM-dd'T'HH:mm:ss.SSSX`).
Normally, the client handles the deserialization, but if someone wants to use the client's model
classes they need to use Concord Server's own timestamp format.