### PR TITLE
concord-client: add basePath to exceptions

### DIFF
--- a/client/src/main/template/libraries/okhttp-gson/ApiClient.mustache
+++ b/client/src/main/template/libraries/okhttp-gson/ApiClient.mustache
@@ -977,6 +977,9 @@ public class ApiClient {
                     throw new ApiException(response.message(), e, response.code(), response.headers().toMultimap());
                 }
             }
+
+            msg = "(" + basePath + ") " + msg;
+
             throw new ApiException(msg, response.code(), response.headers().toMultimap(), respBody);
         }
     }


### PR DESCRIPTION
Add `basePath` to the exception message. Useful for debugging.

E.g.
```
com.walmartlabs.concord.ApiException: (http://localhost:8001) Server response: Process instance not found
```