### PR TITLE
console: tag header navigation using url anchor (v1 only)

### DIFF
--- a/console2/src/components/molecules/LogSegment/index.tsx
+++ b/console2/src/components/molecules/LogSegment/index.tsx
@@ -73,18 +73,18 @@ const LogSegment = ({
 
     const baseUrl = `/process/${instanceId}/log`;
 
-    const myRef = useRef<null | HTMLDivElement>(null);
+    const segmentRef = useRef<null | HTMLDivElement>(null);
 
     useEffect(() => {
-        if (myRef.current && location.hash.includes(`#segmentId=${segmentId}`)) {
-            myRef.current.scrollIntoView({
+        if (segmentRef.current && location.hash.includes(`#segmentId=${segmentId}`)) {
+            segmentRef.current.scrollIntoView({
                 behavior: 'smooth',
                 block: 'end',
                 inline: 'nearest'
             });
             setOpen(true);
         }
-    }, [myRef, segmentId, location]);
+    }, [segmentRef, segmentId, location]);
 
     const loadAllClickHandler = useCallback((ev: React.MouseEvent<any>) => {
         ev.preventDefault();
@@ -132,7 +132,7 @@ const LogSegment = ({
     }
 
     return (
-        <div className="LogSegment" id={`segmentId=${segmentId}`} ref={myRef}>
+        <div className="LogSegment" id={`segmentId=${segmentId}`} ref={segmentRef}>
             <Button
                 fluid={true}
                 size="medium"

--- a/console2/src/components/molecules/ProcessLogViewer/index.tsx
+++ b/console2/src/components/molecules/ProcessLogViewer/index.tsx
@@ -29,7 +29,7 @@ import { ProcessToolbar } from '../../molecules';
 import { TaskCallDetails } from '../../organisms';
 
 import './styles.css';
-import {Link} from "react-router-dom";
+import { Link } from "react-router-dom";
 
 interface State {
     scrollAnchorRef: boolean;
@@ -72,6 +72,7 @@ const renderTagHeader = (
     correlationId?: ConcordId
 ) => (
     <>
+        <div id={`segmentId=${idx}`} ref={segmentRef}>
         <div
             ref={
                 correlationId
@@ -90,8 +91,6 @@ const renderTagHeader = (
             <Link
                 to={`/process/${instanceId}/log#segmentId=${idx}`}
                 className="Anchor"
-                id={`segmentId=${idx}`}
-                ref={segmentRef}
                 data-tooltip="Anchor URL"
                 data-inverted="">
                 <Icon name="linkify" />
@@ -99,6 +98,7 @@ const renderTagHeader = (
             {taskName}
             {onClick && <Icon name={expanded ? 'chevron up' : 'chevron down'} />}
         </Divider>
+        </div>
     </>
 );
 
@@ -184,6 +184,7 @@ class ProcessLogViewer extends React.Component<Props, State> {
         this.scrollToBottom = this.scrollToBottom.bind(this);
         this.handleTagClick = this.handleTagClick.bind(this);
         this.scrollToTag = this.scrollToTag.bind(this);
+        this.segmentScroll = this.segmentScroll.bind(this);
     }
 
     componentDidUpdate(prevProps: Props) {

--- a/console2/src/components/molecules/ProcessLogViewer/index.tsx
+++ b/console2/src/components/molecules/ProcessLogViewer/index.tsx
@@ -56,7 +56,7 @@ interface LogContainerProps {
     instanceId: ConcordId;
     data: LogSegment[];
     onClick: (correlationId: ConcordId) => void;
-    segmentClick: (ref: any, idx: number) => void;
+    segmentClick: (ref: any) => void;
     expandedItems: ConcordId[];
     tagRefs: any[];
 }
@@ -153,7 +153,7 @@ const LogContainer = ({ instanceId, data, tagRefs, onClick, segmentClick, expand
                         tag,
                         tagRefs,
                         () => onClick(tag.correlationId),
-                        () => segmentClick(ref, idx),
+                        () => segmentClick(ref),
                         expanded,
                         idx,
                         ref
@@ -191,7 +191,7 @@ class ProcessLogViewer extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        const { data, selectedCorrelationId,  } = this.props;
+        const { data, selectedCorrelationId } = this.props;
         const { scrollAnchorRef } = this.state;
 
         if (prevProps.data !== data) {
@@ -242,8 +242,8 @@ class ProcessLogViewer extends React.Component<Props, State> {
         this.setState({ expandedItems });
     }
 
-    handleSegmentClick(ref: any, idx: number) {
-        if (ref.current && window.location.hash.includes(`#segmentId=${idx}`)) {
+    handleSegmentClick(ref: any) {
+        if (ref.current && window.location.hash.substring(1).length) {
             ref.current.scrollIntoView({
                 behavior: 'smooth',
                 block: 'start',

--- a/console2/src/components/molecules/ProcessLogViewer/styles.css
+++ b/console2/src/components/molecules/ProcessLogViewer/styles.css
@@ -41,3 +41,13 @@
 .logTagDetails {
     margin-bottom: 20px;
 }
+
+.Anchor {
+    padding-left: 0;
+    padding-right: 5px;
+    color: #e5e2e2;
+}
+
+.Anchor:hover {
+    color: #4183c4;
+}


### PR DESCRIPTION
use URL fragments to navigate to checkpoints [STRDTORC-2250](https://jira.walmart.com/browse/STRDTORC-2250) 
similar implementation in v2 -> https://github.com/walmartlabs/concord/pull/118