### PR TITLE
git-client: preserve MDC in threads

### DIFF
--- a/common/src/main/java/com/walmartlabs/concord/common/LogUtils.java
+++ b/common/src/main/java/com/walmartlabs/concord/common/LogUtils.java
@@ -60,11 +60,15 @@ public final class LogUtils {
     public static Runnable withMdc(Runnable runnable) {
         Map<String, String> mdc = MDC.getCopyOfContextMap();
         return () -> {
-            MDC.setContextMap(mdc);
+            if (mdc != null) {
+                MDC.setContextMap(mdc);
+            }
             try {
                 runnable.run();
             } finally {
-                MDC.clear();
+                if (mdc != null) {
+                    MDC.clear();
+                }
             }
         };
     }
@@ -72,11 +76,15 @@ public final class LogUtils {
     public static <T> Callable<T> withMdc(Callable<T> callable) {
         Map<String, String> mdc = MDC.getCopyOfContextMap();
         return () -> {
-            MDC.setContextMap(mdc);
+            if (mdc != null) {
+                MDC.setContextMap(mdc);
+            }
             try {
                 return callable.call();
             } finally {
-                MDC.clear();
+                if (mdc != null) {
+                    MDC.clear();
+                }
             }
         };
     }

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -30,7 +30,6 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.io.*;
 import java.nio.charset.Charset;


### PR DESCRIPTION
after:
```
16:36:13.488 [pool-2-thread-2] [INFO ] [a7bdce60-b995-433f-8bfe-2c3d39676bac] c.w.concord.repository.GitClient - > git rev-parse HEAD
16:36:13.496 [pool-1-thread-6] [INFO ] [a7bdce60-b995-433f-8bfe-2c3d39676bac] c.w.concord.repository.GitClient - GIT (stdout): 7b1d5d6e26b725692c7fd60ac4b04b23db7dde71
```

before:
```
16:36:13.488 [pool-2-thread-2] [INFO ] [a7bdce60-b995-433f-8bfe-2c3d39676bac] c.w.concord.repository.GitClient - > git rev-parse HEAD
16:36:13.496 [pool-1-thread-6] [INFO ] [] c.w.concord.repository.GitClient - GIT (stdout): 7b1d5d6e26b725692c7fd60ac4b04b23db7dde71
```