### PR TITLE
git-client: Disable git auto-maintenance

### DIFF
--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -130,6 +130,11 @@ public class GitClient {
                 .timeout(cfg.defaultOperationTimeout())
                 .addArgs("config", "advice.detachedHead", "false")
                 .build());
+        exec(Command.builder()
+                .workDir(workDir)
+                .timeout(cfg.defaultOperationTimeout())
+                .addArgs("config", "maintenance.auto", "false")
+                .build());
     }
 
     private void configureRemote(Path workDir, String url) {

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -135,6 +135,11 @@ public class GitClient {
                 .timeout(cfg.defaultOperationTimeout())
                 .addArgs("config", "maintenance.auto", "false")
                 .build());
+        exec(Command.builder()
+                .workDir(workDir)
+                .timeout(cfg.defaultOperationTimeout())
+                .addArgs("config", "gc.auto", "0")
+                .build());
     }
 
     private void configureRemote(Path workDir, String url) {


### PR DESCRIPTION
Cached repos are never pushed back to their origin. Disable auto-maintenance since it will just keep auto-maintenance-ing.

`git maintenance` was introduced in `2.29.0` and auto-maintenance is enabled by default. It can be controlled by `git config maintenance.auto` and the `fetch` parameter `--[no-]auto-maintenance`.