### PR TITLE
dependency-mananager: add support for preemptive basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - dependency-manager: support for pre-emptive basic authentication
-when talking to Maven repositories;
+when talking to Maven repositories ([#293](https://github.com/walmartlabs/concord/pull/293));
 - runtime-v2: support for the `name` attribute in `try` and `block`
 elements ([#289](https://github.com/walmartlabs/concord/pull/289)); 
 - runtime-v2: automatically generate and publish the JSON schema for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- dependency-manager: support for pre-emptive basic authentication
+when talking to Maven repositories;
 - runtime-v2: support for the `name` attribute in `try` and `block`
 elements ([#289](https://github.com/walmartlabs/concord/pull/289)); 
 - runtime-v2: automatically generate and publish the JSON schema for

--- a/dependency-manager/pom.xml
+++ b/dependency-manager/pom.xml
@@ -45,8 +45,8 @@
             <artifactId>maven-resolver-transport-file</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-http</artifactId>
+            <groupId>ca.ibodrov.concord.maven</groupId>
+            <artifactId>concord-maven-resolver-transport-http</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
+++ b/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.dependencymanager;
  * =====
  */
 
+import ca.ibodrov.concord.maven.http.ConcordHttpTransporterFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.walmartlabs.concord.common.ExceptionUtils;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -41,7 +42,6 @@ import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.slf4j.Logger;
@@ -371,7 +371,7 @@ public class DependencyManager {
         DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
         locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
         locator.addService(TransporterFactory.class, FileTransporterFactory.class);
-        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+        locator.addService(TransporterFactory.class, ConcordHttpTransporterFactory.class);
 
         locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
             @Override

--- a/docker-images/base/oss/Dockerfile
+++ b/docker-images/base/oss/Dockerfile
@@ -5,6 +5,9 @@ ARG jdk_version=1.8.0
 
 ENTRYPOINT ["/usr/local/bin/concord_venv/bin/dumb-init", "--"]
 
+RUN echo 'fastestmirror=true' >> /etc/dnf/dnf.conf && \
+    echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
+
 # requires Git >= 2.3
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
     dnf -y upgrade && \

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -78,6 +78,7 @@
         <maven.prj.version>2.2.1</maven.prj.version>
         <maven.resolver.provider.version>3.6.3</maven.resolver.provider.version>
         <maven.resolver.version>1.4.1</maven.resolver.version>
+        <maven.resolver.version.concord>0.0.1</maven.resolver.version.concord>
         <metrics.version>4.1.3</metrics.version>
         <mockito.version>3.2.4</mockito.version>
         <mustache.version>0.9.6</mustache.version>
@@ -396,9 +397,9 @@
                 <version>${maven.resolver.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-transport-http</artifactId>
-                <version>${maven.resolver.version}</version>
+                <groupId>ca.ibodrov.concord.maven</groupId>
+                <artifactId>concord-maven-resolver-transport-http</artifactId>
+                <version>${maven.resolver.version.concord}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -78,7 +78,7 @@
         <maven.prj.version>2.2.1</maven.prj.version>
         <maven.resolver.provider.version>3.6.3</maven.resolver.provider.version>
         <maven.resolver.version>1.4.1</maven.resolver.version>
-        <maven.resolver.version.concord>0.0.1</maven.resolver.version.concord>
+        <maven.resolver.version.concord>0.0.2</maven.resolver.version.concord>
         <metrics.version>4.1.3</metrics.version>
         <mockito.version>3.2.4</mockito.version>
         <mustache.version>0.9.6</mustache.version>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -78,7 +78,7 @@
         <maven.prj.version>2.2.1</maven.prj.version>
         <maven.resolver.provider.version>3.6.3</maven.resolver.provider.version>
         <maven.resolver.version>1.4.1</maven.resolver.version>
-        <maven.resolver.version.concord>0.0.2</maven.resolver.version.concord>
+        <maven.resolver.version.concord>0.0.3</maven.resolver.version.concord>
         <metrics.version>4.1.3</metrics.version>
         <mockito.version>3.2.4</mockito.version>
         <mustache.version>0.9.6</mustache.version>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -78,7 +78,7 @@
         <maven.prj.version>2.2.1</maven.prj.version>
         <maven.resolver.provider.version>3.6.3</maven.resolver.provider.version>
         <maven.resolver.version>1.4.1</maven.resolver.version>
-        <maven.resolver.version.concord>0.0.3</maven.resolver.version.concord>
+        <maven.resolver.version.concord>0.0.4</maven.resolver.version.concord>
         <metrics.version>4.1.3</metrics.version>
         <mockito.version>3.2.4</mockito.version>
         <mustache.version>0.9.6</mustache.version>


### PR DESCRIPTION
Example mvn.json:
```json
{
  "repositories": [
    {
      "id": "host",
      "url": "https://my-bucket.s3.us-west-2.amazonaws.com/maven",
      "auth": {
        "username": "user",
        "password": "pwd",
        "preemptiveAuth": "true"
      }
    }
  ]
}
```