### PR TITLE
runtime-v2: use the dependencies classloader for checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## [Unreleased]
+
+### Changed
+
+- runtime-v2: fixed a checkpoint serialization issue when classes
+from `dependencies` are used as flow variables.
+
+
+
 ## [1.76.0] - 2020-12-22
 
 ### Added

--- a/common/src/main/java/com/walmartlabs/concord/common/ObjectInputStreamWithClassLoader.java
+++ b/common/src/main/java/com/walmartlabs/concord/common/ObjectInputStreamWithClassLoader.java
@@ -1,0 +1,65 @@
+package com.walmartlabs.concord.common;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Proxy;
+
+/**
+ * Almost a carbon copy of <a href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/input/ClassLoaderObjectInputStream.html">ClassLoaderObjectInputStream</a>
+ * from commons-io.
+ */
+public class ObjectInputStreamWithClassLoader extends ObjectInputStream {
+
+    private final ClassLoader classLoader;
+
+    public ObjectInputStreamWithClassLoader(InputStream in, ClassLoader classLoader) throws IOException {
+        super(in);
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        try {
+            return Class.forName(desc.getName(), false, classLoader);
+        } catch (ClassNotFoundException e) {
+            // delegate to super class loader which can resolve primitives
+            return super.resolveClass(desc);
+        }
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        Class<?>[] interfaceClasses = new Class[interfaces.length];
+        for (int i = 0; i < interfaces.length; i++) {
+            interfaceClasses[i] = Class.forName(interfaces[i], false, classLoader);
+        }
+
+        try {
+            return Proxy.getProxyClass(classLoader, interfaceClasses);
+        } catch (IllegalArgumentException e) {
+            return super.resolveProxyClass(interfaces);
+        }
+    }
+}

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -78,12 +78,11 @@ public class ProcessIT {
         ConcordProcess proc = concord.processes().start(payload);
 
         ProcessEntry pe = proc.waitForStatus(ProcessEntry.StatusEnum.FINISHED);
-        assertEquals(ProcessEntry.StatusEnum.FINISHED, pe.getStatus());
-
-        // ---
 
         proc.assertLog(".*Runtime: concord-v2.*");
         proc.assertLog(".*log from script: 123.*");
+
+        assertEquals(ProcessEntry.StatusEnum.FINISHED, pe.getStatus());
     }
 
     /**

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointClasses/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpointClasses/concord.yml
@@ -1,0 +1,17 @@
+configuration:
+  runtime: "concord-v2"
+  dependencies:
+    - "mvn://com.walmartlabs.concord.it.tasks:serialization-test:PROJECT_VERSION"
+
+flows:
+  default:
+    - task: customBean
+      in:
+        msg: "Hello!"
+      out: myResult
+
+    - log: "1: ${myResult.value.value}"
+
+    - checkpoint: test
+
+    - log: "2: ${myResult.value.value}"

--- a/it/tasks/serialization-test/pom.xml
+++ b/it/tasks/serialization-test/pom.xml
@@ -20,6 +20,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runtime-sdk-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>

--- a/it/tasks/serialization-test/src/main/java/com/walmartlabs/concord/it/tasks/serializationtest/CustomBean.java
+++ b/it/tasks/serialization-test/src/main/java/com/walmartlabs/concord/it/tasks/serializationtest/CustomBean.java
@@ -1,0 +1,41 @@
+package com.walmartlabs.concord.it.tasks.serializationtest;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.Serializable;
+
+/**
+ * A custom class to test checkpointing with "3rd party" classes.
+ */
+public class CustomBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String value;
+
+    public CustomBean(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/it/tasks/serialization-test/src/main/java/com/walmartlabs/concord/it/tasks/serializationtest/CustomBeanTask.java
+++ b/it/tasks/serialization-test/src/main/java/com/walmartlabs/concord/it/tasks/serializationtest/CustomBeanTask.java
@@ -1,0 +1,40 @@
+package com.walmartlabs.concord.it.tasks.serializationtest;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2020 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.Task;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import com.walmartlabs.concord.runtime.v2.sdk.Variables;
+
+import javax.inject.Named;
+
+/**
+ * A custom task to test 3rd party classes being used as flow variables.
+ */
+@Named("customBean")
+public class CustomBeanTask implements Task {
+
+    @Override
+    public TaskResult execute(Variables input) throws Exception {
+        return TaskResult.success()
+                .value("value", new CustomBean(input.assertString("msg")));
+    }
+}

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/StateManager.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/StateManager.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.runtime.common;
  */
 
 import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.common.ObjectInputStreamWithClassLoader;
 import com.walmartlabs.concord.common.TemporaryPath;
 import com.walmartlabs.concord.sdk.Constants;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -111,7 +112,7 @@ public final class StateManager {
      * the standard location inside the provided {@code baseDir}.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Serializable> T readProcessState(Path baseDir) {
+    public static <T extends Serializable> T readProcessState(Path baseDir, ClassLoader cl) {
         Path stateDir = baseDir.resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
                 .resolve(Constants.Files.JOB_STATE_DIR_NAME);
 
@@ -120,7 +121,7 @@ public final class StateManager {
             return null;
         }
 
-        try (ObjectInputStream in = new ObjectInputStream(Files.newInputStream(p))) {
+        try (ObjectInputStream in = new ObjectInputStreamWithClassLoader(Files.newInputStream(p), cl)) {
             return (T) in.readObject();
         } catch (ClassNotFoundException | IOException e) {
             throw new RuntimeException(e);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -45,6 +45,7 @@ import com.walmartlabs.concord.svm.ThreadStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -61,21 +62,23 @@ public class Main {
     private final RunnerConfiguration runnerCfg;
     private final ProcessConfiguration processCfg;
     private final WorkingDirectory workDir;
-
     private final TaskProviders taskProviders;
+    private final ClassLoader classLoader;
 
     @Inject
     public Main(Runner runner,
                 RunnerConfiguration runnerCfg,
                 ProcessConfiguration processCfg,
                 WorkingDirectory workDir,
-                TaskProviders taskProviders) {
+                TaskProviders taskProviders,
+                @Named("runtime") ClassLoader classLoader) {
 
         this.runner = runner;
         this.runnerCfg = runnerCfg;
         this.processCfg = processCfg;
         this.workDir = workDir;
         this.taskProviders = taskProviders;
+        this.classLoader = classLoader;
     }
 
     public static void main(String[] args) throws Exception {
@@ -139,7 +142,7 @@ public class Main {
         //  - continuing from a checkpoint
         //  - resuming after suspend
 
-        ProcessSnapshot snapshot = StateManager.readProcessState(workDir);
+        ProcessSnapshot snapshot = StateManager.readProcessState(workDir, classLoader);
         Set<String> events = StateManager.readResumeEvents(workDir); // TODO make it an interface?
 
         Action action = currentAction(snapshot, events);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/ProcessDependenciesModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/ProcessDependenciesModule.java
@@ -21,7 +21,7 @@ package com.walmartlabs.concord.runtime.v2.runner.guice;
  */
 
 import com.google.inject.AbstractModule;
-import com.walmartlabs.concord.runtime.v2.runner.InjectorFactory;
+import com.google.inject.name.Names;
 import com.walmartlabs.concord.sdk.Constants;
 import org.eclipse.sisu.space.BeanScanning;
 import org.eclipse.sisu.space.SpaceModule;
@@ -55,8 +55,8 @@ public class ProcessDependenciesModule extends AbstractModule {
     protected void configure() {
         try {
             ClassLoader cl = loadDependencies(workDir, dependencies);
-            Thread.currentThread().setContextClassLoader(cl);
             install(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX));
+            bind(ClassLoader.class).annotatedWith(Names.named("runtime")).toInstance(cl);
         } catch (IOException e) {
             addError(e);
         }
@@ -64,7 +64,7 @@ public class ProcessDependenciesModule extends AbstractModule {
 
     private static URLClassLoader loadDependencies(Path workDir, Collection<String> dependencies) throws IOException {
         List<URL> urls = toURLs(workDir, dependencies);
-        return new URLClassLoader(urls.toArray(new URL[0]), InjectorFactory.class.getClassLoader());
+        return new URLClassLoader(urls.toArray(new URL[0]), ProcessDependenciesModule.class.getClassLoader());
     }
 
     private static List<URL> toURLs(Path workDir, Collection<String> dependencies) throws IOException {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/ProcessDependenciesModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/ProcessDependenciesModule.java
@@ -55,6 +55,10 @@ public class ProcessDependenciesModule extends AbstractModule {
     protected void configure() {
         try {
             ClassLoader cl = loadDependencies(workDir, dependencies);
+
+            // required to support ScriptEngines from external dependencies
+            Thread.currentThread().setContextClassLoader(cl);
+
             install(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX));
             bind(ClassLoader.class).annotatedWith(Names.named("runtime")).toInstance(cl);
         } catch (IOException e) {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -26,6 +26,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.forms.Form;
 import com.walmartlabs.concord.runtime.common.FormService;
@@ -112,6 +113,8 @@ public class MainTest {
             @Override
             protected void configure() {
                 install(new BaseRunnerModule());
+
+                bind(ClassLoader.class).annotatedWith(Names.named("runtime")).toInstance(MainTest.class.getClassLoader());
 
                 bind(CheckpointService.class).toInstance(checkpointService);
                 bind(DependencyManager.class).to(DefaultDependencyManager.class);

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -100,7 +100,7 @@
         <swagger.version>1.5.20</swagger.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
         <testcontainers.concord.version>0.0.33</testcontainers.concord.version>
-        <testcontainers.version>1.13.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <wiremock.version>2.26.1</wiremock.version>
     </properties>


### PR DESCRIPTION
Explicitly specify the classloader when deserializing checkpoints.

Before the change, checkpoints used the default classloader of the
runner which doesn't contain classes from `dependencies`.

While it is still not recommended to use 3rd party classes as flow
variables, it might be okay for situations when both the server
and the runtime have the same 3rd party JARs on the classpath.