### PR TITLE
server: task scheduler up

### DIFF
--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -90,5 +90,6 @@
     <include file="v1.58.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.60.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.66.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.69.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.69.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.69.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="1690000" author="ybrigo@gmail.com">
+        <addColumn tableName="TASKS">
+            <column name="LAST_ERROR_AT" type="timestamptz">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="TASKS">
+            <column name="LAST_ERROR" type="text">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <sql>
+            create type task_status_type as enum ('OK', 'ERROR', 'RUNNING', 'STALLED')
+        </sql>
+
+        <sql>
+            ALTER TABLE TASKS
+            ALTER COLUMN TASK_STATUS TYPE task_status_type
+            USING TASK_STATUS::task_status_type
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/task/TaskScheduler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/task/TaskScheduler.java
@@ -189,7 +189,7 @@ public class TaskScheduler extends PeriodicTask {
                 List<String> ids = tx.select(TASKS.TASK_ID)
                         .from(TASKS)
                         .where(TASKS.TASK_INTERVAL.greaterThan(0L)
-                                .and(TASKS.TASK_STATUS.notEqual(TaskStatusType.RUNNING))
+                                .and(TASKS.TASK_STATUS.notEqual(TaskStatusType.RUNNING).or(TASKS.TASK_STATUS.isNull()))
                                 .and(TASKS.FINISHED_AT.isNull()
                                         .or(TASKS.FINISHED_AT.plus(TASKS.TASK_INTERVAL.mul(i)).lessOrEqual(currentOffsetDateTime()))))
                         .forUpdate()


### PR DESCRIPTION
- simplify task poll conditions;
- save task error stack trace into DB;
- better task heartbeat/stalled updates.