### PR TITLE
runtime-v2: fix potential NPE in TaskCallCommand

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -193,7 +193,12 @@ public class Run implements Callable<Integer> {
         try {
             runner.start(cfg, processDefinition, args);
         } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
+            if (verbose) {
+                System.err.print("Error: ");
+                e.printStackTrace(System.err);
+            } else {
+                System.err.println("Error: " + e.getMessage());
+            }
             return 1;
         }
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallCommand.java
@@ -86,9 +86,11 @@ public class TaskCallCommand extends StepCommand<TaskCall> {
             throw new RuntimeException(e);
         }
 
-        String out = opts.out();
-        if (out != null) {
-            ctx.variables().set(out, result.toMap());
+        if (result != null) {
+            String out = opts.out();
+            if (out != null) {
+                ctx.variables().set(out, result.toMap());
+            }
         }
     }
 


### PR DESCRIPTION
Fix NPE when a task returns `null` instead of a `TaskResult`.
Also, print out the error's stacktrace in `verbose` mode in the CLI.