### PR TITLE
concord-repository: fix fetching a specific commitId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ info popup ([#288](https://github.com/walmartlabs/concord/pull/288)).
 
 ### Changed
 
+- concord-repository: fix Git repository fetching when the request
+specifies the `branchOrTag` and the `commitId` parameters
+simultaneously;
 - runtime-v2: use the standard `AbstractMap.SimpleImmutableEntry`
 to iterate over `Map` elements in the `withItems` implementation.
 ([#285](https://github.com/walmartlabs/concord/pull/285)).

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -84,6 +84,14 @@ public class GitClient {
             throw new IllegalArgumentException("Specify branch, tag or commit Id.");
         }
 
+        // commitId has the precedence
+        if (req.commitId() != null && req.branchOrTag() != null) {
+            req = FetchRequest.builder()
+                    .from(req)
+                    .branchOrTag(null)
+                    .build();
+        }
+
         assertSecret(req.url(), req.secret());
 
         try {
@@ -163,7 +171,7 @@ public class GitClient {
         args.add("fetch");
         if (shallow) {
             args.add("--depth=1");
-        } else if (isShallowRepo(workDir)){
+        } else if (isShallowRepo(workDir)) {
             args.add("--unshallow");
         }
         args.add("origin");
@@ -310,7 +318,7 @@ public class GitClient {
                             .workDir(workDir)
                             .timeout(cfg.defaultOperationTimeout())
                             .addArgs("config", "--file", ".gitmodules", "--name-only", "--get-regexp", "path")
-                    .build())
+                            .build())
                     .split("\\r?\\n");
         } catch (RepositoryException e) {
             log.warn("updateSubmodules ['{}'] -> error while retrieving the list of submodules: {}", workDir, e.getMessage());


### PR DESCRIPTION
When fetching a Git repository, we try to limit the number of remote
refs we fetch.

Before this change fetch might fail if the request specifies
both a branch and commitId - the client was configuring wrong values for
`remote.origin.fetch`.

Steps to reproduce:
- create a Git repository with a default branch + a non default branch with a commit that exist only in the latter;
- configure a repository, use the default branch;
- send a request like so
```
curl -ik -H 'Authorization: ...' -F repoCommitId=$COMMIT_ID_FROM_BRANCH -F org=Default -F project=test -F repo=test http://localhost:8001/api/v1/process
```
- the process should fail with `code: 128, fatal: reference is not a tree: $COMMIT_ID_FROM_BRANCH`