### PR TITLE
server: new github trigger condition repositoryInfo.enabled

### DIFF
--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -91,5 +91,6 @@
     <include file="v1.60.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.66.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.69.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.75.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.75.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.75.0.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="1750000" author="ybrigo@gmail.com" runInTransaction="false">
+        <sql>
+            update TRIGGERS set CONDITIONS = '{"version": 2, "type": "push", "branch": ".*", "githubOrg": ".*", "githubRepo": ".*", "repositoryInfo": [{"repository": ".*", "enabled": true}]}'
+            where
+            PROJECT_ID = '${concordTriggersProjectId}'
+            and EVENT_SOURCE = 'github'
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/GithubEventResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/GithubEventResource.java
@@ -168,7 +168,7 @@ public class GithubEventResource implements Resource {
         }
         startedProcessesPerEvent.update(startedProcesses);
 
-        log.info("onEvent ['{}', '{}'] -> done, started processes: {}", deliveryId, eventName, startedProcesses);
+        log.info("onEvent ['{}', '{}'] -> done, started process count: {}", deliveryId, eventName, startedProcesses);
 
         return "ok";
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/GithubEventResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/GithubEventResource.java
@@ -168,6 +168,8 @@ public class GithubEventResource implements Resource {
         }
         startedProcessesPerEvent.update(startedProcesses);
 
+        log.info("onEvent ['{}', '{}'] -> done, started processes: {}", deliveryId, eventName, startedProcesses);
+
         return "ok";
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Constants.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/Constants.java
@@ -34,6 +34,7 @@ public final class Constants {
     public static final String REPO_BRANCH_KEY = "branch";
     public static final String REPO_ID_KEY = "repositoryId";
     public static final String REPO_NAME_KEY = "repository";
+    public static final String REPO_ENABLED_KEY = "enabled";
     public static final String SENDER_KEY = "sender";
     public static final String STATUS_KEY = "status";
     public static final String TYPE_KEY = "type";

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
@@ -177,6 +177,7 @@ public class GithubTriggerV2Processor implements GithubTriggerProcessor {
                 repositoryInfo.put(REPO_NAME_KEY, r.getName());
                 repositoryInfo.put(PROJECT_ID_KEY, r.getProjectId());
                 repositoryInfo.put(REPO_BRANCH_KEY, r.getBranch() != null ? r.getBranch() : GitConstants.DEFAULT_BRANCH);
+                repositoryInfo.put(REPO_ENABLED_KEY, !r.isDisabled());
 
                 repositoryInfos.add(repositoryInfo);
             }

--- a/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
+++ b/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
@@ -24,5 +24,6 @@ triggers:
         githubRepo: ".*"
         branch: ".*"
         repositoryInfo:
-          # trigger only for registered repos (i.e. added to Concord)
+          # trigger only for registered enabled repos (i.e. added to Concord)
           - repository: ".*"
+            enabled: true


### PR DESCRIPTION
```
  - github:
      version: 2
      entryPoint: "onChange"
      conditions:
        type: "push"
        ...
        repositoryInfo:
          # trigger only for registered enabled repos (i.e. added to Concord)
          - repository: ".*"
            enabled: true
```