### PR TITLE
concord-server: Fix repository refresh filtering on GitHub event

### DIFF
--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/GitUtils.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/GitUtils.java
@@ -38,17 +38,21 @@ public final class GitUtils {
     }
 
     public static Path createBareRepository(Path data, Path baseTmpDir) throws Exception {
-        return createBareRepository(data, "initial message", baseTmpDir);
+        return createBareRepository(data, "initial message", baseTmpDir, null);
     }
 
     public static Path createBareRepository(Path data, String commitMessage) throws Exception {
-        return createBareRepository(data, commitMessage, null);
+        return createBareRepository(data, commitMessage, null, null);
     }
 
-    public static Path createBareRepository(Path data, String commitMessage, Path baseTmpDir) throws Exception {
+    public static Path createBareRepository(Path data, String commitMessage, Path baseTmpDir, String leaf) throws Exception {
+        if (leaf == null) {
+            leaf = "test";
+        }
+
         // init bare repository
         Path tmp = createTempDir(baseTmpDir);
-        Path repo = tmp.resolve("test");
+        Path repo = tmp.resolve(leaf);
         Files.createDirectories(repo);
 
         Git.init().setBare(true).setDirectory(repo.toFile()).call();

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractGitHubTriggersIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractGitHubTriggersIT.java
@@ -30,12 +30,11 @@ import com.walmartlabs.concord.it.common.GitUtils;
 import com.walmartlabs.concord.it.common.ITUtils;
 import com.walmartlabs.concord.it.common.ServerClient;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.transport.RefSpec;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
@@ -54,6 +53,11 @@ public abstract class AbstractGitHubTriggersIT extends AbstractServerIT {
     protected Path initRepo(String resource) throws Exception {
         Path src = Paths.get(AbstractGitHubTriggersIT.class.getResource(resource).toURI());
         return GitUtils.createBareRepository(src);
+    }
+
+    protected Path initRepo(String resource, String leaf) throws Exception {
+        Path src = Paths.get(AbstractGitHubTriggersIT.class.getResource(resource).toURI());
+        return GitUtils.createBareRepository(src, "init", null, leaf);
     }
 
     protected Path initProjectAndRepo(String orgName, String projectName, String repoName, String repoBranch, Path bareRepo) throws Exception {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/HasVariableFunctionTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/HasVariableFunctionTest.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.runtime.v2.runner.el;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.walmartlabs.concord.common.ConfigurationUtils;
 import com.walmartlabs.concord.runtime.v2.runner.el.functions.HasVariableFunction;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
@@ -162,13 +162,16 @@ public class GithubTriggerV2Processor implements GithubTriggerProcessor {
         @Override
         @WithTimer
         public void enrich(Payload payload, TriggerEntry trigger, Map<String, Object> result) {
-            Object projectInfoConditions = trigger.getConditions().get(com.walmartlabs.concord.sdk.Constants.Trigger.REPOSITORY_INFO);
+            Object projectInfoConditions =
+                    trigger.getConditions().get(com.walmartlabs.concord.sdk.Constants.Trigger.REPOSITORY_INFO);
             if (projectInfoConditions == null || payload.getFullRepoName() == null) {
                 return;
             }
 
             List<Map<String, Object>> repositoryInfos = new ArrayList<>();
-            List<RepositoryEntry> repositories = repositoryDao.find(payload.getFullRepoName());
+            List<RepositoryEntry> repositories =
+                    repositoryDao.findSimilar("%/" + payload.getFullRepoName() + "(.git)?/?");
+
             for (RepositoryEntry r : repositories) {
                 Map<String, Object> repositoryInfo = new HashMap<>();
                 repositoryInfo.put(REPO_ID_KEY, r.getId());

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryDao.java
@@ -197,6 +197,21 @@ public class RepositoryDao extends AbstractDao {
         return select.fetch(this::toEntry);
     }
 
+    public List<RepositoryEntry> findSimilar(String repoUrlPattern) {
+        return findSimilar(null, repoUrlPattern);
+    }
+
+    public List<RepositoryEntry> findSimilar(UUID projectId, String pattern) {
+        SelectConditionStep<Record12<UUID, UUID, String, String, String, String, String, Boolean, JSONB, UUID, String, String>> select = selectRepositoryEntry(dsl())
+                .where(REPOSITORIES.REPO_URL.similarTo(pattern));
+
+        if (projectId != null) {
+            select.and(REPOSITORIES.PROJECT_ID.eq(projectId));
+        }
+
+        return select.fetch(this::toEntry);
+    }
+
     public List<RepositoryEntry> findBySecretId(DSLContext tx, UUID secretId) {
         return selectRepositoryEntry(tx)
                 .where(REPOSITORIES.SECRET_ID.eq(secretId))


### PR DESCRIPTION
Currently, multiple repositories share a similar name with different endings in their URL, e.g.
```
[1] https://github.com/myorg/my-repo.git
[2] https://github.com/myorg/my-repo-tools.git
[3] https://github.com/myorg/my-repo-old.git
```
...when a `push` event is received for the repo with the shorter URL, all of the repositories are refreshed.

This fix implements a regular expression filter for finding the matching repository.