### PR TITLE
Process-requirement-api: filter to consider list of agent flavors

### DIFF
--- a/server/db/src/main/java/com/walmartlabs/concord/db/PgUtils.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/PgUtils.java
@@ -80,6 +80,14 @@ public final class PgUtils {
         return cause instanceof PSQLException && ((PSQLException) e.getCause()).getSQLState().equals("23505");
     }
 
+    public static Condition jsonbTextExistsByPath(Field<JSONB> field, List<String> path, String value) {
+        return DSL.condition("{0} #> {1} ?? {2}", field, inline(toPath(path)), DSL.value(value));
+    }
+
+    public static Condition jsonbTextNotExistsByPath(Field<JSONB> field, List<String> path, String value) {
+        return DSL.condition("not {0} #> {1} ?? {2}", field, inline(toPath(path)), DSL.value(value));
+    }
+
     private static String toPath(List<String> path) {
         return "{" + String.join(",", path) + "}";
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/FilterUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/FilterUtils.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.walmartlabs.concord.db.PgUtils.jsonbTextByPath;
+import static com.walmartlabs.concord.db.PgUtils.*;
 import static org.jooq.impl.DSL.currentOffsetDateTime;
 
 public final class FilterUtils {
@@ -145,11 +145,11 @@ public final class FilterUtils {
                     break;
                 }
                 case EQUALS: {
-                    q.addConditions(jsonbTextByPath(column, f.path()).eq(f.value()));
+                    q.addConditions(jsonbTextExistsByPath(column, f.path(),f.value()));
                     break;
                 }
                 case NOT_EQUALS: {
-                    q.addConditions(jsonbTextByPath(column, f.path()).notEqual(f.value()));
+                    q.addConditions(jsonbTextNotExistsByPath(column, f.path(),f.value()));
                     break;
                 }
                 case STARTS_WITH: {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/FilterUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/FilterUtils.java
@@ -145,11 +145,11 @@ public final class FilterUtils {
                     break;
                 }
                 case EQUALS: {
-                    q.addConditions(jsonbTextExistsByPath(column, f.path(),f.value()));
+                    q.addConditions(jsonbTextExistsByPath(column, f.path(), f.value()));
                     break;
                 }
                 case NOT_EQUALS: {
-                    q.addConditions(jsonbTextNotExistsByPath(column, f.path(),f.value()));
+                    q.addConditions(jsonbTextNotExistsByPath(column, f.path(), f.value()));
                     break;
                 }
                 case STARTS_WITH: {


### PR DESCRIPTION
Add condition to consider the process when flavours are given as list in requirements i,e more than one flavour

for ex: `{"agent": {"flavor": ["k8s-s-w3", "k8s-kitt", "k8s-s-w2"]}}`