### PR TITLE
server: better error messages while processing imports

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentImportManagerProvider.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.nio.file.Path;
+import java.util.Objects;
 
 @Singleton
 public class AgentImportManagerProvider implements Provider<AgentImportManager> {
@@ -42,7 +43,7 @@ public class AgentImportManagerProvider implements Provider<AgentImportManager> 
 
             String entryDest = entry.dest();
             if (entry.dest() != null) {
-                dst = dst.resolve(entryDest);
+                dst = dst.resolve(Objects.requireNonNull(entryDest));
             }
 
             repositoryManager.export(entry.url(), entry.version(), null, entry.path(), dst, entry.secret(), entry.exclude());

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.cli;
  * =====
  */
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
 import com.walmartlabs.concord.cli.runner.*;
 import com.walmartlabs.concord.common.ConfigurationUtils;
@@ -27,6 +28,7 @@ import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.imports.ImportManager;
 import com.walmartlabs.concord.imports.ImportManagerFactory;
+import com.walmartlabs.concord.imports.ImportProcessingException;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinitionUtils;
 import com.walmartlabs.concord.process.loader.v2.ProcessDefinitionV2;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
@@ -136,9 +138,12 @@ public class Run implements Callable<Integer> {
 
         ProjectLoaderV2.Result loadResult;
         try {
-
             loadResult = new ProjectLoaderV2(importManager)
                     .load(targetDir, new CliImportsNormalizer(importsSource, verbose));
+        } catch (ImportProcessingException e) {
+            ObjectMapper om = new ObjectMapper();
+            System.err.println("Error while processing import " + om.writeValueAsString(e.getImport()) + ": " + e.getMessage());
+            return -1;
         } catch (Exception e) {
             System.err.println("Error while loading " + targetDir);
             e.printStackTrace();

--- a/imports/src/main/java/com/walmartlabs/concord/imports/DefaultImportManager.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/DefaultImportManager.java
@@ -56,7 +56,12 @@ public class DefaultImportManager implements ImportManager {
 
         for (Import i : items) {
             listener.beforeImport(i);
-            Snapshot s = assertProcessor(i.type()).process(i, dest);
+            Snapshot s;
+            try {
+                s = assertProcessor(i.type()).process(i, dest);
+            } catch (Exception e) {
+                throw new ImportProcessingException(i, e);
+            }
             listener.afterImport(i);
             result.add(s);
         }

--- a/imports/src/main/java/com/walmartlabs/concord/imports/ImportProcessingException.java
+++ b/imports/src/main/java/com/walmartlabs/concord/imports/ImportProcessingException.java
@@ -20,19 +20,16 @@ package com.walmartlabs.concord.imports;
  * =====
  */
 
-import java.util.List;
+public class ImportProcessingException extends Exception {
 
-public interface ImportsListener {
+    private final Import value;
 
-    default void onStart(List<Import> items) {
+    public ImportProcessingException(Import value, Exception e) {
+        super(e.getMessage(), e);
+        this.value = value;
     }
 
-    default void onEnd(List<Import> items) {
-    }
-
-    default void beforeImport(Import i) {
-    }
-
-    default void afterImport(Import i) {
+    public Import getImport() {
+        return value;
     }
 }

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitCliRepositoryProvider.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitCliRepositoryProvider.java
@@ -77,7 +77,7 @@ public class GitCliRepositoryProvider implements RepositoryProvider {
             }
         }
 
-        throw new RepositoryException("git fetch failed", lastException);
+        throw lastException;
     }
 
     @Override

--- a/repository/src/main/java/com/walmartlabs/concord/repository/RepositoryCache.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/RepositoryCache.java
@@ -96,7 +96,7 @@ public class RepositoryCache {
                 } catch (IllegalArgumentException e) {
                     throw e;
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException(e.getMessage(), e);
                 } finally {
                     l.unlock();
                 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ImportManagerProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ImportManagerProvider.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.UUID;
 
 @Named
@@ -80,7 +81,7 @@ public class ImportManagerProvider implements Provider<ImportManager> {
                 Repository repository = repositoryManager.fetch(entry.url(), entry.version(), null, entry.path(), secret);
                 Path dst = workDir;
                 if (entry.dest() != null) {
-                    dst = dst.resolve(entry.dest());
+                    dst = dst.resolve(Objects.requireNonNull(entry.dest()));
                 }
                 return repository.export(dst, entry.exclude());
             });

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/FailProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/FailProcessor.java
@@ -20,7 +20,6 @@ package com.walmartlabs.concord.server.process.pipelines.processors;
  * =====
  */
 
-import com.walmartlabs.concord.server.policy.PolicyException;
 import com.walmartlabs.concord.server.process.Payload;
 import com.walmartlabs.concord.server.process.logs.ProcessLogManager;
 import com.walmartlabs.concord.server.process.queue.ProcessQueueDao;
@@ -55,11 +54,8 @@ public class FailProcessor implements ExceptionProcessor {
             return;
         }
 
-        if (e instanceof PolicyException) {
-            logManager.error(processKey, "Process failed: {}", e.getMessage());
-        } else {
-            logManager.error(processKey, "Process failed: {}", e.getMessage(), e);
-        }
+        logManager.error(processKey, "Process failed: {}", e.getMessage());
+
         queueManager.updateStatus(processKey, ProcessStatus.FAILED);
     }
 }


### PR DESCRIPTION
now:
```
12:50:41 [INFO ] Storing policy '[concord-base]' data
12:51:14 [ERROR] Process failed: Error while processing import {
  "type" : "git",
  "url" : "https://github.com/walmartlabs/concord.git",
  "version" : "xxx",
  "path" : "examples/hello_world",
  "dest" : "concord"
}. Error: Couldn't find any revision to build. Verify the repository and branch configuration.
```

before:
```
19:08:51 [ERROR] Process failed: Error while loading the project, check the syntax. com.walmartlabs.concord.repository.RepositoryException: git fetch failed
com.walmartlabs.concord.server.process.ProcessException: Error while loading the project, check the syntax. com.walmartlabs.concord.repository.RepositoryException: git fetch failed
	at com.walmartlabs.concord.server.process.pipelines.processors.ProcessDefinitionProcessor.process(ProcessDefinitionProcessor.java:105)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.AttachmentStoringProcessor.process(AttachmentStoringProcessor.java:63)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.ansible.InventoryProcessor.process(InventoryProcessor.java:62)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.RepositoryInfoUpdateProcessor.process(RepositoryInfoUpdateProcessor.java:67)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.RepositoryProcessor.process(RepositoryProcessor.java:122)
	at com.walmartlabs.concord.server.metrics.MetricInterceptor.invoke(MetricInterceptor.java:54)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.WorkspaceArchiveProcessor.process(WorkspaceArchiveProcessor.java:56)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.PolicyExportProcessor.process(PolicyExportProcessor.java:83)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.PayloadRestoreProcessor.process(PayloadRestoreProcessor.java:82)
	at com.walmartlabs.concord.server.metrics.MetricInterceptor.invoke(MetricInterceptor.java:54)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.LoggingMDCProcessor.process(LoggingMDCProcessor.java:34)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.RunAsCurrentProcessUserProcessor.lambda$0(RunAsCurrentProcessUserProcessor.java:40)
	at com.walmartlabs.concord.server.process.ProcessSecurityContext.runAsCurrentUser(ProcessSecurityContext.java:140)
	at com.walmartlabs.concord.server.process.pipelines.processors.RunAsCurrentProcessUserProcessor.process(RunAsCurrentProcessUserProcessor.java:40)
	at com.walmartlabs.concord.server.process.pipelines.processors.Chain.process(Chain.java:47)
	at com.walmartlabs.concord.server.process.pipelines.processors.Pipeline.process(Pipeline.java:42)
	at com.walmartlabs.concord.server.process.queue.EnqueuedBatchTask$Worker.startProcess(EnqueuedBatchTask.java:222)
	at com.walmartlabs.concord.server.process.queue.EnqueuedBatchTask$Worker.startProcessBatch(EnqueuedBatchTask.java:208)
	at com.walmartlabs.concord.server.process.queue.EnqueuedBatchTask$Worker.run(EnqueuedBatchTask.java:180)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: com.walmartlabs.concord.repository.RepositoryException: git fetch failed
	at com.walmartlabs.concord.repository.RepositoryCache.withLock(RepositoryCache.java:99)
	at com.walmartlabs.concord.repository.RepositoryCache.withLock(RepositoryCache.java:84)
	at com.walmartlabs.concord.server.repository.RepositoryManager.withLock(RepositoryManager.java:152)
	at com.walmartlabs.concord.server.ImportManagerProvider$RepositoryExporterImpl.export(ImportManagerProvider.java:79)
	at com.walmartlabs.concord.imports.RepositoryProcessor.process(RepositoryProcessor.java:43)
	at com.walmartlabs.concord.imports.RepositoryProcessor.process(RepositoryProcessor.java:1)
	at com.walmartlabs.concord.imports.DefaultImportManager.process(DefaultImportManager.java:59)
	at com.walmartlabs.concord.project.ProjectLoader.loadProject(ProjectLoader.java:83)
	at com.walmartlabs.concord.process.loader.ProjectLoader.loadProject(ProjectLoader.java:70)
	at com.walmartlabs.concord.server.process.pipelines.processors.ProcessDefinitionProcessor.process(ProcessDefinitionProcessor.java:79)
	... 32 more
Caused by: com.walmartlabs.concord.repository.RepositoryException: git fetch failed
	at com.walmartlabs.concord.repository.GitCliRepositoryProvider.fetch(GitCliRepositoryProvider.java:80)
	at com.walmartlabs.concord.repository.RepositoryProviders.fetch(RepositoryProviders.java:39)
	at com.walmartlabs.concord.server.repository.RepositoryManager.fetch(RepositoryManager.java:132)
	at com.walmartlabs.concord.server.repository.RepositoryManager.fetch(RepositoryManager.java:123)
	at com.walmartlabs.concord.server.ImportManagerProvider$RepositoryExporterImpl.lambda$0(ImportManagerProvider.java:80)
	at com.walmartlabs.concord.repository.RepositoryCache.withLock(RepositoryCache.java:95)
	... 41 more
Caused by: com.walmartlabs.concord.repository.RepositoryException: Couldn't find any revision to build. Verify the repository and branch configuration.
	at com.walmartlabs.concord.repository.GitClient.getBranchRevision(GitClient.java:311)
	at com.walmartlabs.concord.repository.GitClient.fetch(GitClient.java:117)
	at com.walmartlabs.concord.repository.GitCliRepositoryProvider.fetch(GitCliRepositoryProvider.java:69)
	... 46 more
```