### PR TITLE
concord-server: use java.time.Duration for all intervals in the config

### DIFF
--- a/server/db/src/main/java/com/walmartlabs/concord/db/PgUtils.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/PgUtils.java
@@ -30,11 +30,11 @@ import org.postgresql.util.PSQLException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.inline;
+import static org.jooq.impl.DSL.*;
 
 public final class PgUtils {
 
@@ -86,6 +86,14 @@ public final class PgUtils {
 
     public static Condition jsonbTextNotExistsByPath(Field<JSONB> field, List<String> path, String value) {
         return DSL.condition("not {0} #> {1} ?? {2}", field, inline(toPath(path)), DSL.value(value));
+    }
+
+    /**
+     * Returns a JOOQ field "now - d" where "d" is the specified duration.
+     * The result is rounded down to seconds.
+     */
+    public static Field<OffsetDateTime> nowMinus(Duration d) {
+        return currentOffsetDateTime().minus(interval((d.toMillis() / 1000 ) + " seconds"));
     }
 
     private static String toPath(List<String> path) {

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -1,3 +1,13 @@
+# Default configuration for Concord Server
+#
+# Note, time intervals accept the following formats:
+# "20000" (20000 milliseconds)
+# "20 seconds"
+# "20 days"
+#
+# The biggest unit allowed is "days"
+# See also com.typesafe.config.impl.SimpleConfig#parseDuration
+
 concord-server {
 
     server {
@@ -135,16 +145,16 @@ concord-server {
         # enable cleanup of process checkpoints
         checkpointCleanup = true
 
-        # max age of the process state data (PG interval)
+        # max age of the process state data (interval)
         maxStateAge = "7 days"
 
-        # max age of failed processes to handle (PG interval)
+        # max age of failed processes to handle (interval)
         maxFailureHandlingAge = "3 days"
 
-        # max age of stalled processes to handle (PG interval)
+        # max age of stalled processes to handle (interval)
         maxStalledAge = "1 minute"
 
-        # max age of processes which are failed to start (PG interval)
+        # max age of processes which are failed to start (interval)
         maxStartFailureAge = "10 minutes"
 
         # list of process state files that must be encrypted before storing
@@ -155,7 +165,7 @@ concord-server {
         # (optional) a key used to sign important process data (such as initiator or currentUser IDs)
         #signingKeyPath = "..."
 
-        # process wait conditions check interval
+        # interval between checking for process wait conditions (interval)
         waitCheckPeriod = "5 seconds"
         waitCheckPollLimit = 1000
 
@@ -387,16 +397,16 @@ concord-server {
 
     # AD/LDAP group synchronization
     ldapGroupSync {
-        # interval between runs (Duration)
+        # interval between runs
         interval = "1 day"
 
         # the number of users fetched at the time
         fetchLimit = 100
 
-        # interval for group sync on login (PostgreSQL interval)
+        # interval for group sync on login (interval)
         minAgeLogin = "1 hour"
 
-        # interval for the automatic group sync (PostgreSQL interval)
+        # interval for the automatic group sync (interval)
         minAgeSync = "1 day"
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogCleaner.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogCleaner.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server.audit;
 
 import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
+import com.walmartlabs.concord.db.PgUtils;
 import com.walmartlabs.concord.server.cfg.AuditConfiguration;
 import com.walmartlabs.concord.server.sdk.ScheduledTask;
 import org.jooq.Configuration;
@@ -34,9 +35,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.time.OffsetDateTime;
 
-import static com.walmartlabs.concord.db.PgUtils.interval;
 import static com.walmartlabs.concord.server.jooq.tables.AuditLog.AUDIT_LOG;
-import static org.jooq.impl.DSL.currentOffsetDateTime;
 
 @Named("audit-log-cleaner")
 @Singleton
@@ -60,8 +59,7 @@ public class AuditLogCleaner implements ScheduledTask {
 
     @Override
     public void performTask() {
-        // TODO use PG's intervals
-        Field<OffsetDateTime> cutoff = currentOffsetDateTime().minus(interval(cfg.getMaxLogAge().toMillis() + " ms"));
+        Field<OffsetDateTime> cutoff = PgUtils.nowMinus(cfg.getMaxLogAge());
         cleanerDao.deleteOldLogs(cutoff);
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/LdapGroupSyncConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/LdapGroupSyncConfiguration.java
@@ -42,11 +42,11 @@ public class LdapGroupSyncConfiguration  implements Serializable {
 
     @Inject
     @Config("ldapGroupSync.minAgeLogin")
-    private String minAgeLogin;
+    private Duration minAgeLogin;
 
     @Inject
     @Config("ldapGroupSync.minAgeSync")
-    private String minAgeSync;
+    private Duration minAgeSync;
 
     public Duration getInterval() {
         return interval;
@@ -56,11 +56,11 @@ public class LdapGroupSyncConfiguration  implements Serializable {
         return fetchLimit;
     }
 
-    public String getMinAgeLogin() {
+    public Duration getMinAgeLogin() {
         return minAgeLogin;
     }
 
-    public String getMinAgeSync() {
+    public Duration getMinAgeSync() {
         return minAgeSync;
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessConfiguration.java
@@ -62,7 +62,8 @@ public class ProcessConfiguration implements Serializable {
 
     @Inject
     @Config("process.maxStateAge")
-    private String maxStateAge;
+    private Duration maxStateAge;
+
     @Inject
     @Config("process.secureFiles")
     private List<String> secureFiles;
@@ -92,7 +93,7 @@ public class ProcessConfiguration implements Serializable {
         this.signingKeyPath = signingKeyPath != null ? Paths.get(signingKeyPath) : null;
     }
 
-    public ProcessConfiguration(String maxStateAge, List<String> secureFiles) {
+    public ProcessConfiguration(Duration maxStateAge, List<String> secureFiles) {
         this.maxStateAge = maxStateAge;
         this.secureFiles = secureFiles;
     }
@@ -121,7 +122,7 @@ public class ProcessConfiguration implements Serializable {
         return checkpointCleanup;
     }
 
-    public String getMaxStateAge() {
+    public Duration getMaxStateAge() {
         return maxStateAge;
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessWatchdogConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessWatchdogConfiguration.java
@@ -38,29 +38,29 @@ public class ProcessWatchdogConfiguration implements Serializable {
 
     @Inject
     @Config("process.maxFailureHandlingAge")
-    private String maxFailureHandlingAge;
+    private Duration maxFailureHandlingAge;
 
     @Inject
     @Config("process.maxStalledAge")
-    private String maxStalledAge;
+    private Duration maxStalledAge;
 
     @Inject
     @Config("process.maxStartFailureAge")
-    private String maxStartFailureAge;
+    private Duration maxStartFailureAge;
 
     public Duration getPeriod() {
         return period;
     }
 
-    public String getMaxFailureHandlingAge() {
+    public Duration getMaxFailureHandlingAge() {
         return maxFailureHandlingAge;
     }
 
-    public String getMaxStalledAge() {
+    public Duration getMaxStalledAge() {
         return maxStalledAge;
     }
 
-    public String getMaxStartFailureAge() {
+    public Duration getMaxStartFailureAge() {
         return maxStartFailureAge;
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessCleaner.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessCleaner.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server.process;
 
 import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
+import com.walmartlabs.concord.db.PgUtils;
 import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
 import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import com.walmartlabs.concord.server.sdk.ScheduledTask;
@@ -72,7 +73,7 @@ public class ProcessCleaner implements ScheduledTask {
 
     @Override
     public void performTask() {
-        Field<OffsetDateTime> cutoff = currentOffsetDateTime().minus(interval(cfg.getMaxStateAge()));
+        Field<OffsetDateTime> cutoff = PgUtils.nowMinus(cfg.getMaxStateAge());
         cleanerDao.deleteOldState(cutoff, cfg);
         cleanerDao.deleteOrphans(cfg);
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
@@ -154,7 +154,7 @@ public class ProcessQueueWatchdog implements ScheduledTask {
 
         @Override
         public void run() {
-            Field<OffsetDateTime> maxAge = currentOffsetDateTime().minus(interval(cfg.getMaxFailureHandlingAge()));
+            Field<OffsetDateTime> maxAge = PgUtils.nowMinus(cfg.getMaxFailureHandlingAge());
 
             for (PollEntry e : POLL_ENTRIES) {
                 List<ProcessEntry> parents = watchdogDao.poll(e, maxAge, 1);
@@ -194,15 +194,13 @@ public class ProcessQueueWatchdog implements ScheduledTask {
     private final class ProcessStalledWorker implements Runnable {
         @Override
         public void run() {
-            String maxAge = cfg.getMaxStalledAge();
-
             watchdogDao.transaction(tx -> {
-                Field<OffsetDateTime> cutOff = currentOffsetDateTime().minus(interval(maxAge));
+                Field<OffsetDateTime> cutoff = PgUtils.nowMinus(cfg.getMaxStalledAge());
 
-                List<ProcessKey> pks = watchdogDao.pollStalled(tx, POTENTIAL_STALLED_STATUSES, cutOff, 1);
+                List<ProcessKey> pks = watchdogDao.pollStalled(tx, POTENTIAL_STALLED_STATUSES, cutoff, 1);
                 for (ProcessKey pk : pks) {
                     queueManager.updateAgentId(tx, pk, null, ProcessStatus.FAILED);
-                    logManager.warn(pk, "Process stalled, no heartbeat for more than '{}'", maxAge);
+                    logManager.warn(pk, "Process stalled, no heartbeat for more than '{}'", cfg.getMaxStalledAge());
                     log.info("processStalled -> marked as failed: {}", pk);
                 }
             });
@@ -212,15 +210,13 @@ public class ProcessQueueWatchdog implements ScheduledTask {
     private final class ProcessStartFailuresWorker implements Runnable {
         @Override
         public void run() {
-            String maxAge = cfg.getMaxStartFailureAge();
-
             watchdogDao.transaction(tx -> {
-                Field<OffsetDateTime> cutOff = currentOffsetDateTime().minus(interval(maxAge));
+                Field<OffsetDateTime> cutOff = PgUtils.nowMinus(cfg.getMaxStartFailureAge());
 
                 List<ProcessKey> pks = watchdogDao.pollStalled(tx, FAILED_TO_START_STATUSES, cutOff, 1);
                 for (ProcessKey pk : pks) {
                     queueManager.updateAgentId(tx, pk, null, ProcessStatus.FAILED);
-                    logManager.warn(pk, "Process failed to start for more than '{}'", maxAge);
+                    logManager.warn(pk, "Process failed to start for more than '{}'", cfg.getMaxStartFailureAge());
                     log.info("processStartFailures -> marked as failed: {}", pk);
                 }
             });

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapGroupManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapGroupManager.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.server.security.ldap;
  * =====
  */
 
+import com.walmartlabs.concord.db.PgUtils;
 import com.walmartlabs.concord.server.cfg.LdapGroupSyncConfiguration;
 import org.jooq.Field;
 
@@ -45,7 +46,7 @@ public class LdapGroupManager {
     }
 
     public void cacheLdapGroupsIfNeeded(UUID userId, Set<String> groups) {
-        Field<OffsetDateTime> cutOff = currentOffsetDateTime().minus(interval(syncCfg.getMinAgeLogin()));
-        groupDao.updateIfNeeded(userId, groups, cutOff);
+        Field<OffsetDateTime> cutoff = PgUtils.nowMinus(syncCfg.getMinAgeLogin());
+        groupDao.updateIfNeeded(userId, groups, cutoff);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
@@ -82,7 +82,7 @@ public class UserLdapGroupSynchronizer implements ScheduledTask {
 
     @Override
     public void performTask() {
-        Field<OffsetDateTime> cutoff = currentOffsetDateTime().minus(PgUtils.interval(cfg.getMinAgeSync()));
+        Field<OffsetDateTime> cutoff = PgUtils.nowMinus(cfg.getMinAgeSync());
         long usersCount = 0;
         List<UserItem> users;
         do {

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/state/ProcessStateManagerTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/state/ProcessStateManagerTest.java
@@ -28,10 +28,10 @@ import com.walmartlabs.concord.server.ConcordObjectMapper;
 import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
 import com.walmartlabs.concord.server.cfg.SecretStoreConfiguration;
 import com.walmartlabs.concord.server.policy.PolicyManager;
-import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.process.logs.ProcessLogManager;
 import com.walmartlabs.concord.server.process.queue.ProcessKeyCache;
 import com.walmartlabs.concord.server.process.queue.ProcessQueueDao;
+import com.walmartlabs.concord.server.sdk.ProcessKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -40,7 +40,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -64,7 +66,7 @@ public class ProcessStateManagerTest extends AbstractDaoTest {
 
         //
         ProcessKeyCache processKeyCache = new ProcessKeyCache(new ProcessQueueDao(getConfiguration(), new ConcordObjectMapper(new ObjectMapper())));
-        ProcessConfiguration stateCfg = new ProcessConfiguration("24 hours", Collections.singletonList(Constants.Files.CONFIGURATION_FILE_NAME));
+        ProcessConfiguration stateCfg = new ProcessConfiguration(Duration.of(24, ChronoUnit.HOURS), Collections.singletonList(Constants.Files.CONFIGURATION_FILE_NAME));
         ProcessStateManager stateManager = new ProcessStateManager(getConfiguration(), mock(SecretStoreConfiguration.class), stateCfg, mock(PolicyManager.class), mock(ProcessLogManager.class), processKeyCache);
         stateManager.importPath(processKey, null, baseDir, (p, attrs) -> true);
 
@@ -110,7 +112,7 @@ public class ProcessStateManagerTest extends AbstractDaoTest {
         }
 
         ProcessKeyCache processKeyCache = new ProcessKeyCache(new ProcessQueueDao(getConfiguration(), new ConcordObjectMapper(new ObjectMapper())));
-        ProcessConfiguration stateCfg = new ProcessConfiguration("24 hours", Collections.singletonList(Constants.Files.CONFIGURATION_FILE_NAME));
+        ProcessConfiguration stateCfg = new ProcessConfiguration(Duration.of(24, ChronoUnit.HOURS), Collections.singletonList(Constants.Files.CONFIGURATION_FILE_NAME));
         ProcessStateManager stateManager = new ProcessStateManager(getConfiguration(), mock(SecretStoreConfiguration.class), stateCfg, mock(PolicyManager.class), mock(ProcessLogManager.class), processKeyCache);
         stateManager.importPath(processKey, "/", baseDir, (p, attrs) -> true);
     }


### PR DESCRIPTION
Before this change, the Server configuration used a mix of PostgreSQL
interval types and java.time.Duration. Additionally, the existing
Duration properties were converted into milliseconds which causes issues
with large values (e.g. can't set `audit.maxLogAge` interval to more
than `2147483647 ms` or ~24 days.

This PR changes all interval properties to Duration. When the value is
passed to PG it is rounded down to seconds (instead of milliseconds)
which allows values up to ~24000 days.