### PR TITLE
runtime-v2: support for expressions in `out` block of flow call step

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/FlowCallOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/FlowCallOptions.java
@@ -47,6 +47,12 @@ public interface FlowCallOptions extends StepOptions {
         return Collections.emptyList();
     }
 
+    @Value.Default
+    @AllowNulls
+    default Map<String, Serializable> outExpr() {
+        return Collections.emptyMap();
+    }
+
     @Nullable
     WithItems withItems();
 

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
@@ -21,26 +21,27 @@ package com.walmartlabs.concord.runtime.v2.parser;
  */
 
 import com.walmartlabs.concord.runtime.v2.Constants;
-import com.walmartlabs.concord.runtime.v2.model.FlowCall;
-import com.walmartlabs.concord.runtime.v2.model.FlowCallOptions;
-import com.walmartlabs.concord.runtime.v2.model.ImmutableFlowCallOptions;
-import com.walmartlabs.concord.runtime.v2.model.WithItems;
+import com.walmartlabs.concord.runtime.v2.model.*;
 import io.takari.parc.Parser;
 
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.*;
 import static com.walmartlabs.concord.runtime.v2.parser.RetryGrammar.retryVal;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.with;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.options;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.*;
+import static io.takari.parc.Combinators.or;
 
 public final class FlowCallGrammar {
+
+    private static Parser<Atom, ImmutableFlowCallOptions.Builder> flowCallOutOption(ImmutableFlowCallOptions.Builder o) {
+        return orError(or(maybeMap.map(o::outExpr), stringOrArrayVal.map(o::out)), YamlValueType.FLOW_CALL_OUT);
+    }
 
     private static Parser<Atom, FlowCallOptions> callOptions(String stepName) {
         return with(() -> optionsBuilder(stepName),
                 o -> options(
                         optional("in", mapVal.map(o::input)),
-                        optional("out", stringOrArrayVal.map(o::out)),
+                        optional("out", flowCallOutOption(o)),
                         optional("meta", mapVal.map(o::putAllMeta)),
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v)))),
                         optional("retry", retryVal.map(o::retry)),

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
@@ -34,7 +34,7 @@ import static io.takari.parc.Combinators.or;
 public final class FlowCallGrammar {
 
     private static Parser<Atom, ImmutableFlowCallOptions.Builder> flowCallOutOption(ImmutableFlowCallOptions.Builder o) {
-        return orError(or(maybeMap.map(o::outExpr), stringOrArrayVal.map(o::out)), YamlValueType.FLOW_CALL_OUT);
+        return orError(or(maybeMap.map(o::outExpr), or(maybeString.map(o::addOut), maybeStringArray.map(o::out))), YamlValueType.FLOW_CALL_OUT);
     }
 
     private static Parser<Atom, FlowCallOptions> callOptions(String stepName) {

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarV2.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarV2.java
@@ -76,6 +76,7 @@ public final class GrammarV2 {
     });
     public static final Parser<Atom, Integer> maybeInt = _val(JsonToken.VALUE_NUMBER_INT).map(v -> v.getValue(YamlValueType.INT));
     public static final Parser<Atom, String> maybeString = _val(JsonToken.VALUE_STRING).map(v -> v.getValue(YamlValueType.STRING));
+    public static final Parser<Atom, List<String>> maybeStringArray = arrayOfValues.map(v -> v.getListValue(YamlValueType.STRING));
     public static final Parser<Atom, Map<String, Serializable>> maybeMap = object.map(YamlObject::getValue);
     public static final Parser<Atom, Object> patternOrArrayVal = value.map(GrammarV2::patternOrArrayConverter);
     public static final Parser<Atom, Duration> durationVal = value.map(GrammarV2::durationConverter);

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
@@ -97,7 +97,7 @@ public final class YamlValueType<T> {
     public static final YamlValueType<ExclusiveModeConfiguration> EXCLUSIVE_MODE = type("EXCLUSIVE_MODE");
     public static final YamlValueType<EventConfiguration> EVENTS_CFG = type("EVENTS_CONFIGURATION");
     public static final YamlValueType<ImmutableTaskCallOptions.Builder> TASK_CALL_OUT = type("STRING or OBJECT");
-    public static final YamlValueType<ImmutableFlowCallOptions.Builder> FLOW_CALL_OUT = type("ARRAY_OF_STRING or OBJECT");
+    public static final YamlValueType<ImmutableFlowCallOptions.Builder> FLOW_CALL_OUT = type("STRING or ARRAY_OF_STRING or OBJECT");
 
     private final String name;
 

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
@@ -97,6 +97,7 @@ public final class YamlValueType<T> {
     public static final YamlValueType<ExclusiveModeConfiguration> EXCLUSIVE_MODE = type("EXCLUSIVE_MODE");
     public static final YamlValueType<EventConfiguration> EVENTS_CFG = type("EVENTS_CONFIGURATION");
     public static final YamlValueType<ImmutableTaskCallOptions.Builder> TASK_CALL_OUT = type("STRING or OBJECT");
+    public static final YamlValueType<ImmutableFlowCallOptions.Builder> FLOW_CALL_OUT = type("ARRAY_OF_STRING or OBJECT");
 
     private final String name;
 

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FlowCallStepSerializer.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FlowCallStepSerializer.java
@@ -57,6 +57,7 @@ public class FlowCallStepSerializer extends StdSerializer<FlowCall> {
 
         writeNotEmptyObjectField("in", options.input(), gen);
         writeNotEmptyObjectField("out", options.out(), gen);
+        writeNotEmptyObjectField("out", options.outExpr(), gen);
 
         if (options.withItems() != null) {
             gen.writeObjectField("withItems", options.withItems());

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
@@ -83,6 +83,20 @@ public class ProjectSerializerV2Test extends AbstractParserTest {
     }
 
     @Test
+    public void testFlowCallOutExpr() throws Exception {
+        FlowCallOptions opts = FlowCallOptions.builder()
+                .putInput("in-1", "v1")
+                .putOutExpr("o1", "${o.one}")
+                .withItems(withItems())
+                .retry(retry())
+                .errorSteps(steps())
+                .build();
+
+        String result = toYaml(new FlowCall(location(), "flow", opts));
+        assertResult("serializer/flowCallStepOutExpr.yml", result);
+    }
+
+    @Test
     public void testFormCall() throws Exception {
         FormField f = FormField.builder()
                 .name("field-name")

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -824,19 +824,6 @@ public class YamlErrorParserTest extends AbstractParserTest {
     }
 
     @Test
-    public void test304() throws Exception {
-        String msg =
-                "(004.yml): Error @ line: 5, col: 9. Invalid value type, expected: STRING_OR_ARRAY, got: OBJECT\n" +
-                        "\twhile processing steps:\n" +
-                        "\t'out' @ line: 4, col: 7\n" +
-                        "\t\t'call' @ line: 3, col: 7\n" +
-                        "\t\t\t'main' @ line: 2, col: 3\n" +
-                        "\t\t\t\t'flows' @ line: 1, col: 1";
-
-        assertErrorMessage("errors/flowCall/004.yml", msg);
-    }
-
-    @Test
     public void test305() throws Exception {
         String msg =
                 "(005.yml): Error @ line: 5, col: 10. Invalid value type, expected: OBJECT, got: NULL. Remove attribute or complete the definition\n" +

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -800,7 +800,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test302() throws Exception {
         String msg =
-                "(002.yml): Error @ line: 4, col: 11. Invalid value type, expected: STRING_OR_ARRAY, got: NULL. Remove attribute or complete the definition\n" +
+                "(002.yml): Error @ line: 4, col: 11. Invalid value type, expected: STRING or ARRAY_OF_STRING or OBJECT, got: NULL. Remove attribute or complete the definition\n" +
                         "\twhile processing steps:\n" +
                         "\t'out' @ line: 4, col: 7\n" +
                         "\t\t'call' @ line: 3, col: 7\n" +
@@ -813,7 +813,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test303() throws Exception {
         String msg =
-                "(003.yml): Error @ line: 4, col: 12. Invalid value type, expected: STRING_OR_ARRAY, got: INT\n" +
+                "(003.yml): Error @ line: 4, col: 12. Invalid value type, expected: STRING or ARRAY_OF_STRING or OBJECT, got: INT\n" +
                         "\twhile processing steps:\n" +
                         "\t'out' @ line: 4, col: 7\n" +
                         "\t\t'call' @ line: 3, col: 7\n" +

--- a/runtime/v2/model/src/test/resources/errors/flowCall/004.yml
+++ b/runtime/v2/model/src/test/resources/errors/flowCall/004.yml
@@ -1,5 +1,0 @@
-flows:
-  main:
-    - call: "boo"
-      out:
-        k: "v"

--- a/runtime/v2/model/src/test/resources/serializer/flowCallStepOutExpr.yml
+++ b/runtime/v2/model/src/test/resources/serializer/flowCallStepOutExpr.yml
@@ -1,0 +1,18 @@
+call: "flow"
+in:
+  in-1: "v1"
+out:
+  o1: "${o.one}"
+withItems:
+- "item1"
+- "item2"
+retry:
+  times: "${times}"
+  delay: "${delay}"
+  in:
+    retry-input: "v1"
+error:
+- checkpoint: "chp1"
+  meta:
+    meta-1: "v1"
+    meta-2: "v2"

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
@@ -33,6 +33,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.*;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -79,10 +80,40 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         // an "out" handler:
         // grab the out variable from the called flow's frame
         // and put it into the callee's frame
-        Command processOutVars = new CopyVariablesCommand(opts.out(), innerFrame, null);
+        Command processOutVars;
+        if (!opts.outExpr().isEmpty()) {
+            processOutVars = new EvalVariablesCommand(ctx, opts.outExpr(), innerFrame);
+        } else {
+            processOutVars = new CopyVariablesCommand(opts.out(), innerFrame, null);
+        }
 
         // push the out handler first so it executes after the called flow's frame is done
         state.peekFrame(threadId).push(processOutVars);
         state.pushFrame(threadId, innerFrame);
+    }
+
+    private static class EvalVariablesCommand implements Command {
+
+        private final Context ctx;
+        private final Map<String, Serializable> variables;
+        private final Frame variablesFrame;
+
+        private EvalVariablesCommand(Context ctx, Map<String, Serializable> variables, Frame variablesFrame) {
+            this.ctx = ctx;
+            this.variables = variables;
+            this.variablesFrame = variablesFrame;
+        }
+
+        @Override
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public void eval(Runtime runtime, State state, ThreadId threadId) {
+            Frame frame = state.peekFrame(threadId);
+            frame.pop();
+
+            ExpressionEvaluator expressionEvaluator = runtime.getService(ExpressionEvaluator.class);
+            Map<String, Object> vars = (Map)variablesFrame.getLocals();
+            Map<String, Serializable> out = expressionEvaluator.evalAsMap(EvalContextFactory.global(ctx, vars), variables);
+            out.forEach((k, v) -> ctx.variables().set(k, v));
+        }
     }
 }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -783,6 +783,17 @@ public class MainTest {
         assertLog(log, ".*result: some-value.*");
     }
 
+    @Test
+    public void testFlowOutExpression() throws Exception {
+        deploy("flowOutExpr");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        byte[] log = run();
+        assertLog(log, ".*v: 123.*");
+    }
+
     private void deploy(String resource) throws URISyntaxException, IOException {
         Path src = Paths.get(MainTest.class.getResource(resource).toURI());
         IOUtils.copy(src, workDir);

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/flowOutExpr/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/flowOutExpr/concord.yml
@@ -1,0 +1,12 @@
+flows:
+  default:
+    - call: test
+      out:
+        v: ${x.y}
+
+    - log: "v: ${v}"
+
+  test:
+    - set:
+        x:
+          y: 123


### PR DESCRIPTION
```
flows:
  default:
    - call: test
      out:
        v: ${x.y}

    - log: "v: ${v}" # 123

  test:
    - set:
        x:
          y: 123
```