### PR TITLE
server: Allow parameter entry as query parameter

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/inventory/InventoryQueryResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/inventory/InventoryQueryResource.java
@@ -173,7 +173,7 @@ public class InventoryQueryResource implements Resource {
                              @ApiParam @PathParam("queryName") @ConcordKey String queryName,
                              @ApiParam @Valid Map<String, Object> params) {
 
-        return storageQueryResource.exec(orgName, inventoryName, queryName, params);
+        return storageQueryResource.exec(orgName, inventoryName, queryName, null, params);
     }
 
     private static InventoryQueryEntry convert(JsonStoreQueryEntry query) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryExecDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryExecDao.java
@@ -43,9 +43,7 @@ import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static com.walmartlabs.concord.server.jooq.Tables.INVENTORY_DATA;
 import static com.walmartlabs.concord.server.jooq.Tables.JSON_STORE_DATA;
@@ -67,7 +65,7 @@ public class JsonStoreQueryExecDao extends AbstractDao {
         this.storeQueryDao = storeQueryDao;
     }
 
-    public List<Object> exec(UUID storeId, String queryName, Map<String, Object> params) {
+    public List<Object> exec(UUID storeId, String queryName, Object params) {
         JsonStoreQueryEntry q = storeQueryDao.get(storeId, queryName);
         if (q == null) {
             throw new ValidationErrorsException("Query not found: " + queryName);
@@ -76,7 +74,7 @@ public class JsonStoreQueryExecDao extends AbstractDao {
         return execSql(q.storeId(), q.text(), params, null);
     }
 
-    public List<Object> execSql(UUID storeId, String query, Map<String, Object> params, Integer maxLimit) {
+    public List<Object> execSql(UUID storeId, String query, Object params, Integer maxLimit) {
         String sql = createQuery(query, maxLimit);
 
         // TODO we should probably inspect the query to determine whether we need to bind the params or not

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryManager.java
@@ -130,7 +130,7 @@ public class JsonStoreQueryManager {
         addAuditLog(AuditAction.DELETE, org.getId(), store.id(), queryName);
     }
 
-    public List<Object> exec(String orgName, String storeName, String queryName, Map<String, Object> params) {
+    public List<Object> exec(String orgName, String storeName, String queryName, Object params) {
         OrganizationEntry org = orgManager.assertAccess(orgName, true);
         JsonStoreEntry store = jsonStoreAccessManager.assertAccess(org.getId(), null, storeName, ResourceAccessLevel.READER, true);
         return execDao.exec(store.id(), queryName, params);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreQueryResource.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.server.org.jsonstore;
  */
 
 import com.walmartlabs.concord.common.validation.ConcordKey;
+import com.walmartlabs.concord.sdk.MapUtils;
 import com.walmartlabs.concord.server.GenericOperationResult;
 import com.walmartlabs.concord.server.OperationResult;
 import com.walmartlabs.concord.server.sdk.ConcordApplicationException;
@@ -140,6 +141,7 @@ public class JsonStoreQueryResource implements Resource {
      * @param orgName   organization's name
      * @param storeName store's name
      * @param queryName query's name
+     * @param paramName param name from {@code params} to use
      * @param params    query params
      * @return query result
      */
@@ -152,10 +154,18 @@ public class JsonStoreQueryResource implements Resource {
     public List<Object> exec(@ApiParam @PathParam("orgName") @ConcordKey String orgName,
                              @ApiParam @PathParam("storeName") @ConcordKey String storeName,
                              @ApiParam @PathParam("queryName") @ConcordKey String queryName,
+                             @ApiParam @QueryParam("paramName") String paramName,
                              @ApiParam @Valid Map<String, Object> params) {
 
+        Object p;
+        if (paramName != null) {
+            p = MapUtils.assertVariable(params, paramName, Object.class);
+        } else {
+            p = params;
+        }
+
         try {
-            return storeQueryManager.exec(orgName, storeName, queryName, params);
+            return storeQueryManager.exec(orgName, storeName, queryName, p);
         } catch (ValidationErrorsException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
Two things make it difficult to compare against a list of values in a json store query
1. JSqlParse chokes on quite a lot of postgres functions and operators
2. Query parameters currently have to be a Map

This is a seemingly simple query that doesn't parse.
```sql
select item_data
from json_store_data
where item_data->'myId' <@ ?::jsonb->'myId'
```

The idea for this change is to continue to use a Map as the given paramters to the REST API call, but add a parameter to specify an entry in the map use actually use as the query parameter when executing the query

```shell
curl -in -X POST -H 'Content-Type: application/json' \
  -d '{"theIds": ["123", "456"]}' \
  'http://localhost:8001/api/v1/org/Default/jsonstore/test-store/query/test-query/exec?paramName=theIds'

[ {
  "status" : "GOOD",
  "myId" : "123"
}, {
  "status" : "GOOD",
  "myId" : "456"
} ]
```