### PR TITLE
dependency-manager: remove dots from the resolveFile log

### DIFF
--- a/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
+++ b/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
@@ -217,7 +217,7 @@ public class DependencyManager {
                 return dst;
             }
 
-            log.info("resolveFile -> downloading {}...", uri);
+            log.info("resolveFile -> downloading {}", uri);
 
             Path tmp = baseDir.resolve(name + ".tmp");
             try {


### PR DESCRIPTION
So that clickable URLs in the UI don't end with `...`