### PR TITLE
resource-tasks: implement prettyPrintYaml method

### DIFF
--- a/plugins/tasks/resource/pom.xml
+++ b/plugins/tasks/resource/pom.xml
@@ -36,6 +36,12 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTask.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTask.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 public class ResourceTask implements Task {
 
     public String asString(String path) throws IOException {
-       return ResourceTaskCommon.asString(path);
+        return ResourceTaskCommon.asString(path);
     }
 
     public Object asJson(String path) throws IOException {
@@ -67,8 +67,16 @@ public class ResourceTask implements Task {
         return delegate(workDir).writeAsYaml(content);
     }
 
-    public String prettyPrintJson(Object json) throws IOException {
-        return ResourceTaskCommon.prettyPrintJson(json);
+    public String prettyPrintJson(Object value) throws IOException {
+        return ResourceTaskCommon.prettyPrintJson(value);
+    }
+
+    public String prettyPrintYaml(Object value) throws IOException {
+        return ResourceTaskCommon.prettyPrintYaml(value);
+    }
+
+    public String prettyPrintYaml(Object value, int indent) throws IOException {
+        return ResourceTaskCommon.prettyPrintYaml(value, indent);
     }
 
     private static ResourceTaskCommon delegate(Context ctx) {

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.plugins.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +30,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 public class ResourceTaskCommon {
 
@@ -109,14 +111,39 @@ public class ResourceTaskCommon {
         return workDir.relativize(tmpFile.toAbsolutePath()).toString();
     }
 
-    public static String prettyPrintJson(Object json) throws IOException {
+    public static String prettyPrintJson(Object value) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        if (json instanceof String) {
-            // To add line feeds
-            json = mapper.readValue((String) json, Object.class);
+        if (value instanceof String) {
+            // to add line feeds
+            value = mapper.readValue((String) value, Object.class);
         }
 
-        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+    }
+
+    public static String prettyPrintYaml(Object value) throws IOException {
+        return prettyPrintYaml(value, 0);
+    }
+
+    public static String prettyPrintYaml(Object value, int indent) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+        if (value instanceof String) {
+            value = mapper.readValue((String) value, Object.class);
+        }
+
+        String prefix = null;
+        if (indent > 0) {
+            char[] ch = new char[indent + 1];
+            ch[0] = '\n';
+            Arrays.fill(ch, 1, ch.length, ' ');
+            prefix = new String(ch);
+        }
+
+        String s = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        if (prefix != null) {
+            s = prefix + s.replace("\n", prefix);
+        }
+        return s;
     }
 
     static void writeToFile(Path file, PathHandler h) throws IOException {

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/v2/ResourceTaskV2.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/v2/ResourceTaskV2.java
@@ -74,4 +74,12 @@ public class ResourceTaskV2 implements Task {
     public String prettyPrintJson(Object json) throws IOException {
         return ResourceTaskCommon.prettyPrintJson(json);
     }
+
+    public String prettyPrintYaml(Object value) throws IOException {
+        return ResourceTaskCommon.prettyPrintYaml(value);
+    }
+
+    public String prettyPrintYaml(Object value, int indent) throws IOException {
+        return ResourceTaskCommon.prettyPrintYaml(value, indent);
+    }
 }

--- a/plugins/tasks/resource/src/test/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommonTest.java
+++ b/plugins/tasks/resource/src/test/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommonTest.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.plugins.resource;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+public class ResourceTaskCommonTest {
+
+    @Test
+    public void testPrettyPrintYaml() throws Exception {
+        Map<String, Object> m = new HashMap<>();
+        m.put("x", 123);
+        m.put("y", Collections.singletonMap("a", false));
+
+        assertValidYaml(ResourceTaskCommon.prettyPrintYaml(m, 0));
+        assertValidYaml(String.format("value: %s", ResourceTaskCommon.prettyPrintYaml(m, 2)));
+        assertValidYaml(String.format("value: %s", ResourceTaskCommon.prettyPrintYaml(Arrays.asList("a", "b", "c"), 2)));
+    }
+
+    private static void assertValidYaml(String s) throws IOException {
+        new ObjectMapper(new YAMLFactory()).readValue(s, Object.class);
+    }
+}


### PR DESCRIPTION
Useful for injecting values into other YAML files (e.g. Helm values.yaml).

Example:

```yaml
flows:
  default:
    - set:
        data:
          x: 1
          y:
            a: 10
            b: 20
          z:
            - "a"
            - "b"

    - set:
        result: |
          data: ${resource.prettyPrintYaml(data, 2)}

    - log: |
        -------------------------------------------
        ${result}
```

```
> concord run

Starting...
16:22:05.564 [main] -------------------------------------------
data:
  x: 1
  y:
    a: 10
    b: 20
  z:
  - "a"
  - "b"



...done!
```