### PR TITLE
agent: allow redirect runner logs to stdout

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/WorkerModule.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/WorkerModule.java
@@ -32,13 +32,17 @@ import com.walmartlabs.concord.agent.remote.ApiClientFactory;
 import com.walmartlabs.concord.agent.remote.ProcessStatusUpdater;
 import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.SecretClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.UUID;
 
 public class WorkerModule extends AbstractModule {
 
-    private static final String REDIRECT_RUNNER_LOG_KEY = "REDIRECT_RUNNER_TO_STDOUT";
+    private static final Logger log = LoggerFactory.getLogger(WorkerModule.class);
+
+    private static final String REDIRECT_PROCESS_LOGS_TO_STDOUT_KEY = "REDIRECT_PROCESS_LOGS_TO_STDOUT";
 
     private final String agentId;
     private final UUID instanceId;
@@ -86,9 +90,12 @@ public class WorkerModule extends AbstractModule {
 
         Multibinder<LogAppender> logAppenders = Multibinder.newSetBinder(binder(), LogAppender.class);
         logAppenders.addBinding().to(RemoteLogAppender.class);
-        if (Boolean.parseBoolean(System.getenv(REDIRECT_RUNNER_LOG_KEY))) {
+
+        if (Boolean.parseBoolean(System.getenv(REDIRECT_PROCESS_LOGS_TO_STDOUT_KEY))) {
+            log.info("Redirecting process logs into the agent's stdout...");
             logAppenders.addBinding().to(StdOutLogAppender.class);
         }
+
         bind(LogAppender.class).to(CombinedLogAppender.class);
 
         bind(AgentImportManager.class).toProvider(AgentImportManagerProvider.class);

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/CombinedLogAppender.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/CombinedLogAppender.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.agent.logging;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import javax.inject.Inject;
 import java.util.Set;
 import java.util.UUID;

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/CombinedLogAppender.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/CombinedLogAppender.java
@@ -1,0 +1,40 @@
+package com.walmartlabs.concord.agent.logging;
+
+import javax.inject.Inject;
+import java.util.Set;
+import java.util.UUID;
+
+public class CombinedLogAppender implements LogAppender {
+
+    private final Set<LogAppender> appenders;
+
+    @Inject
+    public CombinedLogAppender(Set<LogAppender> appenders) {
+        this.appenders = appenders;
+    }
+
+    @Override
+    public void appendLog(UUID instanceId, byte[] ab) {
+        appenders.forEach(a -> a.appendLog(instanceId, ab));
+    }
+
+    @Override
+    public boolean appendLog(UUID instanceId, long segmentId, byte[] ab) {
+        boolean result = true;
+        for (LogAppender a : appenders) {
+            boolean done = a.appendLog(instanceId, segmentId, ab);
+            result = result && done;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean updateSegment(UUID instanceId, long segmentId, LogSegmentStats stats) {
+        boolean result = true;
+        for (LogAppender a : appenders) {
+            boolean done = a.updateSegment(instanceId, segmentId, stats);
+            result = result && done;
+        }
+        return result;
+    }
+}

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/StdOutLogAppender.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/StdOutLogAppender.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.agent.logging;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import java.util.UUID;
 
 public class StdOutLogAppender implements LogAppender {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/StdOutLogAppender.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/StdOutLogAppender.java
@@ -1,0 +1,24 @@
+package com.walmartlabs.concord.agent.logging;
+
+import java.util.UUID;
+
+public class StdOutLogAppender implements LogAppender {
+
+    private static final String PREFIX = "RUNNER: ";
+
+    @Override
+    public void appendLog(UUID instanceId, byte[] ab) {
+        System.out.print(PREFIX + new String(ab));
+    }
+
+    @Override
+    public boolean appendLog(UUID instanceId, long segmentId, byte[] ab) {
+        System.out.print(PREFIX + new String(ab));
+        return true;
+    }
+
+    @Override
+    public boolean updateSegment(UUID instanceId, long segmentId, LogSegmentStats stats) {
+        return true;
+    }
+}


### PR DESCRIPTION
with `REDIRECT_RUNNER_TO_STDOUT=true` agent env variable runner logs prints to agent stdout:
```
...
14:25:15.040 [queue-client] [INFO ] c.w.c.server.queueclient.QueueClient - send ['ProcessRequest{correlationId='3', capabilities='{}'}'] -> done
RUNNER: 2021-03-15T11:25:15.102+0000 [INFO ] Resolving process dependencies...
RUNNER: 2021-03-15T11:25:15.675+0000 [INFO ] Checking the dependency policy...
RUNNER: 2021-03-15T11:25:15.691+0000 [INFO ] Dependencies: 
....
```