### PR TITLE
server: use form values for readonly fields

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormServiceV1.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormServiceV1.java
@@ -223,28 +223,8 @@ public class FormServiceV1 {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> merge(Form form, Map<String, Object> data) {
-        String formName = form.getFormDefinition().getName();
-
-        Map<String, Object> env = form.getEnv();
-        if (env == null) {
-            env = Collections.emptyMap();
-        }
-
-        Map<String, Object> formState = (Map<String, Object>) env.get(formName);
-        if (formState == null) {
-            formState = Collections.emptyMap();
-        }
-
-        Map<String, Object> options = form.getOptions();
-        Map<String, Object> extraValues = options != null ? (Map<String, Object>) options.get("values") : null;
-
-        // merge the initial form values and the "extra" values, provided
-        // in the "values" option of the form
-        Map<String, Object> a = new HashMap<>(formState);
-        Map<String, Object> b = new HashMap<>(extraValues != null ? extraValues : Collections.emptyMap());
-        ConfigurationUtils.merge(a, b);
+        Map<String, Object> a = FormUtils.values(form);
 
         // overwrite the collected values with the submitted data
         Map<String, Object> c = new HashMap<>(data != null ? data : Collections.emptyMap());


### PR DESCRIPTION
```
configuration: 
  arguments: 
    formsList: 
      - Form1
      - Form2
      - Form3

flows: 
  default:
    - log: "Forms ${formsList}"
    - call: initiateForm
      withItems: ${formsList}
      
    
  initiateForm:
    - log: "Initiated: ${item}"
    
    - form: dummyForm
      values:
        name: ${item}
      saveSubmittedBy: true
    - log: "Form's data: ${dummyForm}"    # Here output is same for each form instead of updating accordingly
    
    
forms:
  dummyForm:
    - name: { label: 'Form name', type: string, readonly: true }
```

logs:
```
05:45:01 [INFO ] Forms [Form1, Form2, Form3]
05:45:01 [INFO ] Initiated: Form1
...
05:47:57 [INFO ] Form's data: {name=Form1...  # correct value
...
05:47:58 [INFO ] Initiated: Form2
...
05:48:04 [INFO ] Form's data: {name=Form1...  # incorrect, it should have shown Form2
...
05:48:04 [INFO ] Initiated: Form3
...
05:48:15 [INFO ] Form's data: {name=Form1...  # incorrect, it should have shown Form3
```

