### PR TITLE
concord-agent: disable preforks by default, use stable workDir

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
@@ -47,6 +47,7 @@ public class AgentConfiguration {
     private final Path dependencyCacheDir;
     private final Path dependencyListsDir;
     private final Path payloadDir;
+    private final Path workDirBase;
 
     private final Path logDir;
     private final long logMaxDelay;
@@ -66,6 +67,7 @@ public class AgentConfiguration {
         this.dependencyCacheDir = getOrCreatePath(cfg, "dependencyCacheDir");
         this.dependencyListsDir = getOrCreatePath(cfg, "dependencyListsDir");
         this.payloadDir = getOrCreatePath(cfg, "payloadDir");
+        this.workDirBase = getOrCreatePath(cfg, "workDirBase");
 
         this.logDir = getOrCreatePath(cfg, "logDir");
         this.logMaxDelay = cfg.getDuration("logMaxDelay", TimeUnit.MILLISECONDS);
@@ -94,6 +96,10 @@ public class AgentConfiguration {
 
     public Path getPayloadDir() {
         return payloadDir;
+    }
+
+    public Path getWorkDirBase() {
+        return workDirBase;
     }
 
     public Path getLogDir() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/PreForkConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/PreForkConfiguration.java
@@ -31,13 +31,19 @@ import java.util.concurrent.TimeUnit;
 @Singleton
 public class PreForkConfiguration {
 
+    private final boolean enabled;
     private final long maxAge;
     private final int maxCount;
 
     @Inject
     public PreForkConfiguration(Config cfg) {
+        this.enabled = cfg.getBoolean("prefork.enabled");
         this.maxAge = cfg.getDuration("prefork.maxAge", TimeUnit.MILLISECONDS);
         this.maxCount = cfg.getInt("prefork.maxCount");
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 
     public long getMaxAge() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/Utils.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/Utils.java
@@ -63,10 +63,14 @@ public final class Utils {
 
             String value = cfg.getString(key);
             if (value.startsWith("/")) {
-                Path p = Paths.get(value);
+                Path p = Paths.get(value)
+                        .normalize()
+                        .toAbsolutePath();
+
                 if (!Files.exists(p)) {
                     Files.createDirectories(p);
                 }
+
                 return p;
             }
             return IOUtils.createTempDir(value);

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
@@ -30,7 +30,6 @@ import com.walmartlabs.concord.agent.guice.AgentDependencyManager;
 import com.walmartlabs.concord.agent.logging.ProcessLog;
 import com.walmartlabs.concord.agent.logging.ProcessLogFactory;
 import com.walmartlabs.concord.agent.remote.AttachmentsUploader;
-import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
 
@@ -46,6 +45,7 @@ public class JobExecutorFactory {
     private final AgentConfiguration agentCfg;
     private final ServerConfiguration serverCfg;
     private final DockerConfiguration dockerCfg;
+    private final PreForkConfiguration preForkCfg;
 
     private final RunnerV1Configuration runnerV1Cfg;
     private final RunnerV2Configuration runnerV2Cfg;
@@ -63,6 +63,7 @@ public class JobExecutorFactory {
     public JobExecutorFactory(AgentConfiguration agentCfg,
                               ServerConfiguration serverCfg,
                               DockerConfiguration dockerCfg,
+                              PreForkConfiguration preForkCfg,
                               RunnerV1Configuration runnerV1Cfg,
                               RunnerV2Configuration runnerV2Cfg,
                               AgentDependencyManager dependencyManager,
@@ -75,6 +76,7 @@ public class JobExecutorFactory {
         this.agentCfg = agentCfg;
         this.serverCfg = serverCfg;
         this.dockerCfg = dockerCfg;
+        this.preForkCfg = preForkCfg;
 
         this.runnerV1Cfg = runnerV1Cfg;
         this.runnerV2Cfg = runnerV2Cfg;
@@ -112,6 +114,7 @@ public class JobExecutorFactory {
                     .jvmParams(runnerCfg.getJvmParams())
                     .dependencyListDir(agentCfg.getDependencyListsDir())
                     .dependencyCacheDir(agentCfg.getDependencyCacheDir())
+                    .workDirBase(agentCfg.getWorkDirBase())
                     .runnerPath(runnerCfg.getPath())
                     .runnerCfgDir(runnerCfg.getCfgDir())
                     .runnerSecurityManagerEnabled(runnerCfg.isSecurityManagerEnabled())
@@ -122,6 +125,7 @@ public class JobExecutorFactory {
                     .segmentedLogs(segmentedLogs)
                     .logDir(agentCfg.getLogDir())
                     .persistentWorkDir(runnerCfg.getPersistentWorkDir())
+                    .preforkEnabled(preForkCfg.isEnabled())
                     .build();
 
             JobExecutor delegate = new RunnerJobExecutor(runnerExecutorCfg, dependencyManager, defaultDependencies, attachmentsUploader, processPool, processLogFactory, executor);

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/ProcessPool.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/ProcessPool.java
@@ -87,9 +87,9 @@ public class ProcessPool {
                     throw new ExecutionException("Error while starting a new process", e);
                 }
 
-                log.info("take -> started a new process: {}", entry.procDir);
+                log.info("take -> started a new process: {}", entry.workDir);
             } else {
-                log.info("take -> using a pre-forked instance: {}", entry.procDir);
+                log.info("take -> using a pre-forked instance: {}", entry.workDir);
             }
 
             executor.submit(() -> populate(hc, launcher));
@@ -170,9 +170,9 @@ public class ProcessPool {
 
     private static void cleanup(ProcessEntry process) {
         try {
-            IOUtils.deleteRecursively(process.procDir);
+            IOUtils.deleteRecursively(process.workDir);
         } catch (IOException e) {
-            log.info("cleanup ['{}'] -> error: {}", process.procDir, e.getMessage());
+            log.info("cleanup ['{}'] -> error: {}", process.workDir, e.getMessage());
             // ignore
         }
     }
@@ -186,22 +186,22 @@ public class ProcessPool {
 
         private final long timestamp;
         private final Process process;
-        private final Path procDir;
+        private final Path workDir;
 
         private boolean remove = false;
 
-        public ProcessEntry(Process process, Path procDir) {
+        public ProcessEntry(Process process, Path workDir) {
             this.timestamp = System.currentTimeMillis();
             this.process = process;
-            this.procDir = procDir;
+            this.workDir = workDir;
         }
 
         public Process getProcess() {
             return process;
         }
 
-        public Path getProcDir() {
-            return procDir;
+        public Path getWorkDir() {
+            return workDir;
         }
     }
 }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerCommandBuilder.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerCommandBuilder.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class RunnerCommandBuilder {
 
     private String javaCmd;
-    private Path procDir;
+    private Path workDir;
     private Path runnerPath;
     private Path runnerCfgPath;
     private String logLevel;
@@ -44,8 +44,8 @@ public class RunnerCommandBuilder {
         return this;
     }
 
-    public RunnerCommandBuilder procDir(Path procDir) {
-        this.procDir = procDir;
+    public RunnerCommandBuilder workDir(Path workDir) {
+        this.workDir = workDir;
         return this;
     }
 
@@ -110,8 +110,8 @@ public class RunnerCommandBuilder {
         l.add("-Dsun.zip.disableMemoryMapping=true");
 
         // working directory
-        if (procDir != null) {
-            l.add("-Duser.dir=" + procDir.toString());
+        if (workDir != null) {
+            l.add("-Duser.dir=" + workDir.toString());
         }
 
         // default to UTF-8

--- a/agent/src/main/java/com/walmartlabs/concord/agent/remote/AttachmentsUploader.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/remote/AttachmentsUploader.java
@@ -42,8 +42,8 @@ public class AttachmentsUploader {
         this.apiClient = apiClient;
     }
 
-    public void upload(UUID instanceId, Path payloadDir) throws Exception {
-        Path attachmentsDir = payloadDir.resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME);
+    public void upload(UUID instanceId, Path workDir) throws Exception {
+        Path attachmentsDir = workDir.resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME);
         if (!Files.exists(attachmentsDir)) {
             return;
         }

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -1,3 +1,14 @@
+# Concord Agent
+#
+# Note: most of path parameters accept either absolute paths or a directory
+# name. With the latter, the effective path is ${CONCORD_TMP_DIR}/${value}
+#
+# E.g.
+#
+#   workDirBase = "workDirs" # means "/tmp/workDirs", created automatically
+#
+#   dependencyCacheDir = "/data/concord/dependencyCache" # path to an existing directory
+#
 concord-agent {
 
     # unique ID of the agent
@@ -16,8 +27,14 @@ concord-agent {
 
     # base directory to store the process payload
     # created automatically if not specified
-    # the actual payload is stored in "${payloadDir}/${randomName}"
     payloadDir = "payload"
+
+    # base directory for the process' ${workDir}
+    #
+    # Use the same value and use absolute paths when running multiple Agents.
+    # If the process keeps ${workDir} value as a part of another variable,
+    # the value might not longer be valid if the process restarts.
+    workDirBase = "/tmp/concord-agent/workDirs"
 
     # directory to store the process logs
     # created automatically if not specified
@@ -40,8 +57,27 @@ concord-agent {
 
     # JVM prefork settings
     prefork {
+        # enable/disabled the use of "preforks"
+        #
+        # When enabled, Agent keeps a copy of the process' JVM as a "spare".
+        # If Agent receives another process with the same classpath, JVM and
+        # Concord Runtime parameters, the "spare" is used. This can sometimes
+        # minimize the cost of JVM startup and classpath scanning.
+        #
+        # Note, enabling this mechanism can have other side-effects.
+        # The effective ${workDir} might exist before the process ID is known
+        # (in order to keep a "spare" running there, with all Java dependencies
+        # loaded).
+        # If any process keeps a copy of ${workDir} value as a part of another
+        # variable, the value might get stale if the process restarts (or resumes
+        # after suspend).
+        #
+        # When "false", the process' ${workDir} is always ${workDirBase}/${instanceId}
+        enabled = false
+
         # maximum time to keep a preforked JVM
         maxAge = "30 seconds"
+
         # maximum number of preforks
         maxCount = 3
     }

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -69,8 +69,8 @@ concord-agent {
         # (in order to keep a "spare" running there, with all Java dependencies
         # loaded).
         # If any process keeps a copy of ${workDir} value as a part of another
-        # variable, the value might get stale if the process restarts (or resumes
-        # after suspend).
+        # variable, the value might get stale, e.g. if the process restarts
+        # (or resumes after suspend) and, subsequently, gets a "fresh" workDir.
         #
         # When "false", the process' ${workDir} is always ${workDirBase}/${instanceId}
         enabled = false

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -33,7 +33,8 @@ concord-agent {
     #
     # Use the same value and use absolute paths when running multiple Agents.
     # If the process keeps ${workDir} value as a part of another variable,
-    # the value might not longer be valid if the process restarts.
+    # the value might not longer be valid if the process restarts and
+    # gets a new Agent.
     workDirBase = "/tmp/concord-agent/workDirs"
 
     # directory to store the process logs

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
@@ -35,7 +35,8 @@ public final class ConcordConfiguration {
                 .pullPolicy(PullPolicy.defaultPolicy())
                 .streamServerLogs(true)
                 .streamAgentLogs(true)
-                .useLocalMavenRepository(true);
+                .useLocalMavenRepository(true)
+                .extraConfigurationSupplier(() -> "concord-agent { prefork { enabled = true } }");
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v2/pom.xml
+++ b/it/runtime-v2/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
 
         <!-- to test the scripting feature -->
         <dependency>

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -57,7 +57,8 @@ public final class ConcordConfiguration {
                 .streamServerLogs(true)
                 .streamAgentLogs(true)
                 .sharedContainerDir(sharedDir)
-                .useLocalMavenRepository(true);
+                .useLocalMavenRepository(true)
+                .extraConfigurationSupplier(() -> "concord-agent { prefork { enabled = true } }");
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -198,7 +198,7 @@ public class ProcessIT {
         proc.assertLog(".*#1.*x=123.*");
         proc.assertLog(".*#2.*y=234.*");
         proc.assertLog(".*#3.*y=345.*");
-        proc.assertLog(".*same workDir: true.*");
+        proc.assertLog(".*same workDir: false.*");
 
         // ---
 

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -198,7 +198,7 @@ public class ProcessIT {
         proc.assertLog(".*#1.*x=123.*");
         proc.assertLog(".*#2.*y=234.*");
         proc.assertLog(".*#3.*y=345.*");
-        proc.assertLog(".*same workDir: false.*");
+        proc.assertLog(".*same workDir: true.*");
 
         // ---
 

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/checkpoints/concord.yml
@@ -26,3 +26,5 @@ flows:
     - log: "#3 ${aVar}" # ${x=123, y=345}
 
     - log: "same workDir: ${workDir == oldWorkDir}" # 'true' first time, 'false' after restoring a checkpoint
+
+    # see also the description of "prefork.enable" parameter in concord-agent.conf

--- a/it/server/src/test/resources/agent.conf
+++ b/it/server/src/test/resources/agent.conf
@@ -1,5 +1,9 @@
 concord-agent {
 
+    prefork {
+        enabled = true
+    }
+
     capabilities = {
         type = "test"
     }

--- a/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
+++ b/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
@@ -328,6 +328,7 @@ public class Constants {
         /**
          * Directory which contains payload data.
          */
+        @Deprecated
         public static final String PAYLOAD_DIR_NAME = "payload";
 
         /**


### PR DESCRIPTION
See the description of [the new concord-agent.conf parameters](https://github.com/walmartlabs/concord/compare/stable-workdir#diff-659ff82d720ea53124e3e275edd8ad0067c6fc36e9514cad060bb8c21da3f359R37).

I'll do some manual testing, but the startup time impact should be negligible for v2 processes.
Since we started using sisu-maven-plugin, the classpath scanning time is pretty much no longer an issue.

Setting `preforks.enabled = true` returns the old behavior which might be desired for v1-heavy environments.




