### PR TITLE
runtime-v2: support for expressions in `out` block of expr call step

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Expression.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Expression.java
@@ -23,7 +23,7 @@ package com.walmartlabs.concord.runtime.v2.model;
 public class Expression extends AbstractStep<ExpressionOptions> {
 
     public static Expression shortForm(Location location, String expr) {
-        return new Expression(location, expr, null);
+        return new Expression(location, expr, ExpressionOptions.builder().build());
     }
 
     private static final long serialVersionUID = 1L;

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ExpressionOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ExpressionOptions.java
@@ -20,12 +20,15 @@ package com.walmartlabs.concord.runtime.v2.model;
  * =====
  */
 
+import com.walmartlabs.concord.common.AllowNulls;
 import com.walmartlabs.concord.runtime.v2.parser.StepOptions;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true)
@@ -35,6 +38,12 @@ public interface ExpressionOptions extends StepOptions {
 
     @Nullable
     String out();
+
+    @Value.Default
+    @AllowNulls
+    default Map<String, Serializable> outExpr() {
+        return Collections.emptyMap();
+    }
 
     @Value.Default
     default List<Step> errorSteps() {

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
@@ -97,6 +97,7 @@ public final class YamlValueType<T> {
     public static final YamlValueType<ExclusiveModeConfiguration> EXCLUSIVE_MODE = type("EXCLUSIVE_MODE");
     public static final YamlValueType<EventConfiguration> EVENTS_CFG = type("EVENTS_CONFIGURATION");
     public static final YamlValueType<ImmutableTaskCallOptions.Builder> TASK_CALL_OUT = type("STRING or OBJECT");
+    public static final YamlValueType<ImmutableExpressionOptions.Builder> EXPRESSION_CALL_OUT = type("STRING or OBJECT");
 
     private final String name;
 

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/ExpressionStepSerializer.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/ExpressionStepSerializer.java
@@ -59,6 +59,8 @@ public class ExpressionStepSerializer extends StdSerializer<Expression> {
             gen.writeObjectField("out", options.out());
         }
 
+        writeNotEmptyObjectField("out", options.outExpr(), gen);
+
         writeNotEmptyObjectField("meta", options.meta(), gen);
         writeNotEmptyObjectField("error", options.errorSteps(), gen);
     }

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
@@ -261,7 +261,7 @@ public class ProjectSerializerV2Test extends AbstractParserTest {
 
 
     @Test
-    public void testProcessDefinition() throws Exception{
+    public void testProcessDefinition() throws Exception {
         Map<String, Form> forms = Collections.singletonMap("form1", Form.builder()
                 .name("form1")
                 .addFields(FormField.builder()

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectSerializerV2Test.java
@@ -219,6 +219,19 @@ public class ProjectSerializerV2Test extends AbstractParserTest {
     }
 
     @Test
+    public void testExprCallOutExpr() throws Exception {
+        ExpressionOptions opts = ExpressionOptions.builder()
+                .putOutExpr("out-result", "${result.first}")
+                .meta(meta())
+                .errorSteps(steps())
+                .build();
+
+        String result = toYaml(new Expression(location(), "${a}", opts));
+        assertResult("serializer/expressionStepOutExpr.yml", result);
+    }
+
+
+    @Test
     public void testProcessDefinition() throws Exception{
         Map<String, Form> forms = Collections.singletonMap("form1", Form.builder()
                 .name("form1")

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1121,7 +1121,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test602() throws Exception {
         String msg =
-                "(002.yml): Error @ line: 4, col: 11. Invalid value type, expected: STRING, got: NULL. Remove attribute or complete the definition\n" +
+                "(002.yml): Error @ line: 4, col: 11. Invalid value type, expected: STRING or OBJECT, got: NULL. Remove attribute or complete the definition\n" +
                         "\twhile processing steps:\n" +
                         "\t'out' @ line: 4, col: 7\n" +
                         "\t\t'expr' @ line: 3, col: 7\n" +
@@ -1134,7 +1134,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test603() throws Exception {
         String msg =
-                "(003.yml): Error @ line: 4, col: 12. Invalid value type, expected: STRING, got: INT\n" +
+                "(003.yml): Error @ line: 4, col: 12. Invalid value type, expected: STRING or OBJECT, got: INT\n" +
                         "\twhile processing steps:\n" +
                         "\t'out' @ line: 4, col: 7\n" +
                         "\t\t'expr' @ line: 3, col: 7\n" +
@@ -1142,19 +1142,6 @@ public class YamlErrorParserTest extends AbstractParserTest {
                         "\t\t\t\t'flows' @ line: 1, col: 1";
 
         assertErrorMessage("errors/expression/003.yml", msg);
-    }
-
-    @Test
-    public void test604() throws Exception {
-        String msg =
-                "(004.yml): Error @ line: 5, col: 9. Invalid value type, expected: STRING, got: OBJECT\n" +
-                        "\twhile processing steps:\n" +
-                        "\t'out' @ line: 4, col: 7\n" +
-                        "\t\t'expr' @ line: 3, col: 7\n" +
-                        "\t\t\t'main' @ line: 2, col: 3\n" +
-                        "\t\t\t\t'flows' @ line: 1, col: 1";
-
-        assertErrorMessage("errors/expression/004.yml", msg);
     }
 
     @Test

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -157,7 +157,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertTrue(t.getOptions().errorSteps().get(0) instanceof Expression);
         Expression errorStep = (Expression) t.getOptions().errorSteps().get(0);
         assertEquals("${booError}", errorStep.getExpr());
-        assertNull(errorStep.getOptions());
+        assertNotNull(errorStep.getOptions());
 
         // meta
         assertMeta("expression-call", t.getOptions());
@@ -182,7 +182,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertTrue(t.getOptions().errorSteps().get(0) instanceof Expression);
         Expression errorStep = (Expression) t.getOptions().errorSteps().get(0);
         assertEquals("${exp}", errorStep.getExpr());
-        assertNull(errorStep.getOptions());
+        assertNotNull(errorStep.getOptions());
 
         // withItems
         assertEquals("a", ((List<String>) t.getOptions().withItems().value()).get(0));

--- a/runtime/v2/model/src/test/resources/errors/expression/004.yml
+++ b/runtime/v2/model/src/test/resources/errors/expression/004.yml
@@ -1,5 +1,0 @@
-flows:
-  main:
-    - expr: "${boo}"
-      out:
-        k: "v"

--- a/runtime/v2/model/src/test/resources/serializer/expressionStepOutExpr.yml
+++ b/runtime/v2/model/src/test/resources/serializer/expressionStepOutExpr.yml
@@ -1,0 +1,11 @@
+expr: "${a}"
+out:
+  out-result: "${result.first}"
+meta:
+  meta-1: "v1"
+  meta-2: "v2"
+error:
+- checkpoint: "chp1"
+  meta:
+    meta-1: "v1"
+    meta-2: "v2"

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
@@ -25,12 +25,14 @@ import com.walmartlabs.concord.runtime.v2.model.ExpressionOptions;
 import com.walmartlabs.concord.runtime.v2.runner.el.EvalContextFactory;
 import com.walmartlabs.concord.runtime.v2.runner.el.ExpressionEvaluator;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
-import com.walmartlabs.concord.svm.Frame;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.State;
 import com.walmartlabs.concord.svm.ThreadId;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Evaluates the specified {@link Expression} step and (optionally) saves
@@ -46,29 +48,24 @@ public class ExpressionCommand extends StepCommand<Expression> {
 
     @Override
     protected void execute(Runtime runtime, State state, ThreadId threadId) {
-        Frame frame = state.peekFrame(threadId);
-        frame.pop();
+        state.peekFrame(threadId).pop();
 
         Context ctx = runtime.getService(Context.class);
 
         Expression step = getStep();
         String expr = step.getExpr();
 
-        ExpressionOptions opts = step.getOptions();
-        String out = opts != null ? opts.out() : null;
-
         ExpressionEvaluator ee = runtime.getService(ExpressionEvaluator.class);
-        Object v = ee.eval(EvalContextFactory.global(ctx), expr, Object.class);
+        Object result = ee.eval(EvalContextFactory.global(ctx), expr, Object.class);
 
-        if (out != null) {
-            if (v != null && !(v instanceof Serializable)) {
-                String msg = String.format("The expression's (%s) result is not a Serializable value, it cannot be saved as a flow variable: %s", expr, v.getClass());
-                throw new IllegalArgumentException(msg);
-            }
-
-            frame.setLocal(out, (Serializable) v);
-
-            // TODO common structure for results
+        ExpressionOptions opts = Objects.requireNonNull(step.getOptions());
+        if (!opts.outExpr().isEmpty()) {
+            ExpressionEvaluator expressionEvaluator = runtime.getService(ExpressionEvaluator.class);
+            Map<String, Object> vars = Collections.singletonMap("result", result);
+            Map<String, Serializable> out = expressionEvaluator.evalAsMap(EvalContextFactory.global(ctx, vars), opts.outExpr());
+            out.forEach((k, v) -> ctx.variables().set(k, v));
+        } else if (opts.out() != null) {
+            ctx.variables().set(opts.out(), result);
         }
     }
 

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -783,6 +783,17 @@ public class MainTest {
         assertLog(log, ".*result: some-value.*");
     }
 
+    @Test
+    public void testExprOutExpression() throws Exception {
+        deploy("exprOutExpr");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        byte[] log = run();
+        assertLog(log, ".*result: v.*");
+    }
+
     private void deploy(String resource) throws URISyntaxException, IOException {
         Path src = Paths.get(MainTest.class.getResource(resource).toURI());
         IOUtils.copy(src, workDir);

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/exprOutExpr/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/exprOutExpr/concord.yml
@@ -1,0 +1,7 @@
+flows:
+  default:
+    - expr: "${ {'k': 'v'} }"
+      out:
+        theThingIActuallyWanted: "${result.k}"
+
+    - log: "result: ${theThingIActuallyWanted}"


### PR DESCRIPTION
```
flows:
  default:
    - expr: "${ {'k': 'v'} }"
      out:
        theThingIActuallyWanted: "${result.k}"

    - log: "result: ${theThingIActuallyWanted}"
```