### PR TITLE
ansible: allow users to append custom libs into PYTHONPATH

### DIFF
--- a/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleEnv.java
+++ b/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleEnv.java
@@ -86,6 +86,15 @@ public class AnsibleEnv {
         return this;
     }
 
+    public AnsibleEnv append(String key, String value, String delimiter) {
+        String current = env.get(key);
+        if (current == null) {
+            return put(key, value);
+        }
+
+        return put(key, value + delimiter + current);
+    }
+
     /**
      * Overridable environment variables.
      */

--- a/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleLibs.java
+++ b/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleLibs.java
@@ -61,7 +61,7 @@ public class AnsibleLibs {
     }
 
     public AnsibleLibs enrichEnv(AnsibleEnv env) {
-        env.put("PYTHONPATH", workDir.relativize(tmpDir.resolve(PYTHON_LIB_DIR)).toString());
+        env.append("PYTHONPATH", workDir.relativize(tmpDir.resolve(PYTHON_LIB_DIR)).toString(), ":");
         return this;
     }
 }


### PR DESCRIPTION
for example for ansible with docker:
```
    - task: ansible
      in:
        extraEnv:
          PYTHONPATH: "/home/concord/shared"
        ...
```