### PR TITLE
policy-engine: policy to rewrite dependency versions

### DIFF
--- a/policy-engine/pom.xml
+++ b/policy-engine/pom.xml
@@ -42,6 +42,10 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/DependencyRewritePolicy.java
+++ b/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/DependencyRewritePolicy.java
@@ -1,0 +1,102 @@
+package com.walmartlabs.concord.policyengine;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2018 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.walmartlabs.concord.dependencymanager.DependencyManager.MAVEN_SCHEME;
+import static com.walmartlabs.concord.policyengine.Utils.matches;
+
+public class DependencyRewritePolicy {
+
+    private final List<DependencyRewriteRule> rules;
+
+    public DependencyRewritePolicy(List<DependencyRewriteRule> rules) {
+        this.rules = rules;
+    }
+
+    public Collection<URI> rewrite(Collection<URI> dependencies, RewriteListener listener) {
+        if (rules == null || rules.isEmpty() || dependencies.isEmpty()) {
+            return dependencies;
+        }
+
+        List<URI> result = new ArrayList<>(dependencies.size());
+        for (URI u : dependencies) {
+            result.add(rewrite(u, listener));
+        }
+        return result;
+    }
+
+    private URI rewrite(URI value, RewriteListener listener) {
+        String scheme = value.getScheme();
+        if (!MAVEN_SCHEME.equalsIgnoreCase(scheme)) {
+            return value;
+        }
+
+        Artifact artifact = new DefaultArtifact(value.getAuthority());
+        for (DependencyRewriteRule rule : rules) {
+            if (match(rule, artifact)) {
+                listener.onRewrite(rule.getMsg(), value, rule.getValue());
+                return rule.getValue();
+            }
+        }
+
+        return value;
+    }
+
+    private static boolean match(DependencyRewriteRule r, Artifact a) {
+        if (r.getGroupId() != null && !matches(r.getGroupId(), a.getGroupId())) {
+            return false;
+        }
+
+        if (r.getArtifactId() != null && !matches(r.getArtifactId(), a.getArtifactId())) {
+            return false;
+        }
+
+        if (r.getFromVersion() != null && compareVersions(r.getFromVersion(), a.getVersion()) > 0) {
+            return false;
+        }
+
+        if (r.getToVersion() != null && compareVersions(r.getToVersion(), a.getVersion()) < 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int compareVersions(String a, String b) {
+        ComparableVersion v1 = new ComparableVersion(a);
+        ComparableVersion v2 = new ComparableVersion(b);
+        return v1.compareTo(v2);
+    }
+
+    public interface RewriteListener {
+
+        void onRewrite(String msg, URI from, URI to);
+    }
+}

--- a/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/DependencyRewriteRule.java
+++ b/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/DependencyRewriteRule.java
@@ -1,0 +1,104 @@
+package com.walmartlabs.concord.policyengine;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2018 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Objects;
+
+public class DependencyRewriteRule implements Serializable {
+
+    private final String msg;
+    private final String groupId;
+    private final String artifactId;
+    private final String fromVersion;
+    private final String toVersion;
+    private final URI value;
+
+    @JsonCreator
+    public DependencyRewriteRule(
+            @JsonProperty("msg") String msg,
+            @JsonProperty("groupId") String groupId,
+            @JsonProperty("artifactId") String artifactId,
+            @JsonProperty("fromVersion") String fromVersion,
+            @JsonProperty("toVersion") String toVersion,
+            @JsonProperty("value") URI value) {
+
+        this.msg = msg;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.fromVersion = fromVersion;
+        this.toVersion = toVersion;
+        this.value = value;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getFromVersion() {
+        return fromVersion;
+    }
+
+    public String getToVersion() {
+        return toVersion;
+    }
+
+    public URI getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DependencyRewriteRule that = (DependencyRewriteRule) o;
+        return Objects.equals(msg, that.msg) && Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId) && Objects.equals(fromVersion, that.fromVersion) && Objects.equals(toVersion, that.toVersion) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(msg, groupId, artifactId, fromVersion, toVersion, value);
+    }
+
+    @Override
+    public String toString() {
+        return "DependencyRewriteRule{" +
+                "msg='" + msg + '\'' +
+                ", groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", fromVersion='" + fromVersion + '\'' +
+                ", toVersion='" + toVersion + '\'' +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/PolicyEngine.java
+++ b/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/PolicyEngine.java
@@ -29,6 +29,7 @@ public class PolicyEngine {
     private final PolicyEngineRules rules;
 
     private final DependencyPolicy dependencyPolicy;
+    private final DependencyRewritePolicy dependencyRewritePolicy;
     private final FilePolicy filePolicy;
     private final TaskPolicy taskPolicy;
     private final WorkspacePolicy workspacePolicy;
@@ -57,6 +58,7 @@ public class PolicyEngine {
         this.ruleNames = ruleNames;
         this.rules = rules;
         this.dependencyPolicy = new DependencyPolicy(rules.getDependencyRules());
+        this.dependencyRewritePolicy = new DependencyRewritePolicy(rules.getDependencyRewriteRules());
         this.filePolicy = new FilePolicy(rules.getFileRules());
         this.taskPolicy = new TaskPolicy(rules.getTaskRules());
         this.workspacePolicy = new WorkspacePolicy(rules.getWorkspaceRule());
@@ -87,6 +89,10 @@ public class PolicyEngine {
 
     public DependencyPolicy getDependencyPolicy() {
         return dependencyPolicy;
+    }
+
+    public DependencyRewritePolicy getDependencyRewritePolicy() {
+        return dependencyRewritePolicy;
     }
 
     public FilePolicy getFilePolicy() {

--- a/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/PolicyEngineRules.java
+++ b/policy-engine/src/main/java/com/walmartlabs/concord/policyengine/PolicyEngineRules.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 public class PolicyEngineRules {
 
     private final PolicyRules<DependencyRule> dependencyRules;
+    private final List<DependencyRewriteRule> dependencyRewriteRules;
     private final PolicyRules<FileRule> fileRules;
     private final PolicyRules<TaskRule> taskRules;
     private final WorkspaceRule workspaceRule;
@@ -60,7 +61,8 @@ public class PolicyEngineRules {
                              @JsonProperty("defaultProcessCfg") Map<String, Object> defaultProcessCfg,
                              @JsonProperty("dependencyVersions")List<DependencyVersionsPolicy.Dependency> dependencyVersions,
                              @JsonProperty("attachments") AttachmentsRule attachmentsRule,
-                             @JsonProperty("state") PolicyRules<StateRule> stateRules) {
+                             @JsonProperty("state") PolicyRules<StateRule> stateRules,
+                             @JsonProperty("dependencyRewrite") List<DependencyRewriteRule> dependencyRewriteRules) {
 
         this.dependencyRules = dependencyRules;
         this.fileRules = fileRules;
@@ -77,10 +79,15 @@ public class PolicyEngineRules {
         this.defaultProcessCfg = defaultProcessCfg;
         this.dependencyVersions = dependencyVersions;
         this.stateRules = stateRules;
+        this.dependencyRewriteRules = dependencyRewriteRules;
     }
 
     public PolicyRules<DependencyRule> getDependencyRules() {
         return dependencyRules;
+    }
+
+    public List<DependencyRewriteRule> getDependencyRewriteRules() {
+        return dependencyRewriteRules;
     }
 
     public PolicyRules<FileRule> getFileRules() {

--- a/policy-engine/src/test/java/com/walmartlabs/concord/policyengine/PolicyEngineRulesTest.java
+++ b/policy-engine/src/test/java/com/walmartlabs/concord/policyengine/PolicyEngineRulesTest.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.policyengine;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
+import java.net.URI;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
@@ -82,9 +83,11 @@ public class PolicyEngineRulesTest {
         StateRule s2 = new StateRule("msg1", 321L, null, null);
         PolicyRules<StateRule> stateRules = new PolicyRules<>(null, Collections.singletonList(s1), Collections.singletonList(s2));
 
+        List<DependencyRewriteRule> depRewriteRules = Collections.singletonList(new DependencyRewriteRule("mmmsg", "grp", "artifact", "versionFrom", "versionTo", new URI("value")));
+
         PolicyEngineRules r = new PolicyEngineRules(dependencyRules, fileRules, taskRules, workspaceRule,
                 containerRules, queueRules, protectedTasksRules, entityRules, processCfg, new JsonStoreRule(storageRule, storageDataRule),
-                defaultProcessCfg, dependencies, attachmentsRule, stateRules);
+                defaultProcessCfg, dependencies, attachmentsRule, stateRules, depRewriteRules);
 
         r.addCustomRule("ansible", Collections.singletonMap("k", "v"));
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PolicyEngineProvider.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PolicyEngineProvider.java
@@ -60,7 +60,7 @@ public class PolicyEngineProvider implements Provider<PolicyEngine> {
     private PolicyEngineRules readPolicyRules(Path ws) {
         Path policyFile = ws.resolve(Constants.Files.CONCORD_SYSTEM_DIR_NAME).resolve(Constants.Files.POLICY_FILE_NAME);
         if (!Files.exists(policyFile)) {
-            return new PolicyEngineRules(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            return new PolicyEngineRules(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         }
 
         try {

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessorTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessorTest.java
@@ -92,7 +92,7 @@ public class ConfigurationProcessorTest {
         defaultProcessCfgPolicy.put("a", "default");
         defaultProcessCfgPolicy.put("process-cfg-policy", "default-2");
 
-        PolicyEngineRules policy = new PolicyEngineRules(null, null, null, null, null, null, null, null, processCfgPolicy, null, defaultProcessCfgPolicy, null, null, null);
+        PolicyEngineRules policy = new PolicyEngineRules(null, null, null, null, null, null, null, null, processCfgPolicy, null, defaultProcessCfgPolicy, null, null, null, null);
 
         // ---
         when(orgDao.getConfiguration(eq(orgId))).thenReturn(orgCfg);


### PR DESCRIPTION
example:
```
{
   "dependencyRewrite":[
      {
         "msg":"\n*******************************\n\nansible-tasks < 1.71.0 is deprecated.\nPlease update your dependencies to the latest recommended versions.\n\n*******************************\n",
         "groupId":"com.walmartlabs.concord.plugins.basic",
         "fromVersion":"1.62.0",
         "toVersion":"1.70.3",
         "artifactId":"ansible-tasks",
         "value":"mvn://com.walmartlabs.concord.plugins.basic:ansible-tasks:1.71.0"
      }
   ]
}
```
will replace all ansible deps with versions [1.62.0, 1.70.3] to 1.71.0

process logs:
```
13:53:43 [INFO ] Updating dependency from 'mvn://com.walmartlabs.concord.plugins.basic:ansible-tasks:1.70.0' to 'mvn://com.walmartlabs.concord.plugins.basic:ansible-tasks:1.71.0'
13:53:43 [WARN ] 
*******************************

ansible-tasks < 1.71.0 is deprecated.
Please update your dependencies to the latest recommended versions.

*******************************
```