### PR TITLE
concord-server: update jOOQ to 3.14.0

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -248,8 +248,9 @@ public class ProcessIT {
         assertEquals(3, checkpoints.size());
 
         checkpoints.sort(Comparator.comparing(ProcessCheckpointEntry::getName));
-        assertEquals("aaa", checkpoints.get(2).getName());
-
+        assertEquals("aaa", checkpoints.get(0).getName());
+        assertEquals("bbb", checkpoints.get(1).getName());
+        assertEquals("ccc", checkpoints.get(2).getName());
 
         // ---
 

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -240,15 +240,16 @@ public class ProcessIT {
 
         ConcordProcess proc = concord.processes().start(payload);
         proc.expectStatus(ProcessEntry.StatusEnum.FINISHED);
+        proc.assertLogAtLeast(".*#4.*z=345.*", 1);
 
         // ---
 
         List<ProcessCheckpointEntry> checkpoints = proc.checkpoints();
         assertEquals(3, checkpoints.size());
 
-        checkpoints.sort(Comparator.comparing(ProcessCheckpointEntry::getCreatedAt));
+        checkpoints.sort(Comparator.comparing(ProcessCheckpointEntry::getName));
+        assertEquals("aaa", checkpoints.get(2).getName());
 
-        assertEquals("third", checkpoints.get(2).getName());
 
         // ---
 

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointsParallel/concord.yml
@@ -13,13 +13,13 @@ flows:
             - set:
                 aVar.y: 234
             - log: "#2 ${aVar}"
-            - checkpoint: "first"
+            - checkpoint: "aaa"
         - block:
             - set:
                 aVar.z: 345
             - log: "#3 ${aVar}"
-            - checkpoint: "second"
+            - checkpoint: "bbb"
 
-    - checkpoint: "third"
+    - checkpoint: "ccc"
 
     - log: "#4 ${aVar}"

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/AbstractHttpTaskTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/AbstractHttpTaskTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractHttpTaskTest {
     @Rule
     public WireMockRule rule = new WireMockRule(wireMockConfig()
             .dynamicPort()
-            .notifier(new ConsoleNotifier(true)));
+            .notifier(new ConsoleNotifier(Boolean.parseBoolean(System.getProperty("concord.test.verbose")))));
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File(System.getProperty("user.dir") + "/src/test/resources/__files"));

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/AbstractHttpTaskTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/AbstractHttpTaskTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractHttpTaskTest {
     @Rule
     public WireMockRule rule = new WireMockRule(wireMockConfig()
             .dynamicPort()
-            .notifier(new ConsoleNotifier(Boolean.parseBoolean(System.getProperty("concord.test.verbose")))));
+            .notifier(new ConsoleNotifier(true)));
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File(System.getProperty("user.dir") + "/src/test/resources/__files"));

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
@@ -37,7 +36,7 @@ import static org.mockito.Mockito.when;
 
 public class HttpTaskTest extends AbstractHttpTaskTest {
 
-    private final Context mockContext = mock(Context.class);
+    private Context mockContext = mock(Context.class);
 
     @Test
     public void testForAsStringMethod() throws Exception {
@@ -128,17 +127,15 @@ public class HttpTaskTest extends AbstractHttpTaskTest {
 
     @Test(expected = Exception.class)
     public void testExecuteForException() throws Exception {
-        int randomPort = ThreadLocalRandom.current().nextInt(65536);
         initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + randomPort + "/fault", false, 0, true);
+                "http://localhost:" + rule.port() + "/fault", false, 0, true);
         task.execute(mockContext);
     }
 
     @Test
     public void testExecuteWithIgnoreError() throws Exception {
-        int randomPort = ThreadLocalRandom.current().nextInt(65536);
         initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + randomPort + "/fault", true, 0, true);
+                "http://localhost:" + rule.port() + "/fault", true, 0, true);
         task.execute(mockContext);
     }
 

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 public class HttpTaskTest extends AbstractHttpTaskTest {
 
-    private Context mockContext = mock(Context.class);
+    private final Context mockContext = mock(Context.class);
 
     @Test
     public void testForAsStringMethod() throws Exception {
@@ -127,15 +128,17 @@ public class HttpTaskTest extends AbstractHttpTaskTest {
 
     @Test(expected = Exception.class)
     public void testExecuteForException() throws Exception {
+        int randomPort = ThreadLocalRandom.current().nextInt(65536);
         initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + rule.port() + "/fault", false, 0, true);
+                "http://localhost:" + randomPort + "/fault", false, 0, true);
         task.execute(mockContext);
     }
 
     @Test
     public void testExecuteWithIgnoreError() throws Exception {
+        int randomPort = ThreadLocalRandom.current().nextInt(65536);
         initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + rule.port() + "/fault", true, 0, true);
+                "http://localhost:" + randomPort + "/fault", true, 0, true);
         task.execute(mockContext);
     }
 

--- a/server/db/src/main/java/com/walmartlabs/concord/db/AbstractDao.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/AbstractDao.java
@@ -45,21 +45,21 @@ public abstract class AbstractDao {
     }
 
     protected void tx(Tx t) {
-        DSL.using(cfg).transaction(cfg -> {
+        dsl().transaction(cfg -> {
             DSLContext tx = DSL.using(cfg);
             t.run(tx);
         });
     }
 
     protected <T> T txResult(TxResult<T> t) {
-        return DSL.using(cfg).transactionResult(cfg -> {
+        return dsl().transactionResult(cfg -> {
             DSLContext tx = DSL.using(cfg);
             return t.run(tx);
         });
     }
 
     protected InputStream getData(Function<DSLContext, String> sqlFn, PreparedStatementHandler h, int columnIndex) {
-        String sql = sqlFn.apply(DSL.using(cfg));
+        String sql = sqlFn.apply(dsl());
 
         Connection conn = cfg.connectionProvider().acquire(); // NOSONAR
         PreparedStatement ps = null;

--- a/server/db/src/main/java/com/walmartlabs/concord/db/AbstractDao.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/AbstractDao.java
@@ -40,29 +40,26 @@ public abstract class AbstractDao {
         this.cfg = cfg;
     }
 
+    protected DSLContext dsl() {
+        return DSL.using(cfg);
+    }
+
     protected void tx(Tx t) {
-        try (DSLContext ctx = DSL.using(cfg)) {
-            ctx.transaction(cfg -> {
-                DSLContext tx = DSL.using(cfg);
-                t.run(tx);
-            });
-        }
+        DSL.using(cfg).transaction(cfg -> {
+            DSLContext tx = DSL.using(cfg);
+            t.run(tx);
+        });
     }
 
     protected <T> T txResult(TxResult<T> t) {
-        try (DSLContext ctx = DSL.using(cfg)) {
-            return ctx.transactionResult(cfg -> {
-                DSLContext tx = DSL.using(cfg);
-                return t.run(tx);
-            });
-        }
+        return DSL.using(cfg).transactionResult(cfg -> {
+            DSLContext tx = DSL.using(cfg);
+            return t.run(tx);
+        });
     }
 
     protected InputStream getData(Function<DSLContext, String> sqlFn, PreparedStatementHandler h, int columnIndex) {
-        String sql;
-        try (DSLContext create = DSL.using(cfg)) {
-            sql = sqlFn.apply(create);
-        }
+        String sql = sqlFn.apply(DSL.using(cfg));
 
         Connection conn = cfg.connectionProvider().acquire(); // NOSONAR
         PreparedStatement ps = null;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ServerResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ServerResource.java
@@ -26,8 +26,6 @@ import com.walmartlabs.concord.server.boot.BackgroundTasks;
 import com.walmartlabs.concord.server.task.TaskScheduler;
 import com.walmartlabs.concord.server.websocket.WebSocketChannelManager;
 import org.jooq.Configuration;
-import org.jooq.DSLContext;
-import org.jooq.impl.DSL;
 import org.sonatype.siesta.Resource;
 
 import javax.inject.Inject;
@@ -95,9 +93,7 @@ public class ServerResource implements Resource {
         }
 
         public void ping() {
-            try (DSLContext tx = DSL.using(cfg)) {
-                tx.selectOne().execute();
-            }
+            dsl().selectOne().execute();
         }
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/inventory/InventoryDataDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/inventory/InventoryDataDao.java
@@ -98,14 +98,16 @@ public class InventoryDataDao extends AbstractDao {
                         .from(i1)
                         .where(i1.JSON_STORE_ID.eq(inventoryId));
 
+        Field<Integer> levelField = field("level", Integer.class);
+
         SelectConditionStep<Record3<UUID, UUID, Integer>> s2 =
-                select(i2.JSON_STORE_ID, i2.PARENT_INVENTORY_ID, val(1)) // TODO(ib) level().add(1)
+                select(i2.JSON_STORE_ID, i2.PARENT_INVENTORY_ID, levelField.add(1))
                         .from(i2, nodes)
                         .where(i2.JSON_STORE_ID.eq(JSON_STORES.as("nodes").PARENT_INVENTORY_ID));
 
-        SelectConditionStep<Record3<String, JSONB, Integer>> s = tx.withRecursive("nodes", JSON_STORES.JSON_STORE_ID.getName(), JSON_STORES.PARENT_INVENTORY_ID.getName(), "level")
+        SelectConditionStep<Record3<String, JSONB, Integer>> s = tx.withRecursive("nodes", JSON_STORES.JSON_STORE_ID.getName(), JSON_STORES.PARENT_INVENTORY_ID.getName(), levelField.getName())
                 .as(s1.unionAll(s2))
-                .select(JSON_STORE_DATA.ITEM_PATH, JSON_STORE_DATA.ITEM_DATA, val(1)) // TODO(ib) level()
+                .select(JSON_STORE_DATA.ITEM_PATH, JSON_STORE_DATA.ITEM_DATA, levelField.add(1))
                 .from(JSON_STORE_DATA, nodes)
                 .where(JSON_STORE_DATA.JSON_STORE_ID.eq(JSON_STORES.as("nodes").JSON_STORE_ID)
                         .and(JSON_STORE_DATA.ITEM_PATH.startsWith(path)));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryDao.java
@@ -26,7 +26,6 @@ import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.Record4;
 import org.jooq.SelectJoinStep;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -45,59 +44,51 @@ public class JsonStoreQueryDao extends AbstractDao {
     }
 
     public UUID getId(UUID storeId, String queryName) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(JSON_STORE_QUERIES.QUERY_ID)
-                    .from(JSON_STORE_QUERIES)
-                    .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId)
-                            .and(JSON_STORE_QUERIES.QUERY_NAME.eq(queryName)))
-                    .fetchOne(JSON_STORE_QUERIES.QUERY_ID);
-        }
+        return dsl().select(JSON_STORE_QUERIES.QUERY_ID)
+                .from(JSON_STORE_QUERIES)
+                .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId)
+                        .and(JSON_STORE_QUERIES.QUERY_NAME.eq(queryName)))
+                .fetchOne(JSON_STORE_QUERIES.QUERY_ID);
     }
 
     public JsonStoreQueryEntry get(UUID storeId, String queryName) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            Record4<UUID, String, UUID, String> r = createSelect(tx)
-                    .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId)
-                            .and(JSON_STORE_QUERIES.QUERY_NAME.eq(queryName)))
-                    .fetchOne();
+        Record4<UUID, String, UUID, String> r = createSelect(dsl())
+                .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId)
+                        .and(JSON_STORE_QUERIES.QUERY_NAME.eq(queryName)))
+                .fetchOne();
 
-            if (r == null) {
-                return null;
-            }
-
-            return toEntry(r);
+        if (r == null) {
+            return null;
         }
+
+        return toEntry(r);
     }
 
     public JsonStoreQueryEntry get(UUID queryId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return createSelect(tx)
-                    .where(JSON_STORE_QUERIES.QUERY_ID.eq(queryId))
-                    .fetchOne(JsonStoreQueryDao::toEntry);
-        }
+        return createSelect(dsl())
+                .where(JSON_STORE_QUERIES.QUERY_ID.eq(queryId))
+                .fetchOne(JsonStoreQueryDao::toEntry);
     }
 
     public List<JsonStoreQueryEntry> list(UUID storeId, int offset, int limit, String filter) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectJoinStep<Record4<UUID, String, UUID, String>> q = createSelect(tx);
+        SelectJoinStep<Record4<UUID, String, UUID, String>> q = createSelect(dsl());
 
-            if (filter != null) {
-                q.where(JSON_STORE_QUERIES.QUERY_NAME.containsIgnoreCase(filter));
-            }
-
-            if (offset >= 0) {
-                q.offset(offset);
-            }
-
-            if (limit > 0) {
-                q.limit(limit);
-            }
-
-            return q
-                    .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId))
-                    .orderBy(JSON_STORE_QUERIES.QUERY_NAME)
-                    .fetch(JsonStoreQueryDao::toEntry);
+        if (filter != null) {
+            q.where(JSON_STORE_QUERIES.QUERY_NAME.containsIgnoreCase(filter));
         }
+
+        if (offset >= 0) {
+            q.offset(offset);
+        }
+
+        if (limit > 0) {
+            q.limit(limit);
+        }
+
+        return q
+                .where(JSON_STORE_QUERIES.JSON_STORE_ID.eq(storeId))
+                .orderBy(JSON_STORE_QUERIES.QUERY_NAME)
+                .fetch(JsonStoreQueryDao::toEntry);
     }
 
     public UUID insert(UUID storeId, String queryName, String text) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryExecDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryExecDao.java
@@ -37,10 +37,8 @@ import net.sf.jsqlparser.statement.StatementVisitorAdapter;
 import net.sf.jsqlparser.statement.create.table.ColDataType;
 import net.sf.jsqlparser.statement.select.*;
 import org.jooq.Configuration;
-import org.jooq.DSLContext;
 import org.jooq.QueryPart;
 import org.jooq.Record;
-import org.jooq.impl.DSL;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
@@ -81,19 +79,17 @@ public class JsonStoreQueryExecDao extends AbstractDao {
     public List<Object> execSql(UUID storeId, String query, Map<String, Object> params, Integer maxLimit) {
         String sql = createQuery(query, maxLimit);
 
-        try (DSLContext tx = DSL.using(cfg)) {
-            // TODO we should probably inspect the query to determine whether we need to bind the params or not
+        // TODO we should probably inspect the query to determine whether we need to bind the params or not
 
-            QueryPart[] args;
-            if (params == null) {
-                args = new QueryPart[]{val(storeId)};
-            } else {
-                args = new QueryPart[]{val(objectMapper.toString(params)), val(storeId)};
-            }
-
-            return tx.resultQuery(sql, args)
-                    .fetch(this::toExecResult);
+        QueryPart[] args;
+        if (params == null) {
+            args = new QueryPart[]{val(storeId)};
+        } else {
+            args = new QueryPart[]{val(objectMapper.toString(params)), val(storeId)};
         }
+
+        return dsl().resultQuery(sql, args)
+                .fetch(this::toExecResult);
     }
 
     private Object toExecResult(Record record) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/policy/PolicyDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/policy/PolicyDao.java
@@ -25,7 +25,6 @@ import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.server.ConcordObjectMapper;
 import com.walmartlabs.concord.server.jooq.tables.records.PolicyLinksRecord;
 import org.jooq.*;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -50,42 +49,34 @@ public class PolicyDao extends AbstractDao {
     }
 
     public UUID getId(String name) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(POLICIES.POLICY_ID)
-                    .from(POLICIES)
-                    .where(POLICIES.POLICY_NAME.eq(name))
-                    .fetchOne(POLICIES.POLICY_ID);
-        }
+        return dsl().select(POLICIES.POLICY_ID)
+                .from(POLICIES)
+                .where(POLICIES.POLICY_NAME.eq(name))
+                .fetchOne(POLICIES.POLICY_ID);
     }
 
     public PolicyEntry get(UUID policyId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(POLICIES.POLICY_ID,
-                    POLICIES.PARENT_POLICY_ID,
-                    POLICIES.POLICY_NAME,
-                    POLICIES.RULES)
-                    .from(POLICIES)
-                    .where(POLICIES.POLICY_ID.eq(policyId))
-                    .fetchOne(this::toEntry);
-        }
+        return dsl().select(POLICIES.POLICY_ID,
+                POLICIES.PARENT_POLICY_ID,
+                POLICIES.POLICY_NAME,
+                POLICIES.RULES)
+                .from(POLICIES)
+                .where(POLICIES.POLICY_ID.eq(policyId))
+                .fetchOne(this::toEntry);
     }
 
     public PolicyEntry get(String policyName) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(POLICIES.POLICY_ID,
-                    POLICIES.PARENT_POLICY_ID,
-                    POLICIES.POLICY_NAME,
-                    POLICIES.RULES)
-                    .from(POLICIES)
-                    .where(POLICIES.POLICY_NAME.eq(policyName))
-                    .fetchOne(this::toEntry);
-        }
+        return dsl().select(POLICIES.POLICY_ID,
+                POLICIES.PARENT_POLICY_ID,
+                POLICIES.POLICY_NAME,
+                POLICIES.RULES)
+                .from(POLICIES)
+                .where(POLICIES.POLICY_NAME.eq(policyName))
+                .fetchOne(this::toEntry);
     }
 
     public PolicyEntry getLinked(UUID orgId, UUID projectId, UUID userId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return getLinked(tx, orgId, projectId, userId);
-        }
+        return getLinked(dsl(), orgId, projectId, userId);
     }
 
     public PolicyEntry getLinked(DSLContext tx, UUID orgId, UUID projectId, UUID userId) {
@@ -187,14 +178,12 @@ public class PolicyDao extends AbstractDao {
     }
 
     public List<PolicyEntry> list() {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(POLICIES.POLICY_ID,
-                    POLICIES.PARENT_POLICY_ID,
-                    POLICIES.POLICY_NAME,
-                    POLICIES.RULES)
-                    .from(POLICIES)
-                    .fetch(this::toEntry);
-        }
+        return dsl().select(POLICIES.POLICY_ID,
+                POLICIES.PARENT_POLICY_ID,
+                POLICIES.POLICY_NAME,
+                POLICIES.RULES)
+                .from(POLICIES)
+                .fetch(this::toEntry);
     }
 
     private PolicyEntry findPolicyEntry(List<PolicyRule> rules) {
@@ -269,7 +258,7 @@ public class PolicyDao extends AbstractDao {
                 objectMapper.fromJSONB(r.value4()));
     }
 
-    private class PolicyRule {
+    private static class PolicyRule {
 
         private final UUID orgId;
         private final UUID prjId;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/KvDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/KvDao.java
@@ -25,10 +25,8 @@ import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.server.Locks;
 import com.walmartlabs.concord.server.jooq.tables.ProjectKvStore;
 import org.jooq.Configuration;
-import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.exception.DataAccessException;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -89,30 +87,27 @@ public class KvDao extends AbstractDao {
 
     public String getString(UUID projectId, String key) {
         ProjectKvStore kv = PROJECT_KV_STORE.as("kv");
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(kv.VALUE_STRING)
-                    .from(kv)
-                    .where(kv.PROJECT_ID.eq(projectId)
-                            .and(kv.VALUE_KEY.eq(key)))
-                    .fetchOne(kv.VALUE_STRING);
-        }
+        return dsl().select(kv.VALUE_STRING)
+                .from(kv)
+                .where(kv.PROJECT_ID.eq(projectId)
+                        .and(kv.VALUE_KEY.eq(key)))
+                .fetchOne(kv.VALUE_STRING);
     }
 
     public Long getLong(UUID projectId, String key) {
         ProjectKvStore kv = PROJECT_KV_STORE.as("kv");
-        try (DSLContext tx = DSL.using(cfg)) {
-            Record1<Long> r = tx.select(kv.VALUE_LONG)
-                    .from(kv)
-                    .where(kv.PROJECT_ID.eq(projectId)
-                            .and(kv.VALUE_KEY.eq(key)))
-                    .fetchOne();
 
-            if (r == null) {
-                return null;
-            }
+        Record1<Long> r = dsl().select(kv.VALUE_LONG)
+                .from(kv)
+                .where(kv.PROJECT_ID.eq(projectId)
+                        .and(kv.VALUE_KEY.eq(key)))
+                .fetchOne();
 
-            return r.value1();
+        if (r == null) {
+            return null;
         }
+
+        return r.value1();
     }
 
     public synchronized long inc(UUID projectId, String key) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryDao.java
@@ -25,7 +25,6 @@ import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.server.ConcordObjectMapper;
 import org.jooq.*;
 import org.jooq.exception.DataAccessException;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -55,22 +54,19 @@ public class RepositoryDao extends AbstractDao {
     }
 
     public UUID getId(UUID projectId, String repoName) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(REPOSITORIES.REPO_ID)
-                    .from(REPOSITORIES)
-                    .where(REPOSITORIES.PROJECT_ID.eq(projectId)
-                            .and(REPOSITORIES.REPO_NAME.eq(repoName)))
-                    .fetchOne(REPOSITORIES.REPO_ID);
-        }
+        return dsl().select(REPOSITORIES.REPO_ID)
+                .from(REPOSITORIES)
+                .where(REPOSITORIES.PROJECT_ID.eq(projectId)
+                        .and(REPOSITORIES.REPO_NAME.eq(repoName)))
+                .fetchOne(REPOSITORIES.REPO_ID);
     }
 
     public UUID getProjectId(UUID repoId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(REPOSITORIES.PROJECT_ID)
-                    .from(REPOSITORIES)
-                    .where(REPOSITORIES.REPO_ID.eq(repoId))
-                    .fetchOne(REPOSITORIES.PROJECT_ID);
-        }
+
+        return dsl().select(REPOSITORIES.PROJECT_ID)
+                .from(REPOSITORIES)
+                .where(REPOSITORIES.REPO_ID.eq(repoId))
+                .fetchOne(REPOSITORIES.PROJECT_ID);
     }
 
     public RepositoryEntry get(UUID projectId, UUID repoId) {
@@ -159,10 +155,8 @@ public class RepositoryDao extends AbstractDao {
     }
 
     public List<RepositoryEntry> list() {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return selectRepositoryEntry(tx)
-                    .fetch(this::toEntry);
-        }
+        return selectRepositoryEntry(dsl())
+                .fetch(this::toEntry);
     }
 
     public List<RepositoryEntry> list(UUID projectId) {
@@ -174,9 +168,7 @@ public class RepositoryDao extends AbstractDao {
     }
 
     public List<RepositoryEntry> list(UUID projectId, Field<?> sortField, boolean asc) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, projectId, sortField, asc);
-        }
+        return list(dsl(), projectId, sortField, asc);
     }
 
     public List<RepositoryEntry> list(DSLContext tx, UUID projectId, Field<?> sortField, boolean asc) {
@@ -195,16 +187,14 @@ public class RepositoryDao extends AbstractDao {
     }
 
     public List<RepositoryEntry> find(UUID projectId, String repoUrl) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectConditionStep<Record12<UUID, UUID, String, String, String, String, String, Boolean, JSONB, UUID, String, String>> select = selectRepositoryEntry(tx)
-                    .where(REPOSITORIES.REPO_URL.contains(repoUrl));
+        SelectConditionStep<Record12<UUID, UUID, String, String, String, String, String, Boolean, JSONB, UUID, String, String>> select = selectRepositoryEntry(dsl())
+                .where(REPOSITORIES.REPO_URL.contains(repoUrl));
 
-            if (projectId != null) {
-                select.and(REPOSITORIES.PROJECT_ID.eq(projectId));
-            }
-
-            return select.fetch(this::toEntry);
+        if (projectId != null) {
+            select.and(REPOSITORIES.PROJECT_ID.eq(projectId));
         }
+
+        return select.fetch(this::toEntry);
     }
 
     public List<RepositoryEntry> findBySecretId(DSLContext tx, UUID secretId) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretDao.java
@@ -35,7 +35,6 @@ import com.walmartlabs.concord.server.org.ResourceAccessLevel;
 import com.walmartlabs.concord.server.user.UserType;
 import org.jooq.*;
 import org.jooq.exception.DataAccessException;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -85,27 +84,21 @@ public class SecretDao extends AbstractDao {
     }
 
     public UUID getId(UUID orgId, String name) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return getId(tx, orgId, name);
-        }
+        return getId(dsl(), orgId, name);
     }
 
     public String getName(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(SECRETS.SECRET_NAME)
-                    .from(SECRETS)
-                    .where(SECRETS.SECRET_ID.eq(id))
-                    .fetchOne(SECRETS.SECRET_NAME);
-        }
+        return dsl().select(SECRETS.SECRET_NAME)
+                .from(SECRETS)
+                .where(SECRETS.SECRET_ID.eq(id))
+                .fetchOne(SECRETS.SECRET_NAME);
     }
 
     public UUID getOrgId(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(SECRETS.ORG_ID)
-                    .from(SECRETS)
-                    .where(SECRETS.SECRET_ID.eq(id))
-                    .fetchOne(SECRETS.ORG_ID);
-        }
+        return dsl().select(SECRETS.ORG_ID)
+                .from(SECRETS)
+                .where(SECRETS.SECRET_ID.eq(id))
+                .fetchOne(SECRETS.ORG_ID);
     }
 
     public UUID insert(UUID orgId, UUID projectId, String name, UUID ownerId, SecretType type,
@@ -148,29 +141,23 @@ public class SecretDao extends AbstractDao {
     }
 
     public SecretEntry get(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return selectEntry(tx)
-                    .where(SECRETS.SECRET_ID.eq(id))
-                    .fetchOne(SecretDao::toEntry);
-        }
+        return selectEntry(dsl())
+                .where(SECRETS.SECRET_ID.eq(id))
+                .fetchOne(SecretDao::toEntry);
     }
 
     public byte[] getData(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(SECRETS.SECRET_DATA)
-                    .from(SECRETS)
-                    .where(SECRETS.SECRET_ID.eq(id))
-                    .fetchOne(SECRETS.SECRET_DATA);
-        }
+        return dsl().select(SECRETS.SECRET_DATA)
+                .from(SECRETS)
+                .where(SECRETS.SECRET_ID.eq(id))
+                .fetchOne(SECRETS.SECRET_DATA);
     }
 
     public SecretEntry getByName(UUID orgId, String name) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return selectEntry(tx)
-                    .where(SECRETS.ORG_ID.eq(orgId)
-                            .and(SECRETS.SECRET_NAME.eq(name)))
-                    .fetchOne(SecretDao::toEntry);
-        }
+        return selectEntry(dsl())
+                .where(SECRETS.ORG_ID.eq(orgId)
+                        .and(SECRETS.SECRET_NAME.eq(name)))
+                .fetchOne(SecretDao::toEntry);
     }
 
     public void updateProjectScopeByProjectId(DSLContext tx, UUID orgId, UUID projectId, UUID newProjectId) {
@@ -257,54 +244,52 @@ public class SecretDao extends AbstractDao {
 
         sortField = s.field(sortField);
 
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectOnConditionStep<Record15<UUID, String, UUID, String, UUID, String, String, String, String, String, UUID, String, String, String, String>> q = selectEntry(tx, o, s, p, u);
+        SelectOnConditionStep<Record15<UUID, String, UUID, String, UUID, String, String, String, String, String, UUID, String, String, String, String>> q = selectEntry(dsl(), o, s, p, u);
 
-            if (currentUserId != null) {
-                // public secrets are visible for anyone
-                Condition isPublic = s.VISIBILITY.eq(SecretVisibility.PUBLIC.toString());
+        if (currentUserId != null) {
+            // public secrets are visible for anyone
+            Condition isPublic = s.VISIBILITY.eq(SecretVisibility.PUBLIC.toString());
 
-                // check if the user belongs to a team in the org
-                SelectConditionStep<Record1<UUID>> teamIds = select(TEAMS.TEAM_ID)
-                        .from(TEAMS)
-                        .where(TEAMS.ORG_ID.eq(orgId));
+            // check if the user belongs to a team in the org
+            SelectConditionStep<Record1<UUID>> teamIds = select(TEAMS.TEAM_ID)
+                    .from(TEAMS)
+                    .where(TEAMS.ORG_ID.eq(orgId));
 
-                Condition isInATeam = exists(selectOne().from(V_USER_TEAMS)
-                        .where(V_USER_TEAMS.USER_ID.eq(currentUserId)
-                                .and(V_USER_TEAMS.TEAM_ID.in(teamIds))));
+            Condition isInATeam = exists(selectOne().from(V_USER_TEAMS)
+                    .where(V_USER_TEAMS.USER_ID.eq(currentUserId)
+                            .and(V_USER_TEAMS.TEAM_ID.in(teamIds))));
 
-                // check if the user owns secrets in the org
-                Condition ownsSecrets = s.OWNER_ID.eq(currentUserId);
+            // check if the user owns secrets in the org
+            Condition ownsSecrets = s.OWNER_ID.eq(currentUserId);
 
-                // check if the user owns the org
-                Condition ownsOrg = o.OWNER_ID.eq(currentUserId);
+            // check if the user owns the org
+            Condition ownsOrg = o.OWNER_ID.eq(currentUserId);
 
-                // if any of those conditions true then the secret must be visible
-                q.where(or(isPublic, isInATeam, ownsSecrets, ownsOrg));
-            }
-
-            if (orgId != null) {
-                q.where(s.ORG_ID.eq(orgId));
-            }
-
-            if (filter != null) {
-                q.where(s.SECRET_NAME.containsIgnoreCase(filter));
-            }
-
-            if (sortField != null) {
-                q.orderBy(asc ? sortField.asc() : sortField.desc());
-            }
-
-            if (offset >= 0) {
-                q.offset(offset);
-            }
-
-            if (limit > 0) {
-                q.limit(limit);
-            }
-
-            return q.fetch(SecretDao::toEntry);
+            // if any of those conditions true then the secret must be visible
+            q.where(or(isPublic, isInATeam, ownsSecrets, ownsOrg));
         }
+
+        if (orgId != null) {
+            q.where(s.ORG_ID.eq(orgId));
+        }
+
+        if (filter != null) {
+            q.where(s.SECRET_NAME.containsIgnoreCase(filter));
+        }
+
+        if (sortField != null) {
+            q.orderBy(asc ? sortField.asc() : sortField.desc());
+        }
+
+        if (offset >= 0) {
+            q.offset(offset);
+        }
+
+        if (limit > 0) {
+            q.limit(limit);
+        }
+
+        return q.fetch(SecretDao::toEntry);
     }
 
     public void delete(UUID id) {
@@ -319,25 +304,24 @@ public class SecretDao extends AbstractDao {
 
     public List<ResourceAccessEntry> getAccessLevel(UUID orgId, String name) {
         List<ResourceAccessEntry> resourceAccessList = new ArrayList<>();
-        try (DSLContext tx = DSL.using(cfg)) {
-            Result<Record4<UUID, UUID, String, String>> teamAccess = tx.select(
-                    SECRET_TEAM_ACCESS.TEAM_ID,
-                    SECRET_TEAM_ACCESS.SECRET_ID,
-                    TEAMS.TEAM_NAME,
-                    SECRET_TEAM_ACCESS.ACCESS_LEVEL)
-                    .from(SECRET_TEAM_ACCESS)
-                    .leftOuterJoin(TEAMS).on(TEAMS.TEAM_ID.eq(SECRET_TEAM_ACCESS.TEAM_ID))
-                    .where(SECRET_TEAM_ACCESS.SECRET_ID.eq(getByName(orgId, name).getId()))
-                    .fetch();
 
-            for (Record4<UUID, UUID, String, String> t : teamAccess) {
-                resourceAccessList.add(new ResourceAccessEntry(t.get(SECRET_TEAM_ACCESS.TEAM_ID),
-                        null,
-                        t.get(TEAMS.TEAM_NAME),
-                        ResourceAccessLevel.valueOf(t.get(SECRET_TEAM_ACCESS.ACCESS_LEVEL))));
-            }
+        Result<Record4<UUID, UUID, String, String>> teamAccess = dsl().select(
+                SECRET_TEAM_ACCESS.TEAM_ID,
+                SECRET_TEAM_ACCESS.SECRET_ID,
+                TEAMS.TEAM_NAME,
+                SECRET_TEAM_ACCESS.ACCESS_LEVEL)
+                .from(SECRET_TEAM_ACCESS)
+                .leftOuterJoin(TEAMS).on(TEAMS.TEAM_ID.eq(SECRET_TEAM_ACCESS.TEAM_ID))
+                .where(SECRET_TEAM_ACCESS.SECRET_ID.eq(getByName(orgId, name).getId()))
+                .fetch();
 
+        for (Record4<UUID, UUID, String, String> t : teamAccess) {
+            resourceAccessList.add(new ResourceAccessEntry(t.get(SECRET_TEAM_ACCESS.TEAM_ID),
+                    null,
+                    t.get(TEAMS.TEAM_NAME),
+                    ResourceAccessLevel.valueOf(t.get(SECRET_TEAM_ACCESS.ACCESS_LEVEL))));
         }
+
         return resourceAccessList;
     }
 
@@ -348,9 +332,7 @@ public class SecretDao extends AbstractDao {
     }
 
     public boolean hasAccessLevel(UUID secretId, UUID userId, ResourceAccessLevel... levels) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return hasAccessLevel(tx, secretId, userId, levels);
-        }
+        return hasAccessLevel(dsl(), secretId, userId, levels);
     }
 
     private boolean hasAccessLevel(DSLContext tx, UUID secretId, UUID userId, ResourceAccessLevel... levels) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/team/TeamDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/team/TeamDao.java
@@ -28,7 +28,6 @@ import com.walmartlabs.concord.server.jooq.tables.records.TeamsRecord;
 import com.walmartlabs.concord.server.jooq.tables.records.VUserTeamsRecord;
 import com.walmartlabs.concord.server.user.UserType;
 import org.jooq.*;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -64,21 +63,17 @@ public class TeamDao extends AbstractDao {
     }
 
     public UUID getId(UUID orgId, String name) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(TEAMS.TEAM_ID)
-                    .from(TEAMS)
-                    .where(TEAMS.ORG_ID.eq(orgId).and(TEAMS.TEAM_NAME.eq(name)))
-                    .fetchOne(TEAMS.TEAM_ID);
-        }
+        return dsl().select(TEAMS.TEAM_ID)
+                .from(TEAMS)
+                .where(TEAMS.ORG_ID.eq(orgId).and(TEAMS.TEAM_NAME.eq(name)))
+                .fetchOne(TEAMS.TEAM_ID);
     }
 
     public UUID getOrgId(UUID teamId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(TEAMS.ORG_ID)
-                    .from(TEAMS)
-                    .where(TEAMS.TEAM_ID.eq(teamId))
-                    .fetchOne(TEAMS.ORG_ID);
-        }
+        return dsl().select(TEAMS.ORG_ID)
+                .from(TEAMS)
+                .where(TEAMS.TEAM_ID.eq(teamId))
+                .fetchOne(TEAMS.ORG_ID);
     }
 
     public UUID insert(UUID orgId, String name, String description) {
@@ -121,9 +116,7 @@ public class TeamDao extends AbstractDao {
     }
 
     public TeamEntry get(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return get(tx, id);
-        }
+        return get(dsl(), id);
     }
 
     private static SelectJoinStep<Record5<UUID, UUID, String, String, String>> selectTeams(DSLContext tx) {
@@ -146,9 +139,7 @@ public class TeamDao extends AbstractDao {
     }
 
     public TeamEntry getByName(UUID orgId, String name) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return getByName(tx, orgId, name);
-        }
+        return getByName(dsl(), orgId, name);
     }
 
     public TeamEntry getByName(DSLContext tx, UUID orgId, String name) {
@@ -158,9 +149,7 @@ public class TeamDao extends AbstractDao {
     }
 
     public List<TeamEntry> list(UUID orgId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, orgId);
-        }
+        return list(dsl(), orgId);
     }
 
     public List<TeamEntry> list(DSLContext tx, UUID orgId) {
@@ -171,12 +160,13 @@ public class TeamDao extends AbstractDao {
     }
 
     public List<TeamUserEntry> listUsers(UUID teamId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            List<TeamUserEntry> l = new LinkedList<>();
-            l.addAll(listMembers(tx, teamId));
-            l.addAll(listLdapGroupMembers(tx, teamId));
-            return l;
-        }
+        DSLContext tx = dsl();
+
+        List<TeamUserEntry> l = new LinkedList<>();
+        l.addAll(listMembers(tx, teamId));
+        l.addAll(listLdapGroupMembers(tx, teamId));
+
+        return l;
     }
 
     public List<TeamUserEntry> listMembers(DSLContext tx, UUID teamId) {
@@ -277,9 +267,7 @@ public class TeamDao extends AbstractDao {
     }
 
     public boolean isInAnyTeam(UUID orgId, UUID userId, TeamRole... roles) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return isInAnyTeam(tx, orgId, userId, roles);
-        }
+        return isInAnyTeam(dsl(), orgId, userId, roles);
     }
 
     public boolean isInAnyTeam(DSLContext tx, UUID orgId, UUID userId, TeamRole... roles) {
@@ -291,9 +279,7 @@ public class TeamDao extends AbstractDao {
     }
 
     public boolean hasUser(UUID teamId, UUID userId, TeamRole... roles) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return hasUser(tx, teamId, userId, roles);
-        }
+        return hasUser(dsl(), teamId, userId, roles);
     }
 
     public boolean hasUser(DSLContext tx, UUID teamId, UUID userId, TeamRole... roles) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggersDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggersDao.java
@@ -29,7 +29,6 @@ import com.walmartlabs.concord.server.jooq.tables.Organizations;
 import com.walmartlabs.concord.server.jooq.tables.Projects;
 import com.walmartlabs.concord.server.jooq.tables.Repositories;
 import org.jooq.*;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -58,12 +57,10 @@ public class TriggersDao extends AbstractDao {
     }
 
     public TriggerEntry get(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectJoinStep<Record12<UUID, UUID, String, UUID, String, UUID, String, String, String[], JSONB, JSONB, JSONB>> query = selectTriggers(tx);
+        SelectJoinStep<Record12<UUID, UUID, String, UUID, String, UUID, String, String, String[], JSONB, JSONB, JSONB>> query = selectTriggers(dsl());
 
-            return query.where(TRIGGERS.TRIGGER_ID.eq(id))
-                    .fetchOne(this::toEntity);
-        }
+        return query.where(TRIGGERS.TRIGGER_ID.eq(id))
+                .fetchOne(this::toEntity);
     }
 
     public UUID insert(DSLContext tx, UUID projectId, UUID repositoryId, String eventSource, List<String> activeProfiles, Map<String, Object> args, Map<String, Object> conditions, Map<String, Object> config) {
@@ -88,9 +85,7 @@ public class TriggersDao extends AbstractDao {
     }
 
     public List<TriggerEntry> list(UUID projectId, UUID repositoryId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, projectId, repositoryId);
-        }
+        return list(dsl(), projectId, repositoryId);
     }
 
     public List<TriggerEntry> list(DSLContext tx, UUID projectId, UUID repositoryId) {
@@ -101,21 +96,15 @@ public class TriggersDao extends AbstractDao {
     }
 
     public List<TriggerEntry> list(String eventSource, Integer version) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, null, eventSource, version, null);
-        }
+        return list(dsl(), null, eventSource, version, null);
     }
 
     public List<TriggerEntry> list(String eventSource, Integer version, Map<String, String> conditions) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, null, eventSource, version, conditions);
-        }
+        return list(dsl(), null, eventSource, version, conditions);
     }
 
     public List<TriggerEntry> list(UUID projectId, String eventSource, Integer version, Map<String, String> conditions) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return list(tx, projectId, eventSource, version, conditions);
-        }
+        return list(dsl(), projectId, eventSource, version, conditions);
     }
 
     private List<TriggerEntry> list(DSLContext tx, UUID projectId, String eventSource, Integer version, Map<String, String> conditions) {
@@ -139,31 +128,29 @@ public class TriggersDao extends AbstractDao {
     }
 
     public List<TriggerEntry> list(UUID orgId, UUID projectId, UUID repositoryId, String type) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectJoinStep<Record12<UUID, UUID, String, UUID, String, UUID, String, String, String[], JSONB, JSONB, JSONB>> query = selectTriggers(tx);
+        SelectJoinStep<Record12<UUID, UUID, String, UUID, String, UUID, String, String, String[], JSONB, JSONB, JSONB>> query = selectTriggers(dsl());
 
-            if (orgId != null) {
-                SelectConditionStep<Record1<UUID>> projectIds = select(PROJECTS.PROJECT_ID)
-                        .from(PROJECTS)
-                        .where(PROJECTS.ORG_ID.eq(orgId));
+        if (orgId != null) {
+            SelectConditionStep<Record1<UUID>> projectIds = select(PROJECTS.PROJECT_ID)
+                    .from(PROJECTS)
+                    .where(PROJECTS.ORG_ID.eq(orgId));
 
-                query.where(TRIGGERS.PROJECT_ID.in(projectIds));
-            }
-
-            if (projectId != null) {
-                query.where(TRIGGERS.PROJECT_ID.eq(projectId));
-            }
-
-            if (repositoryId != null) {
-                query.where(TRIGGERS.REPO_ID.eq(repositoryId));
-            }
-
-            if (type != null) {
-                query.where(TRIGGERS.EVENT_SOURCE.eq(type));
-            }
-
-            return query.fetch(this::toEntity);
+            query.where(TRIGGERS.PROJECT_ID.in(projectIds));
         }
+
+        if (projectId != null) {
+            query.where(TRIGGERS.PROJECT_ID.eq(projectId));
+        }
+
+        if (repositoryId != null) {
+            query.where(TRIGGERS.REPO_ID.eq(repositoryId));
+        }
+
+        if (type != null) {
+            query.where(TRIGGERS.EVENT_SOURCE.eq(type));
+        }
+
+        return query.fetch(this::toEntity);
     }
 
     private SelectJoinStep<Record12<UUID, UUID, String, UUID, String, UUID, String, String, String[], JSONB, JSONB, JSONB>> selectTriggers(DSLContext tx) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/Dispatcher.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/Dispatcher.java
@@ -46,7 +46,6 @@ import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import com.walmartlabs.concord.server.websocket.WebSocketChannel;
 import com.walmartlabs.concord.server.websocket.WebSocketChannelManager;
 import org.jooq.*;
-import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -361,14 +360,12 @@ public class Dispatcher extends PeriodicTask {
         }
 
         public SecretReference getSecretReference(UUID repoId) {
-            try (DSLContext tx = DSL.using(cfg)) {
-                return tx.select(ORGANIZATIONS.ORG_NAME, SECRETS.SECRET_NAME)
-                        .from(REPOSITORIES)
-                        .leftOuterJoin(SECRETS).on(REPOSITORIES.SECRET_ID.eq(SECRETS.SECRET_ID))
-                        .leftOuterJoin(ORGANIZATIONS).on(SECRETS.ORG_ID.eq(ORGANIZATIONS.ORG_ID))
-                        .where(REPOSITORIES.REPO_ID.eq(repoId))
-                        .fetchOne(r -> new SecretReference(r.value1(), r.value2()));
-            }
+            return dsl().select(ORGANIZATIONS.ORG_NAME, SECRETS.SECRET_NAME)
+                    .from(REPOSITORIES)
+                    .leftOuterJoin(SECRETS).on(REPOSITORIES.SECRET_ID.eq(SECRETS.SECRET_ID))
+                    .leftOuterJoin(ORGANIZATIONS).on(SECRETS.ORG_ID.eq(ORGANIZATIONS.ORG_ID))
+                    .where(REPOSITORIES.REPO_ID.eq(repoId))
+                    .fetchOne(r -> new SecretReference(r.value1(), r.value2()));
         }
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyDao.java
@@ -23,9 +23,7 @@ package com.walmartlabs.concord.server.security.apikey;
 import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
 import org.jooq.Configuration;
-import org.jooq.DSLContext;
 import org.jooq.Record4;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -62,27 +60,23 @@ public class ApiKeyDao extends AbstractDao {
     }
 
     public UUID getId(UUID userId, String keyName) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(API_KEYS.KEY_ID)
-                    .from(API_KEYS)
-                    .where(API_KEYS.USER_ID.eq(userId)
-                            .and(API_KEYS.KEY_NAME.eq(keyName)))
-                    .fetchOne(API_KEYS.KEY_ID);
-        }
+        return dsl().select(API_KEYS.KEY_ID)
+                .from(API_KEYS)
+                .where(API_KEYS.USER_ID.eq(userId)
+                        .and(API_KEYS.KEY_NAME.eq(keyName)))
+                .fetchOne(API_KEYS.KEY_ID);
     }
 
     public List<ApiKeyEntry> list(UUID userId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(
-                    API_KEYS.KEY_ID,
-                    API_KEYS.USER_ID,
-                    API_KEYS.KEY_NAME,
-                    API_KEYS.EXPIRED_AT)
-                    .from(API_KEYS)
-                    .where(API_KEYS.USER_ID.eq(userId))
-                    .orderBy(API_KEYS.KEY_NAME)
-                    .fetch(ApiKeyDao::toEntry);
-        }
+        return dsl().select(
+                API_KEYS.KEY_ID,
+                API_KEYS.USER_ID,
+                API_KEYS.KEY_NAME,
+                API_KEYS.EXPIRED_AT)
+                .from(API_KEYS)
+                .where(API_KEYS.USER_ID.eq(userId))
+                .orderBy(API_KEYS.KEY_NAME)
+                .fetch(ApiKeyDao::toEntry);
     }
 
     public UUID insert(UUID userId, String key, String name, OffsetDateTime expiredAt) {
@@ -101,29 +95,23 @@ public class ApiKeyDao extends AbstractDao {
     }
 
     public UUID getUserId(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(API_KEYS.USER_ID)
-                    .from(API_KEYS)
-                    .where(API_KEYS.KEY_ID.eq(id))
-                    .fetchOne(API_KEYS.USER_ID);
-        }
+        return dsl().select(API_KEYS.USER_ID)
+                .from(API_KEYS)
+                .where(API_KEYS.KEY_ID.eq(id))
+                .fetchOne(API_KEYS.USER_ID);
     }
 
     public ApiKeyEntry find(String key) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(API_KEYS.KEY_ID, API_KEYS.USER_ID, API_KEYS.KEY_NAME, API_KEYS.EXPIRED_AT)
-                    .from(API_KEYS)
-                    .where(API_KEYS.API_KEY.eq(hash(key))
-                            .and(API_KEYS.EXPIRED_AT.isNull()
-                                    .or(API_KEYS.EXPIRED_AT.greaterThan(currentOffsetDateTime()))))
-                    .fetchOne(ApiKeyDao::toEntry);
-        }
+        return dsl().select(API_KEYS.KEY_ID, API_KEYS.USER_ID, API_KEYS.KEY_NAME, API_KEYS.EXPIRED_AT)
+                .from(API_KEYS)
+                .where(API_KEYS.API_KEY.eq(hash(key))
+                        .and(API_KEYS.EXPIRED_AT.isNull()
+                                .or(API_KEYS.EXPIRED_AT.greaterThan(currentOffsetDateTime()))))
+                .fetchOne(ApiKeyDao::toEntry);
     }
 
     public int count(UUID userId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.fetchCount(selectFrom(API_KEYS).where(API_KEYS.USER_ID.eq(userId)));
-        }
+        return dsl().fetchCount(selectFrom(API_KEYS).where(API_KEYS.USER_ID.eq(userId)));
     }
 
     private static String hash(String s) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/template/TemplateAliasDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/template/TemplateAliasDao.java
@@ -25,7 +25,6 @@ import com.walmartlabs.concord.db.MainDB;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.Record2;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -43,19 +42,16 @@ public class TemplateAliasDao extends AbstractDao {
     }
 
     public boolean exists(String alias) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.fetchExists(tx.selectFrom(TEMPLATE_ALIASES)
-                    .where(TEMPLATE_ALIASES.TEMPLATE_ALIAS.eq(alias)));
-        }
+        DSLContext tx = dsl();
+        return tx.fetchExists(tx.selectFrom(TEMPLATE_ALIASES)
+                .where(TEMPLATE_ALIASES.TEMPLATE_ALIAS.eq(alias)));
     }
 
     public Optional<String> get(String alias) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(TEMPLATE_ALIASES.TEMPLATE_URL)
-                    .from(TEMPLATE_ALIASES)
-                    .where(TEMPLATE_ALIASES.TEMPLATE_ALIAS.eq(alias))
-                    .fetchOptional(TEMPLATE_ALIASES.TEMPLATE_URL);
-        }
+        return dsl().select(TEMPLATE_ALIASES.TEMPLATE_URL)
+                .from(TEMPLATE_ALIASES)
+                .where(TEMPLATE_ALIASES.TEMPLATE_ALIAS.eq(alias))
+                .fetchOptional(TEMPLATE_ALIASES.TEMPLATE_URL);
     }
 
     public void insert(String alias, String url) {
@@ -70,11 +66,9 @@ public class TemplateAliasDao extends AbstractDao {
     }
 
     public List<TemplateAliasEntry> list() {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(TEMPLATE_ALIASES.TEMPLATE_ALIAS, TEMPLATE_ALIASES.TEMPLATE_URL)
-                    .from(TEMPLATE_ALIASES)
-                    .fetch(TemplateAliasDao::toEntry);
-        }
+        return dsl().select(TEMPLATE_ALIASES.TEMPLATE_ALIAS, TEMPLATE_ALIASES.TEMPLATE_URL)
+                .from(TEMPLATE_ALIASES)
+                .fetch(TemplateAliasDao::toEntry);
     }
 
     public void delete(String alias) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
@@ -67,7 +67,8 @@ public class UserDao extends AbstractDao {
                     .set(USERS.DISPLAY_NAME, displayName)
                     .set(USERS.USER_EMAIL, email)
                     .returning(USERS.USER_ID)
-                    .fetchOne().getUserId();
+                    .fetchOne()
+                    .getUserId();
 
             if (roles != null) {
                 updateRoles(tx, userId, roles);
@@ -127,19 +128,19 @@ public class UserDao extends AbstractDao {
 
     // TODO add "include" option
     public UserEntry get(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            Record7<UUID, String, String, String, String, String, Boolean> r =
-                    tx.select(USERS.USER_ID, USERS.USER_TYPE, USERS.USERNAME, USERS.DOMAIN, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED)
-                            .from(USERS)
-                            .where(USERS.USER_ID.eq(id))
-                            .fetchOne();
+        DSLContext tx = DSL.using(cfg);
 
-            if (r == null) {
-                return null;
-            }
+        Record7<UUID, String, String, String, String, String, Boolean> r =
+                tx.select(USERS.USER_ID, USERS.USER_TYPE, USERS.USERNAME, USERS.DOMAIN, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED)
+                        .from(USERS)
+                        .where(USERS.USER_ID.eq(id))
+                        .fetchOne();
 
-            return getUserInfo(tx, r);
+        if (r == null) {
+            return null;
         }
+
+        return getUserInfo(tx, r);
     }
 
     /**
@@ -147,52 +148,44 @@ public class UserDao extends AbstractDao {
      * Note that {@code username} and {@code domain} are case-insensitive and forced to lower case.
      */
     public UUID getId(String username, String domain, UserType type) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectConditionStep<Record1<UUID>> q = tx.select(USERS.USER_ID)
-                    .from(USERS)
-                    .where(USERS.USERNAME.eq(toLowerCase(username)));
+        SelectConditionStep<Record1<UUID>> q = dsl().select(USERS.USER_ID)
+                .from(USERS)
+                .where(USERS.USERNAME.eq(toLowerCase(username)));
 
-            if (domain != null) {
-                q.and(USERS.DOMAIN.eq(toLowerCase(domain)));
-            }
-
-            if (type != null) {
-                q.and(USERS.USER_TYPE.eq(type.toString()));
-            }
-
-            List<UUID> result = q.fetch(USERS.USER_ID);
-            if (result.isEmpty()) {
-                return null;
-            } else if (result.size() > 1) {
-                throw new IllegalArgumentException("Non unique results found for username: '" + username + "', domain: '" + domain + "', type: " + type +
-                        ". Note that user and domain names are case-insensitive.");
-            }
-
-            return result.get(0);
+        if (domain != null) {
+            q.and(USERS.DOMAIN.eq(toLowerCase(domain)));
         }
+
+        if (type != null) {
+            q.and(USERS.USER_TYPE.eq(type.toString()));
+        }
+
+        List<UUID> result = q.fetch(USERS.USER_ID);
+        if (result.isEmpty()) {
+            return null;
+        } else if (result.size() > 1) {
+            throw new IllegalArgumentException("Non unique results found for username: '" + username + "', domain: '" + domain + "', type: " + type +
+                    ". Note that user and domain names are case-insensitive.");
+        }
+
+        return result.get(0);
     }
 
     public String getUsername(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(USERS.USERNAME).from(USERS)
-                    .where(USERS.USER_ID.eq(id))
-                    .fetchOne(USERS.USERNAME);
-        }
+        return dsl().select(USERS.USERNAME).from(USERS)
+                .where(USERS.USER_ID.eq(id))
+                .fetchOne(USERS.USERNAME);
     }
 
     public boolean existsById(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            int cnt = tx.fetchCount(tx.selectFrom(USERS)
-                    .where(USERS.USER_ID.eq(id)));
+        int cnt = dsl().fetchCount(selectFrom(USERS)
+                .where(USERS.USER_ID.eq(id)));
 
-            return cnt > 0;
-        }
+        return cnt > 0;
     }
 
     public boolean isInOrganization(UUID userId, UUID orgId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return isInOrganization(tx, userId, orgId);
-        }
+        return isInOrganization(dsl(), userId, orgId);
     }
 
     public boolean isInOrganization(DSLContext tx, UUID userId, UUID orgId) {
@@ -206,25 +199,21 @@ public class UserDao extends AbstractDao {
     }
 
     public Set<UUID> getOrgIds(UUID userId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            SelectConditionStep<Record1<UUID>> teamIds = select(V_USER_TEAMS.TEAM_ID)
-                    .from(V_USER_TEAMS)
-                    .where(V_USER_TEAMS.USER_ID.eq(userId));
+        SelectConditionStep<Record1<UUID>> teamIds = select(V_USER_TEAMS.TEAM_ID)
+                .from(V_USER_TEAMS)
+                .where(V_USER_TEAMS.USER_ID.eq(userId));
 
-            return tx.selectDistinct(TEAMS.ORG_ID)
-                    .from(TEAMS)
-                    .where(TEAMS.TEAM_ID.in(teamIds))
-                    .fetchSet(TEAMS.ORG_ID);
-        }
+        return dsl().selectDistinct(TEAMS.ORG_ID)
+                .from(TEAMS)
+                .where(TEAMS.TEAM_ID.in(teamIds))
+                .fetchSet(TEAMS.ORG_ID);
     }
 
     public String getEmail(UUID id) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(USERS.USER_EMAIL)
-                    .from(USERS)
-                    .where(USERS.USER_ID.eq(id))
-                    .fetchOne(USERS.USER_EMAIL);
-        }
+        return dsl().select(USERS.USER_EMAIL)
+                .from(USERS)
+                .where(USERS.USER_ID.eq(id))
+                .fetchOne(USERS.USER_EMAIL);
     }
 
     public void updateRoles(UUID id, Set<String> roles) {
@@ -243,51 +232,45 @@ public class UserDao extends AbstractDao {
     }
 
     public Optional<Boolean> isDisabled(UUID userId) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(USERS.IS_DISABLED)
-                    .from(USERS)
-                    .where(USERS.USER_ID.eq(userId))
-                    .fetchOne(r -> Optional.ofNullable(r.get(USERS.IS_DISABLED)));
-        }
+        return dsl().select(USERS.IS_DISABLED)
+                .from(USERS)
+                .where(USERS.USER_ID.eq(userId))
+                .fetchOne(r -> Optional.ofNullable(r.get(USERS.IS_DISABLED)));
     }
 
     // TODO add "include" option
     public List<UserEntry> list(String filter, int offset, int limit) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.select(USERS.USER_ID, USERS.USERNAME, USERS.DOMAIN, USERS.USER_TYPE, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED)
-                    .from(USERS)
-                    .where(USERS.IS_DISABLED.isFalse())
-                    .and(value(filter).isNotNull()
-                            .and(USERS.USERNAME.containsIgnoreCase(filter)
-                                    .or(USERS.DISPLAY_NAME.containsIgnoreCase(filter))
-                                    .or(USERS.USER_EMAIL.containsIgnoreCase(filter))))
-                    .orderBy(USERS.DISPLAY_NAME, USERS.USERNAME)
-                    .offset(offset)
-                    .limit(limit)
-                    .fetch(r -> new UserEntry(r.get(USERS.USER_ID),
-                            r.get(USERS.USERNAME),
-                            r.get(USERS.DOMAIN),
-                            r.get(USERS.DISPLAY_NAME),
-                            null,
-                            UserType.valueOf(r.get(USERS.USER_TYPE)),
-                            r.get(USERS.USER_EMAIL),
-                            null,
-                            r.get(USERS.IS_DISABLED)));
-        }
+        return dsl().select(USERS.USER_ID, USERS.USERNAME, USERS.DOMAIN, USERS.USER_TYPE, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED)
+                .from(USERS)
+                .where(USERS.IS_DISABLED.isFalse())
+                .and(value(filter).isNotNull()
+                        .and(USERS.USERNAME.containsIgnoreCase(filter)
+                                .or(USERS.DISPLAY_NAME.containsIgnoreCase(filter))
+                                .or(USERS.USER_EMAIL.containsIgnoreCase(filter))))
+                .orderBy(USERS.DISPLAY_NAME, USERS.USERNAME)
+                .offset(offset)
+                .limit(limit)
+                .fetch(r -> new UserEntry(r.get(USERS.USER_ID),
+                        r.get(USERS.USERNAME),
+                        r.get(USERS.DOMAIN),
+                        r.get(USERS.DISPLAY_NAME),
+                        null,
+                        UserType.valueOf(r.get(USERS.USER_TYPE)),
+                        r.get(USERS.USER_EMAIL),
+                        null,
+                        r.get(USERS.IS_DISABLED)));
     }
 
     public List<LdapGroupSearchResult> searchLdapGroups(String filter) {
-        try (DSLContext tx = DSL.using(cfg)) {
-            return tx.selectDistinct(USER_LDAP_GROUPS.LDAP_GROUP)
-                    .from(USER_LDAP_GROUPS)
-                    .where(USER_LDAP_GROUPS.LDAP_GROUP.likeIgnoreCase(String.format("%%%s%%", filter)))
-                    .orderBy(USER_LDAP_GROUPS.LDAP_GROUP)
-                    .limit(10)
-                    .fetch(r -> LdapGroupSearchResult.builder()
-                            .displayName(r.get(USER_LDAP_GROUPS.LDAP_GROUP))
-                            .groupName(r.get(USER_LDAP_GROUPS.LDAP_GROUP))
-                            .build());
-        }
+        return dsl().selectDistinct(USER_LDAP_GROUPS.LDAP_GROUP)
+                .from(USER_LDAP_GROUPS)
+                .where(USER_LDAP_GROUPS.LDAP_GROUP.likeIgnoreCase(String.format("%%%s%%", filter)))
+                .orderBy(USER_LDAP_GROUPS.LDAP_GROUP)
+                .limit(10)
+                .fetch(r -> LdapGroupSearchResult.builder()
+                        .displayName(r.get(USER_LDAP_GROUPS.LDAP_GROUP))
+                        .groupName(r.get(USER_LDAP_GROUPS.LDAP_GROUP))
+                        .build());
     }
 
     private UserEntry getUserInfo(DSLContext tx, Record7<UUID, String, String, String, String, String, Boolean> r) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
@@ -128,7 +128,7 @@ public class UserDao extends AbstractDao {
 
     // TODO add "include" option
     public UserEntry get(UUID id) {
-        DSLContext tx = DSL.using(cfg);
+        DSLContext tx = dsl();
 
         Record7<UUID, String, String, String, String, String, Boolean> r =
                 tx.select(USERS.USER_ID, USERS.USER_TYPE, USERS.USERNAME, USERS.DOMAIN, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED)

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/AbstractDaoTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/AbstractDaoTest.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.server;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,12 +68,10 @@ public abstract class AbstractDaoTest {
     }
 
     protected void tx(AbstractDao.Tx t) {
-        try (DSLContext ctx = DSL.using(cfg)) {
-            ctx.transaction(cfg -> {
-                DSLContext tx = DSL.using(cfg);
-                t.run(tx);
-            });
-        }
+        DSL.using(cfg).transaction(cfg -> {
+            DSLContext tx = DSL.using(cfg);
+            t.run(tx);
+        });
     }
 
     protected Configuration getConfiguration() {

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/OffsetDateTimeTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/OffsetDateTimeTest.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.server;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ package com.walmartlabs.concord.server;
  */
 
 import com.walmartlabs.concord.common.DateTimeUtils;
-import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -43,20 +42,18 @@ public class OffsetDateTimeTest extends AbstractDaoTest {
         UUID instanceId = UUID.fromString("c686b84f-3d0d-4958-a156-9257db3efa13");
         OffsetDateTime createdAt = DateTimeUtils.fromIsoString("2020-07-16T21:30:53.907Z");
 
-        try (DSLContext tx = DSL.using(getConfiguration())) {
-            tx.connection(conn -> {
-                try (PreparedStatement ps = conn.prepareStatement("select * from process_state where instance_id = ? and instance_created_at = ?")) {
-                    ps.setObject(1, instanceId);
-                    ps.setObject(2, createdAt);
+        DSL.using(getConfiguration()).connection(conn -> {
+            try (PreparedStatement ps = conn.prepareStatement("select * from process_state where instance_id = ? and instance_created_at = ?")) {
+                ps.setObject(1, instanceId);
+                ps.setObject(2, createdAt);
 
-                    try (ResultSet rs = ps.executeQuery()) {
-                        while (rs.next()) {
-                            String s = rs.getString("item_path");
-                            System.out.println(s);
-                        }
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        String s = rs.getString("item_path");
+                        System.out.println(s);
                     }
                 }
-            });
-        }
+            }
+        });
     }
 }

--- a/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/EventDao.java
+++ b/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/EventDao.java
@@ -24,10 +24,8 @@ import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
 import org.jooq.Configuration;
-import org.jooq.DSLContext;
 import org.jooq.Record4;
 import org.jooq.SelectConditionStep;
-import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -49,28 +47,25 @@ public class EventDao extends AbstractDao {
     }
 
     public List<ProcessEventEntry> list(ProcessKey processKey, Map<String, String> dataFilter) {
-        try (DSLContext tx = DSL.using(cfg)) {
+        SelectConditionStep<Record4<UUID, String, OffsetDateTime, String>> q = dsl()
+                .select(PROCESS_EVENTS.EVENT_ID,
+                        PROCESS_EVENTS.EVENT_TYPE,
+                        PROCESS_EVENTS.EVENT_DATE,
+                        PROCESS_EVENTS.EVENT_DATA.cast(String.class))
+                .from(PROCESS_EVENTS)
+                .where(PROCESS_EVENTS.INSTANCE_ID.eq(processKey.getInstanceId())
+                        .and(PROCESS_EVENTS.INSTANCE_CREATED_AT.eq(processKey.getCreatedAt())));
 
-            SelectConditionStep<Record4<UUID, String, OffsetDateTime, String>> q = tx
-                    .select(PROCESS_EVENTS.EVENT_ID,
-                            PROCESS_EVENTS.EVENT_TYPE,
-                            PROCESS_EVENTS.EVENT_DATE,
-                            PROCESS_EVENTS.EVENT_DATA.cast(String.class))
-                    .from(PROCESS_EVENTS)
-                    .where(PROCESS_EVENTS.INSTANCE_ID.eq(processKey.getInstanceId())
-                            .and(PROCESS_EVENTS.INSTANCE_CREATED_AT.eq(processKey.getCreatedAt())));
+        q.and(PROCESS_EVENTS.EVENT_TYPE.eq(Constants.ANSIBLE_EVENT_TYPE));
 
-            q.and(PROCESS_EVENTS.EVENT_TYPE.eq(Constants.ANSIBLE_EVENT_TYPE));
-
-            if (dataFilter != null) {
-                dataFilter.forEach((k, v) -> {
-                    q.and(field("{0}->>{1}", Object.class, PROCESS_EVENTS.EVENT_DATA, inline(k)).eq(v));
-                });
-            }
-
-            return q.orderBy(PROCESS_EVENTS.EVENT_DATE)
-                    .fetch(EventDao::toEntry);
+        if (dataFilter != null) {
+            dataFilter.forEach((k, v) -> {
+                q.and(field("{0}->>{1}", Object.class, PROCESS_EVENTS.EVENT_DATA, inline(k)).eq(v));
+            });
         }
+
+        return q.orderBy(PROCESS_EVENTS.EVENT_DATE)
+                .fetch(EventDao::toEntry);
     }
 
     private static ProcessEventEntry toEntry(Record4<UUID, String, OffsetDateTime, String> r) {

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -59,7 +59,7 @@
         <jaxb.version>2.3.0.1</jaxb.version>
         <jetty.version>9.4.26.v20200117</jetty.version>
         <jgit.version>5.2.0.201812061821-r</jgit.version> <!-- updating requires some changes in how the auth is set up in ITs -->
-        <jooq.version>3.13.4</jooq.version>
+        <jooq.version>3.14.0</jooq.version>
         <jsch.version>0.1.55</jsch.version>
         <json.smart.version>2.3</json.smart.version>
         <jsqlparser.version>3.1</jsqlparser.version>


### PR DESCRIPTION
In jOOQ 3.14.0 `DSLContext` is no longer `AutoCloseable` (see
https://github.com/jOOQ/jOOQ/issues/10512).

Normally, explicit management of `DSLContext` objects is required only
when it is used without a connection pool. Which is not applicable to
the Concord's case.