### PR TITLE
concord-server: tx aware createBinaryData

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretDao.java
@@ -71,6 +71,11 @@ public class SecretDao extends AbstractDao {
         super.tx(t);
     }
 
+    @Override
+    protected <T> T txResult(TxResult<T> t) {
+        return super.txResult(t);
+    }
+
     public UUID getId(UUID orgId, String name) {
         try (DSLContext tx = DSL.using(cfg)) {
             return tx.select(SECRETS.SECRET_ID)
@@ -120,6 +125,7 @@ public class SecretDao extends AbstractDao {
                         SECRETS.STORE_TYPE,
                         SECRETS.VISIBILITY)
                 .values(name, type.toString(), orgId, projectId, ownerId, encryptedBy.toString(), storeType, visibility.toString());
+
         if (insertMode == InsertMode.UPSERT) {
             Optional<SecretsRecord> secretsRecord = builder.onDuplicateKeyIgnore()
                     .returning(SECRETS.SECRET_ID)
@@ -130,6 +136,7 @@ public class SecretDao extends AbstractDao {
                     .fetchOne()
                     .value1());
         }
+
         return builder
                 .returning(SECRETS.SECRET_ID)
                 .fetchOne()
@@ -174,7 +181,7 @@ public class SecretDao extends AbstractDao {
         tx(tx -> updateData(tx, id, data));
     }
 
-    private void updateData(DSLContext tx, UUID id, byte[] data) {
+    public void updateData(DSLContext tx, UUID id, byte[] data) {
         int i = tx.update(SECRETS)
                 .set(SECRETS.SECRET_DATA, data)
                 .where(SECRETS.SECRET_ID.eq(id))
@@ -297,9 +304,13 @@ public class SecretDao extends AbstractDao {
     }
 
     public void delete(UUID id) {
-        tx(tx -> tx.deleteFrom(SECRETS)
+        tx(tx -> delete(tx, id));
+    }
+
+    public void delete(DSLContext tx, UUID id) {
+        tx.deleteFrom(SECRETS)
                 .where(SECRETS.SECRET_ID.eq(id))
-                .execute());
+                .execute();
     }
 
     public List<ResourceAccessEntry> getAccessLevel(UUID orgId, String name) {
@@ -422,6 +433,8 @@ public class SecretDao extends AbstractDao {
     }
 
     public static class SecretDataEntry extends SecretEntry {
+
+        private static final long serialVersionUID = 1L;
 
         private final byte[] data;
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/SecretStore.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/SecretStore.java
@@ -20,15 +20,17 @@ package com.walmartlabs.concord.server.org.secret.store;
  * =====
  */
 
+import org.jooq.DSLContext;
+
 import java.util.UUID;
 
 public interface SecretStore {
 
     boolean isEnabled();
 
-    void store(UUID id, byte[] data);
+    void store(DSLContext tx, UUID id, byte[] data);
 
-    void delete(UUID id);
+    void delete(DSLContext tx, UUID id);
 
     byte[] get(UUID id);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/concord/ConcordSecretStore.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/concord/ConcordSecretStore.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.server.org.secret.store.concord;
 import com.walmartlabs.concord.server.cfg.ConcordSecretStoreConfiguration;
 import com.walmartlabs.concord.server.org.secret.SecretDao;
 import com.walmartlabs.concord.server.org.secret.store.SecretStore;
+import org.jooq.DSLContext;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -61,12 +62,12 @@ public class ConcordSecretStore implements SecretStore {
     }
 
     @Override
-    public void store(UUID id, byte[] data) {
-        secretDao.updateData(id, data);
+    public void store(DSLContext tx, UUID id, byte[] data) {
+        secretDao.updateData(tx, id, data);
     }
 
     @Override
-    public void delete(UUID id) {
+    public void delete(DSLContext tx, UUID id) {
         // do nothing, the data will be deleted when the secret's entry is removed from the DB table
     }
 


### PR DESCRIPTION
Allow explicit transactions in `SecretManager#createBinaryData`
SecretStores can now participate in transactions as well.