### PR TITLE
concord-server: allow overriding of default cfg values

### DIFF
--- a/server/dist/src/assembly/default.conf
+++ b/server/dist/src/assembly/default.conf
@@ -1,19 +1,29 @@
 concord-server {
     db {
         appPassword = "q1"
+        appPassword = ${?DB_PASSWORD}
+
         inventoryPassword = "q1"
+        inventoryPassword = ${?DB_INVENTORY_PASSWORD}
     }
 
     secretStore {
         # base64 of 'example'
         serverPassword = "ZXhhbXBsZQ=="
+        serverPassword = ${?SECRET_STORE_SERVER_PASSWORD}
+
         secretStoreSalt = "ZXhhbXBsZQ=="
+        secretStoreSalt = ${?SECRET_STORE_SALT}
+
         projectSecretSalt = "ZXhhbXBsZQ=="
+        projectSecretSalt = ${?PROJECT_SECRET_SALT}
     }
 
     noderoster {
         db {
             password = "q1"
+            password = ${db.appPassword}
+            password = ${?NODEROSTER_DB_PASSWORD}
         }
     }
 }


### PR DESCRIPTION
Provide a way to override default configuration values without creating a server config file.