### PR TITLE
runtime-v2: more SDK javadoc, publish javadoc artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,22 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven.dependency.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <quiet>true</quiet>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/runtime/v2/sdk/pom.xml
+++ b/runtime/v2/sdk/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>
@@ -71,6 +76,10 @@
                 <configuration>
                     <proc>proc</proc>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Context.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Context.java
@@ -25,50 +25,91 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Provides access to the current call's environment.
+ * Can be injected into task classes using {@link javax.inject.Inject} annotation.
+ */
 public interface Context {
 
     /**
-     * Provides process current working directory.
+     * @return absolute path to the working directory of the current process.
      */
     Path workingDirectory();
 
     /**
-     * Process identifier.
+     * @return the current process ID.
      */
     UUID processInstanceId();
 
     // TODO parentInstanceId?
 
+    /**
+     * Returns all variables declared before the current call.
+     *
+     * @return current variables.
+     */
     Variables variables();
 
     /**
-     * Default task variables
+     * TODO
+     *
+     * @return default task parameters.
      */
     Variables defaultVariables();
 
+    /**
+     * Provides access to the filesystem utilities.
+     *
+     * @return {@link FileService}
+     */
     FileService fileService();
 
+    /**
+     * Allows running Docker containers in Concord processes.
+     *
+     * @return {@link DockerService}
+     */
     DockerService dockerService();
 
+    /**
+     * Provides access to Concord secrets.
+     *
+     * @return {@link SecretService}
+     */
     SecretService secretService();
 
+    /**
+     * Project-level locking.
+     *
+     * @return {@link LockService}
+     */
     LockService lockService();
 
+    /**
+     * @return configuration parameters for accessing Concord API.
+     */
     ApiConfiguration apiConfiguration();
 
+    /**
+     * @return the current process' configuration.
+     */
     ProcessConfiguration processConfiguration();
 
     /**
      * Provides access to the low-level details of the current process.
+     * <p>
+     * Unstable API, subject to change.
      *
-     * @apiNote unstable API, subject to change.
+     * @return {@link Execution}
      */
     Execution execution();
 
     /**
      * Provides low-level access to the DSL compiler.
+     * <p>
+     * Unstable API, subject to change.
      *
-     * @apiNote unstable API, subject to change.
+     * @return {@link Compiler}
      */
     Compiler compiler();
 
@@ -78,11 +119,24 @@ public interface Context {
      * "Evaluates" the specified value, resolving all variables.
      * All expressions are evaluated and replaced with resulting values.
      * Accepts strings (including expressions), lists, sets, arrays and maps.
+     *
+     * @param <T>  the expected type of the result.
+     * @param v    the expression or an object containing expressions (lists, maps, etc).
+     * @param type the expected type of the result.
+     * @return the result of evaluation of the specified type.
      */
     <T> T eval(Object v, Class<T> type);
 
     /**
      * Same as {@link #eval(Object, Class)}, but allows providing additional variables.
+     *
+     * @param <T>                 the expected type of the result.
+     * @param v                   the expression or an object containing expressions
+     *                            (lists, maps, etc).
+     * @param additionalVariables a {@link Map} of additional variables that will be
+     *                            made available during evaluation.
+     * @param type                the expected type of the result.
+     * @return the result of evaluation of the specified type.
      */
     <T> T eval(Object v, Map<String, Object> additionalVariables, Class<T> type);
 
@@ -92,17 +146,21 @@ public interface Context {
      * the current command's execution is complete.
      * On resume, the process execution will continue from
      * the next planned step.
+     *
+     * @param eventName name of the event. Should be unique across the process. The same
+     *                  name must be specified to resume the process.
      */
     void suspend(String eventName);
 
     /**
      * Suspends the current task execution and resumes a {@link ReentrantTask}
      * with the provided payload.
+     * <p>
+     * Unstable API, subject to change.
      *
-     * @param eventName the name of the event on which the process is suspended on.
+     * @param eventName the name of the event on which the process will be suspended on.
      * @param payload   passed to the {@link ReentrantTask#resume(ResumeEvent)} method
      *                  once the process is resumed.
-     * @apiNote unstable API, subject to change
      */
     void reentrantSuspend(String eventName, Map<String, Serializable> payload);
 

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ContextUtils.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ContextUtils.java
@@ -31,6 +31,8 @@ public final class ContextUtils {
     /**
      * Returns the current "retry" attempt number (if applicable).
      *
+     * @param ctx current {@link Context}
+     * @return the current attemp number of {@code null} if the current call is a retry.
      * @see Constants.Runtime#RETRY_ATTEMPT_NUMBER
      */
     public static Integer getCurrentRetryAttemptNumber(Context ctx) {

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DependencyManager.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DependencyManager.java
@@ -32,7 +32,11 @@ import java.nio.file.Path;
 public interface DependencyManager {
 
     /**
-     * Downloads the URL or returns a previously cached copy.
+     * Downloads the specified URI or returns a previously cached copy.
+     *
+     * @param uri target {@link URI}
+     * @return absolute path to the downloaded file.
+     * @throws IOException if an error occurs during downloading or saving the file.
      */
     Path resolve(URI uri) throws IOException;
 }

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DockerContainerSpec.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DockerContainerSpec.java
@@ -102,10 +102,10 @@ public interface DockerContainerSpec {
     interface Options {
 
         /**
-         * Extra /etc/hosts entries.
+         * Extra {@code /etc/hosts} entries.
          * Same as {@code --add-host} option in {@code docker run}
          *
-         * @return
+         * @return list of extra {@code /etc/hosts} entries.
          */
         @Nullable
         List<String> hosts();

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DockerService.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/DockerService.java
@@ -27,10 +27,12 @@ public interface DockerService {
     /**
      * Starts a new Docker container using the provided {@code spec}.
      *
-     * @param spec        the container's specification
-     * @param outCallback callback for stdout
-     * @param errCallback callback for stderr
-     * @return exit code of the `docker run` command
+     * @param spec        the container's specification.
+     * @param outCallback callback for stdout.
+     * @param errCallback callback for stderr.
+     * @return exit code of the `docker run` command.
+     * @throws IOException          if an error occurs during the start of the container.
+     * @throws InterruptedException if the thread was interrupted during the start of the container.
      */
     int start(DockerContainerSpec spec, LogCallback outCallback, LogCallback errCallback) throws IOException, InterruptedException; // TODO throw Exception instead?
 

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Execution.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Execution.java
@@ -45,8 +45,10 @@ public interface Execution {
     Step currentStep();
 
     /**
-     * ID of the current task or expression call. Can be used by plugins to correlate their events
-     * with the task's event.
+     * ID of the current task or the expression call. Can be used by plugins to
+     * correlate their events with the task event.
+     *
+     * @return the event correlation ID of the current step.
      */
     UUID correlationId();
 

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/SensitiveData.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/SensitiveData.java
@@ -29,7 +29,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 /**
  * This annotation can be used to prevent task arguments values from
  * being recorded in process events.
- * <p/>
+ * <p>
  * Currently, it is applicable only for task methods called directly
  * via expressions. For example:
  * <pre>{@code

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Task.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Task.java
@@ -28,6 +28,10 @@ public interface Task {
 
     /**
      * This method is called when the task is invoked using the {@code task} syntax.
+     *
+     * @param input {@code in} parameters.
+     * @return {@link TaskResult} instance.
+     * @throws Exception any error.
      */
     default TaskResult execute(Variables input) throws Exception {
         throw new IllegalStateException("The task doesn't support full task syntax yet. " +

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskProvider.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskProvider.java
@@ -25,7 +25,7 @@ import java.util.Set;
 /**
  * Provider for tasks. Responsible for creating task instances using
  * the supplied {@link Context} and the key.
- * <p/>
+ * <p>
  * Multiple task providers can exist in the same injector.
  * The {@code @Priority} annotation can be used to specify the order
  * in which each provider is called. Providers with lowest numbers are

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskResult.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskResult.java
@@ -35,6 +35,8 @@ public interface TaskResult extends Serializable {
 
     /**
      * Creates a new instance of {@link TaskResult} with {@link SimpleResult#ok()} set to {@code true}.
+     *
+     * @return {@link TaskResult}
      */
     static SimpleResult success() {
         return new SimpleResult(true, null, null);
@@ -55,6 +57,9 @@ public interface TaskResult extends Serializable {
     /**
      * Creates a new instance of {@link TaskResult} with {@link SimpleResult#ok()} set to {@code false}
      * and with the provided error message.
+     *
+     * @param message error message.
+     * @return {@link TaskResult}
      */
     static SimpleResult error(String message) {
         return new SimpleResult(false, message, null);
@@ -71,7 +76,7 @@ public interface TaskResult extends Serializable {
     /**
      * Result of a task call. Provides some common fields such as {@link #ok()}
      * and {@link #error()}, allows arbitrary data in {@link #values()}.
-     * <p/>
+     * <p>
      * All values must be {@link Serializable}, including collection types.
      * Avoid using custom types/classes as values.
      */
@@ -129,6 +134,8 @@ public interface TaskResult extends Serializable {
          * </ul>
          * <p>
          * Those fields will override any values with the same keys.
+         *
+         * @return {@link Map} of all result values.
          */
         public Map<String, Object> toMap() {
             Map<String, Object> result = new HashMap<>(values != null ? values : Collections.emptyMap());

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/WorkingDirectory.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/WorkingDirectory.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 /**
  * Contains path to the current process' working directory.
  * Can be @Inject-ed into services.
- * @apiNote v2 only
  */
 public class WorkingDirectory {
 


### PR DESCRIPTION
Document more methods in the runtime v2 SDK.
Make `javax.inject` an explicit dependency of the SDK.
Publish the javadoc artifact.