### PR TITLE
docker-images: Restrict cryptography dependency to 3.3.1

### DIFF
--- a/docker-images/ansible/oss/Dockerfile
+++ b/docker-images/ansible/oss/Dockerfile
@@ -26,7 +26,7 @@ ENV VIRTUAL_ENV=/usr/local/bin/concord_venv
 
 RUN umask 0022 && \
     pip3 install --no-cache-dir --upgrade --ignore-installed \
-        "cryptography<=3.3.1"
+        "cryptography<=3.3.1" \
         "ansible>=2.8.0,<2.9.0" \
         "Appium-Python-Client<1.0" \
         boto3 \

--- a/docker-images/ansible/oss/Dockerfile
+++ b/docker-images/ansible/oss/Dockerfile
@@ -26,6 +26,7 @@ ENV VIRTUAL_ENV=/usr/local/bin/concord_venv
 
 RUN umask 0022 && \
     pip3 install --no-cache-dir --upgrade --ignore-installed \
+        "cryptography<=3.3.1"
         "ansible>=2.8.0,<2.9.0" \
         "Appium-Python-Client<1.0" \
         boto3 \


### PR DESCRIPTION
`ansible` package installation thru pip3 has a dependency on cryptography package.
But the dependency version is not pinned to a specific version.
So every time ansible package is installed, it fetches the latest version of cryptography package (latest being 3.4.1).
Latest versions of cryptography packages have a dependency on Rust, so the installation fails with ModuleNotFoundError: No module named 'setuptools_rust' error.

Even if we install this package separately, the installation of cryptography package fails with error: Can not find Rust compiler error, since our images dont have Rust compiler installed.

This is to fix our failing Docker image builds, till we decide if we should install Rust on our base images, or continue pinning cryptography to <=3.3.1 (which was the last working version, before they moved to Rust) as done in this PR.

More info: https://github.com/pyca/cryptography/issues/5771