### PR TITLE
concord-server: set SameSite=Lax for the session cookie

### DIFF
--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -19,6 +19,10 @@ concord-server {
         secureCookies = false
         secureCookies = ${?SECURE_COOKIES}
 
+        # make the session cookie use SameSite=Lax policy
+        # see https://github.com/eclipse/jetty.project/issues/4247
+        cookieComment = "__SAME_SITE_LAX__"
+
         # timeout of Jetty sessions
         sessionTimeout = "30 minutes"
         sessionTimeout = ${?SESSION_TIMEOUT}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/HttpServer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/HttpServer.java
@@ -96,6 +96,7 @@ public class HttpServer {
         ServletContext context = contextHandler.getServletContext();
         SessionCookieConfig sessionCookieConfig = context.getSessionCookieConfig();
         sessionCookieConfig.setHttpOnly(true);
+        sessionCookieConfig.setComment(cfg.getCookieComment());
         if (cfg.isSecureCookies()) {
             sessionCookieConfig.setSecure(true);
         }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ServerConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ServerConfiguration.java
@@ -45,6 +45,10 @@ public class ServerConfiguration implements Serializable {
     private boolean secureCookies;
 
     @Inject
+    @Config("server.cookieComment")
+    private String cookieComment;
+
+    @Inject
     @Config("server.sessionTimeout")
     private Duration sessionTimeout;
 
@@ -75,6 +79,10 @@ public class ServerConfiguration implements Serializable {
 
     public boolean isSecureCookies() {
         return secureCookies;
+    }
+
+    public String getCookieComment() {
+        return cookieComment;
     }
 
     public Duration getSessionTimeout() {


### PR DESCRIPTION
Use the `SameSite=Lax` policy for the session cookie to avoid cross-origin requests.