### PR TITLE
runtime-v2: add support for nested log segments

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/DefaultLoggingClient.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/DefaultLoggingClient.java
@@ -49,14 +49,18 @@ public class DefaultLoggingClient implements LoggingClient {
         this.cfg = cfg;
     }
 
-    public long createSegment(UUID correlationId, String name) {
+    @Override
+    public long createSegment(LogSegment logSegment) {
         LogSegmentRequest request = new LogSegmentRequest()
-                .setCorrelationId(correlationId)
+                .setParentSegmentId(logSegment.parentSegmentId())
+                .setCorrelationId(logSegment.correlationId())
                 .setCreatedAt(OffsetDateTime.now(ZoneId.of("UTC")))
-                .setName(name);
+                .setName(logSegment.name());
 
         try {
-            LogSegmentOperationResponse result = ClientUtils.withRetry(cfg.api().retryCount(), cfg.api().retryInterval(), () -> api.segment(instanceId, request));
+            LogSegmentOperationResponse result = ClientUtils.withRetry(cfg.api().retryCount(), cfg.api().retryInterval(),
+                    () -> api.segment(instanceId, request));
+
             return result.getId();
         } catch (ApiException e) {
             throw new RuntimeException(e);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogContext.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogContext.java
@@ -32,6 +32,9 @@ public interface LogContext {
     String segmentName();
 
     @Nullable
+    Long parentSegmentId();
+
+    @Nullable
     Long segmentId();
 
     UUID correlationId();

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogSegment.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogSegment.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.runtime.v2;
+package com.walmartlabs.concord.runtime.v2.runner.logging;
 
 /*-
  * *****
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,23 @@ package com.walmartlabs.concord.runtime.v2;
  * =====
  */
 
-public final class Constants {
+import org.immutables.value.Value;
 
-    public static final String SEGMENT_NAME = "segmentName";
-    public static final String SEGMENT_GROUP = "segmentGroup";
-    public static final String LOG_LEVEL = "logLevel";
+import javax.annotation.Nullable;
+import java.util.UUID;
 
-    private Constants() {
+@Value.Immutable
+public interface LogSegment {
+
+    @Nullable
+    Long parentSegmentId();
+
+    @Nullable
+    UUID correlationId();
+
+    String name();
+
+    static ImmutableLogSegment.Builder builder() {
+        return ImmutableLogSegment.builder();
     }
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LoggingClient.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LoggingClient.java
@@ -20,9 +20,13 @@ package com.walmartlabs.concord.runtime.v2.runner.logging;
  * =====
  */
 
-import java.util.UUID;
-
 public interface LoggingClient {
 
-    long createSegment(UUID correlationId, String name);
+    /**
+     * Creates a new log segment.
+     *
+     * @param segment
+     * @return the segment's ID
+     */
+    long createSegment(LogSegment segment);
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.runtime.v2.runner.vm;
  * =====
  */
 
+import com.sun.corba.se.impl.protocol.giopmsgheaders.FragmentMessage;
 import com.walmartlabs.concord.runtime.v2.model.FlowCall;
 import com.walmartlabs.concord.runtime.v2.model.FlowCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
@@ -88,7 +89,17 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         }
 
         // push the out handler first so it executes after the called flow's frame is done
-        state.peekFrame(threadId).push(processOutVars);
+        Frame outerFrame = state.peekFrame(threadId);
+        outerFrame.push(processOutVars);
+        outerFrame.push(new Command() { // TODO
+            @Override
+            public void eval(Runtime runtime, State state, ThreadId threadId) throws Exception {
+                Frame f = state.peekFrame(threadId);
+                f.pop();
+                f.removeLocal("__parentSegmentId");
+            }
+        });
+
         state.pushFrame(threadId, innerFrame);
     }
 

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/nestedLogSegments/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/nestedLogSegments/concord.yml
@@ -1,0 +1,26 @@
+flows:
+  default:
+    - call: flowA
+      meta:
+        segmentGroup: groupA
+
+    - call: flowB
+      meta:
+        segmentGroup: groupB
+
+  flowA:
+    - name: A1
+      log: "uno"
+    - name: A2
+      log: "dos"
+
+  flowB:
+    - name: B1
+      log: "tres"
+    - call: flowC
+      meta:
+        segmentGroup: groupC
+
+  flowC:
+    - name: C1
+      log: "quatro"

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
@@ -109,6 +109,10 @@ public class Frame implements Serializable {
         return Collections.unmodifiableMap(locals);
     }
 
+    public Serializable removeLocal(String k) {
+        return locals.remove(k);
+    }
+
     public static class Builder {
 
         private FrameType type = FrameType.ROOT;

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -91,5 +91,6 @@
     <include file="v1.60.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.66.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.69.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.74.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.74.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.74.0.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="1740000" author="ibodrov@gmail.com">
+        <addColumn tableName="PROCESS_LOG_SEGMENTS">
+            <column name="PARENT_SEGMENT_ID" type="bigint">
+                <constraints nullable="true"/>
+            </column>
+            <column name="SEGMENT_META" type="jsonb">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/LogSegmentRequest.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/LogSegmentRequest.java
@@ -39,6 +39,9 @@ public interface LogSegmentRequest {
     @Nullable
     UUID correlationId();
 
+    @Nullable
+    Long parentSegmentId();
+
     String name();
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessLogResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessLogResourceV2.java
@@ -113,7 +113,11 @@ public class ProcessLogResourceV2 implements Resource {
                                                @ApiParam LogSegmentRequest request) {
 
         ProcessKey processKey = logAccessManager.assertLogAccess(instanceId);
-        long segmentId = logManager.createSegment(processKey, request.correlationId(), request.name(), request.createdAt());
+        long segmentId = logManager.createSegment(processKey,
+                request.parentSegmentId(),
+                request.correlationId(),
+                request.name(),
+                request.createdAt());
         return new LogSegmentOperationResponse(segmentId, OperationResult.CREATED);
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/logs/ProcessLogManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/logs/ProcessLogManager.java
@@ -90,11 +90,11 @@ public class ProcessLogManager {
         logsDao.createSegment(tx, SYSTEM_SEGMENT_ID, processKey, null, SYSTEM_SEGMENT_NAME, null);
     }
 
-    public long createSegment(ProcessKey processKey, UUID correlationId, String name, OffsetDateTime createdAt) {
+    public long createSegment(ProcessKey processKey, Long parentSegmentId, UUID correlationId, String name, OffsetDateTime createdAt) {
         if (SYSTEM_SEGMENT_NAME.equals(name)) {
             return SYSTEM_SEGMENT_ID;
         }
-        return logsDao.createSegment(processKey, correlationId, name, createdAt, LogSegment.Status.RUNNING.name());
+        return logsDao.createSegment(processKey, parentSegmentId, correlationId, name, createdAt, LogSegment.Status.RUNNING.name());
     }
 
     public void updateSegment(ProcessKey processKey, long segmentId, LogSegment.Status status, Integer warnings, Integer errors) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/logs/ProcessLogsDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/logs/ProcessLogsDao.java
@@ -79,16 +79,24 @@ public class ProcessLogsDao extends AbstractDao {
         return PgIntRange.parse(r.getLogRange().toString());
     }
 
-    public long createSegment(ProcessKey processKey, UUID correlationId, String name, OffsetDateTime createdAt, String status) {
+    public long createSegment(ProcessKey processKey,
+                              Long parentSegmentId,
+                              UUID correlationId,
+                              String name,
+                              OffsetDateTime createdAt,
+                              String status) {
+
         return txResult(tx -> tx.insertInto(PROCESS_LOG_SEGMENTS)
                 .columns(PROCESS_LOG_SEGMENTS.INSTANCE_ID,
                         PROCESS_LOG_SEGMENTS.INSTANCE_CREATED_AT,
+                        PROCESS_LOG_SEGMENTS.PARENT_SEGMENT_ID,
                         PROCESS_LOG_SEGMENTS.CORRELATION_ID,
                         PROCESS_LOG_SEGMENTS.SEGMENT_NAME,
                         PROCESS_LOG_SEGMENTS.SEGMENT_TS,
                         PROCESS_LOG_SEGMENTS.SEGMENT_STATUS)
                 .values(value(processKey.getInstanceId()),
                         value(processKey.getCreatedAt()),
+                        parentSegmentId != null ? value(parentSegmentId) : null,
                         value(correlationId), value(name),
                         createdAt != null ? value(createdAt) : currentOffsetDateTime(),
                         value(status))


### PR DESCRIPTION
Initial support for nested log segments. For now it's just an experiment.

TODO:
- syntax sugar for `meta.segmentGroup` (similarly to `meta.segmentName`)
- allow additional metadata (e.g. thread #) in `LogSegmentRequest`;
- update the UI to pull in the new data;
- test with `parallel` and `parallelWithItems`;
- update serializers if needed; 
- clean up the code