### PR TITLE
agent: better exception handling in worker

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/Worker.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Worker.java
@@ -93,7 +93,7 @@ public class Worker implements Runnable {
             // successful completion
             log.info("run -> done with {}", configuredJobRequest);
             onStatusChange(instanceId, StatusEnum.FINISHED);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // unwrap the exception if needed
             Throwable t = unwrap(e);
 

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
@@ -121,7 +121,7 @@ public class RunnerJobExecutor implements JobExecutor {
             job = job.withDependencies(resolvedDeps);
 
             pe = buildProcessEntry(job);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.warn("exec ['{}'] -> process error: {}", job.getInstanceId(), e.getMessage());
 
             job.getLog().error("Process startup error: {}", e.getMessage());


### PR DESCRIPTION
looks like DependencyManager threw Throwable exception.

agent logs:
```
14:21:48.232 [DefaultMetadataResolver-507-1] [ERROR] c.w.c.d.DependencyManager - transferFailed -> GET FAILED https://repo.maven.apache.org/maven2/org/webjars/npm/lodash._createset/maven-metadata.xml <> /home/concord/.m2/repository/org/webjars/npm/lodash._createset/maven-metadata-central.xml

14:21:49.369 [pool-1-thread-1822] [INFO ] com.walmartlabs.concord.agent.Worker - exec ['d6ace27d-e6d9-4738-948c-3621095b7ebc'] -> removing the payload directory: /tmp/concord/payload/workDir893755744059954205
```

process logs:
```
17:10:00 [INFO ] Resolving process dependencies...
17:24:58 [WARN ] Process failed to start for more than '15 minutes'
```