### PR TITLE
runtime-v2: disable SLF4JPrintStreams info messages

### DIFF
--- a/runtime/v2/runner/src/main/resources/logback.xml
+++ b/runtime/v2/runner/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
     </logger>
 
     <logger name="com.walmartlabs.concord.plugins.log" level="${logLevel:-INFO}"/>
+    <logger name="uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
no more messages:
```
Replaced standard System.out and System.err PrintStreams with SLF4JPrintStreams
Redirected System.out and System.err to SLF4J for this context
```