### PR TITLE
runtime-v1, runtime-v2: more retryable docker pull errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ tasks, highlight failed tasks on the events tab.
 
 ### Changed
 
+- runtime-v1, runtime-v2: update the list of "retryable" errors
+for `docker pull` operations to support recent versions of 
+docker-client;
 - concord-console: add scrolling to the last error popup, trigger
 information popup and the task call details popup;
 - concord-repository: preserve the logger's MDC when logging

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/DockerServiceImpl.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/DockerServiceImpl.java
@@ -49,7 +49,8 @@ public class DockerServiceImpl implements DockerService {
 
     private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
             Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
-            Pattern.compile("Error response from daemon.*Get.*connection refused.*")
+            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
     };
 
     private final List<String> extraVolumes;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultDockerService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultDockerService.java
@@ -49,7 +49,8 @@ public class DefaultDockerService implements DockerService {
 
     private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
             Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
-            Pattern.compile("Error response from daemon.*Get.*connection refused.*")
+            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
     };
 
     private final WorkingDirectory workingDirectory;


### PR DESCRIPTION
Recent docker-client versions use different wording for `docker pull`
errors in case if the registry is unavailable.

```
> docker --version
Docker version 19.03.14, build 5eb3275d40
> docker pull localhost:12345/non-existing
Using default tag: latest
Error response from daemon: Get http://localhost:12345/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```