### PR TITLE
concord-tasks: 'kill' shouldn't error on empty instanceId lists

### DIFF
--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
@@ -616,8 +616,13 @@ public class ConcordTask extends AbstractConcordTask {
     }
 
     private void killMany(Context ctx, Map<String, Object> cfg, List<String> instanceIds) throws Exception {
-        if (instanceIds == null || instanceIds.isEmpty()) {
+        if (instanceIds == null) {
             throw new IllegalArgumentException("'" + INSTANCE_ID_KEY + "' should be a single value or an array of values: " + instanceIds);
+        }
+
+        if (instanceIds.isEmpty()) {
+            log.warn("kill: no process IDs specified, nothing to do.");
+            return;
         }
 
         for (String id : instanceIds) {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -162,7 +162,13 @@ public class ConcordTaskCommon {
     }
 
     public void kill(KillParams in) throws Exception {
-        for (UUID id : in.ids()) {
+        List<UUID> instanceIds = in.ids();
+        if (instanceIds.isEmpty()) {
+            log.warn("kill: no process IDs specified, nothing to do.");
+            return;
+        }
+
+        for (UUID id : instanceIds) {
             withClient(client -> {
                 ProcessApi api = new ProcessApi(client);
                 api.kill(id);

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskParams.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskParams.java
@@ -409,10 +409,6 @@ public class ConcordTaskParams {
                 throw new IllegalArgumentException("'" + INSTANCE_ID_KEY + "' should be a single string, an UUID value or an array of strings or UUIDs: " + v);
             }
 
-            if (ids.isEmpty()) {
-                throw new IllegalArgumentException("'" + INSTANCE_ID_KEY + "' should be a single value or an array of values: " + ids);
-            }
-
             return ids;
         }
 


### PR DESCRIPTION
E.g.
```
- task: concord
  in:
    action: kill
    instanceId: [] # empty list, produced by (for example) ${concord.listSubprocesses(...)}
```