### PR TITLE
console2: allow link columns in process list

### DIFF
--- a/console2/src/api/org/index.ts
+++ b/console2/src/api/org/index.ts
@@ -76,7 +76,12 @@ export enum RenderType {
     /**
      * Render as a duration (current timestamp - value)
      */
-    DURATION = 'duration'
+    DURATION = 'duration',
+
+    /**
+     * Render as link
+     */
+    LINK = 'link'
 }
 
 export interface ColumnDefinition {

--- a/console2/src/components/molecules/ProcessList/index.tsx
+++ b/console2/src/components/molecules/ProcessList/index.tsx
@@ -217,6 +217,17 @@ const renderColumnContent = (e: Entry, c: ColumnDefinition) => {
                 return `Invalid value: ${v}`;
             }
         }
+        case RenderType.LINK: {
+            if (!v || !v.link || !v.title) {
+                return '';
+            }
+
+            return (
+                <a href={v.link} target="_blank" rel="noopener noreferrer">
+                    {v.title}
+                </a>
+            );
+        }
         default: {
             if (c.searchValueType === 'boolean') {
                 return <Checkbox type="checkbox" checked={v} readOnly={true} disabled={true} />;


### PR DESCRIPTION
project configuration:
```
"meta": {
    "ui": {
        ...
        {
          "source": "meta.myLinkValue",
          "caption": "My Link",
          "searchType": "substring",
          "searchValueType": "string",
          "render": "link"
        }
      ]
    }
```

concord.yml:
```
flows:
  default:
  - log: "Hello, ${name}!"

configuration:
  arguments:
    name: "Concord"
  meta:
    myLinkValue:
      title: "PGPTOOLS-50937"
      link: "https://ext/api/PGPTOOLS-50937"
```

result:
<img width="1194" alt="Screenshot 2020-12-17 at 15 50 40" src="https://user-images.githubusercontent.com/980726/102490463-eb70e200-407f-11eb-8843-77c754737eef.png">
