### PR TITLE
concord-tasks: fix "global" parameters not being inherited by "forks"

### DIFF
--- a/plugins/tasks/concord/pom.xml
+++ b/plugins/tasks/concord/pom.xml
@@ -70,6 +70,12 @@
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
@@ -675,7 +675,7 @@ public class ConcordTask extends AbstractConcordTask {
 
     private String getProcessUrl(Context ctx, UUID processId) {
         String action = ContextUtils.getString(ctx, ACTION_KEY);
-        if (Action.STARTEXTERNAL.name().equalsIgnoreCase(action)  || uiLinks == null) {
+        if (Action.STARTEXTERNAL.name().equalsIgnoreCase(action) || uiLinks == null) {
             return "n/a";
         }
 

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskParams.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskParams.java
@@ -271,7 +271,22 @@ public class ConcordTaskParams {
                 forks = Collections.singletonList(new ForkStartParams(variables));
             } else {
                 forks = forksValue.stream()
-                        .map(f -> new ForkStartParams(new MapBackedVariables(f), outVars()))
+                        .map(f -> {
+                            // some parameters (e.g. tags) can be defined for either an "forks" entry or "globally"
+                            // for example:
+                            // - task: concord
+                            //   in:
+                            //     tags: ["red"]
+                            //     forks:
+                            //       - entryPoint: "x" // inherits tags value
+                            //       - entryPoint: "y"
+                            //         tags: ["green"] // provides its own tags
+                            //
+                            // that's why here we're using DelegateVariables which looks for keys in
+                            // the "forks" entry first and then falls back to the "global" section.
+                            Variables vars = new DelegateVariables(new MapBackedVariables(f), variables);
+                            return new ForkStartParams(vars, outVars());
+                        })
                         .collect(Collectors.toList());
             }
 
@@ -442,5 +457,44 @@ public class ConcordTaskParams {
         STARTEXTERNAL,
         FORK,
         KILL
+    }
+
+    private static class DelegateVariables implements Variables {
+
+        private final Variables[] delegates;
+
+        public DelegateVariables(Variables... delegates) {
+            this.delegates = delegates;
+        }
+
+        @Override
+        public Object get(String key) {
+            for (Variables delegate : delegates) {
+                if (delegate.has(key)) {
+                    return delegate.get(key);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void set(String key, Object value) {
+            throw new IllegalStateException("Not supported");
+        }
+
+        @Override
+        public boolean has(String key) {
+            for (Variables delegate : delegates) {
+                if (delegate.has(key)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Map<String, Object> toMap() {
+            throw new IllegalStateException("Not supported");
+        }
     }
 }

--- a/plugins/tasks/concord/src/test/java/com/walmartlabs/concord/client/ConcordTaskParamsTest.java
+++ b/plugins/tasks/concord/src/test/java/com/walmartlabs/concord/client/ConcordTaskParamsTest.java
@@ -1,0 +1,62 @@
+package com.walmartlabs.concord.client;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.client.ConcordTaskParams.ForkParams;
+import com.walmartlabs.concord.client.ConcordTaskParams.ForkStartParams;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConcordTaskParamsTest {
+
+    @Test
+    public void testForks() {
+        List<String> tags = Arrays.asList("x", "y", "z");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("action", "fork");
+        input.put("tags", tags);
+        input.put("forks", Arrays.asList(
+                Collections.singletonMap("entryPoint", "aaa"),
+                Collections.singletonMap("entryPoint", "bbb")
+        ));
+
+        ForkParams params = (ForkParams) ConcordTaskParams.of(new MapBackedVariables(input));
+
+        List<ForkStartParams> forks = params.forks();
+        assertEquals(2, forks.size());
+
+        ForkStartParams f1 = forks.get(0);
+        assertEquals("aaa", f1.entryPoint());
+        assertTrue(f1.tags().containsAll(tags));
+
+        ForkStartParams f2 = forks.get(1);
+        assertEquals("bbb", f2.entryPoint());
+        assertTrue(f2.tags().containsAll(tags));
+
+        System.out.println(params);
+    }
+}


### PR DESCRIPTION
In v1 version of the task, `forks` entries inherit "global" values (such as `tags`). This PR makes the v2 version of the task behave in the same way.

Test case:

```yaml
configuration:
  runtime: "concord-v2"

flows:
  default:
    - task: concord
      in:
        action: fork
        tags:
          - "xyz"
        forks:
          - entryPoint: sayHello # doesn't inherit "tags"
        sync: true
```