### PR TITLE
runtime-v2, concord-console: record post events for failed tasks, mark failed tasks on the events tab

### DIFF
--- a/console2/src/api/process/event/index.ts
+++ b/console2/src/api/process/event/index.ts
@@ -47,6 +47,7 @@ export interface ProcessElementEvent {
     out?: VariableMapping[] | {};
     correlationId?: string;
     duration?: number;
+    error?: string;
 }
 
 export type ProcessEventData = ProcessElementEvent | AnsibleEvent | {};

--- a/console2/src/components/molecules/ProcessElementList/index.tsx
+++ b/console2/src/components/molecules/ProcessElementList/index.tsx
@@ -140,7 +140,10 @@ const renderElementRow = (
     return (
         <Table.Row key={idx}>
             <Table.Cell textAlign="right">{renderDefinitionId(ev, idx, arr)}</Table.Cell>
-            <Table.Cell verticalAlign={'middle'} style={{ wordBreak: 'break-all' }}>
+            <Table.Cell
+                verticalAlign={'middle'}
+                style={{ wordBreak: 'break-all' }}
+                className={ev.data.error !== undefined ? 'error' : ''}>
                 {ev.data.description}
                 {renderRestoreCheckpoint(instanceId, processStatus, ev.data.out)}
             </Table.Cell>

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/resolvers/TaskMethodResolver.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/resolvers/TaskMethodResolver.java
@@ -71,6 +71,8 @@ public class TaskMethodResolver extends javax.el.BeanELResolver {
                     () -> super.invoke(elContext, base, method, paramTypes, params));
         } catch (javax.el.MethodNotFoundException e) {
             throw new MethodNotFoundException(base, method, paramTypes);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/TaskCallEventRecordingListener.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/TaskCallEventRecordingListener.java
@@ -112,7 +112,9 @@ public class TaskCallEventRecordingListener implements TaskCallListener {
         m.put("name", taskName);
 
         m.put("correlationId", event.correlationId());
-
+        if (event.error() != null) {
+            m.put("error", event.error());
+        }
         return m;
     }
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallEvent.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallEvent.java
@@ -59,6 +59,9 @@ public interface TaskCallEvent {
     @Nullable
     Serializable result();
 
+    @Nullable
+    String error();
+
     static ImmutableTaskCallEvent.Builder builder() {
         return ImmutableTaskCallEvent.builder();
     }


### PR DESCRIPTION
<img width="1145" alt="Screenshot 2020-11-29 at 14 58 20" src="https://user-images.githubusercontent.com/980726/100541221-5b473600-3253-11eb-91dd-2640b940946d.png">
