### PR TITLE
concord-server: Only pass enabled repos to refresh task

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/Events.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/Events.java
@@ -42,19 +42,30 @@ public class Events {
 
         public static final String REPOSITORY_UPDATED_EVENT = "repositoryUpdated";
 
-        public static Map<String, Object> repositoryCreated(UUID projectId, UUID repositoryId, String repositoryName) {
-            return event(REPOSITORY_CREATED_EVENT, projectId, repositoryId, repositoryName);
+        public static Map<String, Object> repositoryCreated(UUID projectId,
+                                                            UUID repositoryId,
+                                                            String repositoryName,
+                                                            boolean enabled) {
+            return event(REPOSITORY_CREATED_EVENT, projectId, repositoryId, repositoryName, enabled);
         }
 
-        public static Map<String, Object> repositoryUpdated(UUID projectId, UUID repositoryId, String repositoryName) {
-            return event(REPOSITORY_UPDATED_EVENT, projectId, repositoryId, repositoryName);
+        public static Map<String, Object> repositoryUpdated(UUID projectId,
+                                                            UUID repositoryId,
+                                                            String repositoryName,
+                                                            boolean enabled) {
+            return event(REPOSITORY_UPDATED_EVENT, projectId, repositoryId, repositoryName, enabled);
         }
 
-        private static Map<String, Object> event(String eventType, UUID projectId, UUID repositoryId, String repositoryName) {
+        private static Map<String, Object> event(String eventType,
+                                                 UUID projectId,
+                                                 UUID repositoryId,
+                                                 String repositoryName,
+                                                 boolean enabled) {
             Map<String, Object> repositoryInfo = new HashMap<>();
             repositoryInfo.put(PROJECT_ID_KEY, projectId);
             repositoryInfo.put(REPO_ID_KEY, repositoryId);
             repositoryInfo.put(REPO_NAME_KEY, repositoryName);
+            repositoryInfo.put(REPO_ENABLED_KEY, enabled);
 
             Map<String, Object> event = new HashMap<>();
             event.put(Constants.Trigger.REPOSITORY_INFO, Collections.singletonList(repositoryInfo));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/github/GithubTriggerV2Processor.java
@@ -170,7 +170,7 @@ public class GithubTriggerV2Processor implements GithubTriggerProcessor {
 
             List<Map<String, Object>> repositoryInfos = new ArrayList<>();
             List<RepositoryEntry> repositories =
-                    repositoryDao.findSimilar("%/" + payload.getFullRepoName() + "(.git)?/?");
+                    repositoryDao.findSimilar("%[/:]" + payload.getFullRepoName() + "(.git)?/?");
 
             for (RepositoryEntry r : repositories) {
                 Map<String, Object> repositoryInfo = new HashMap<>();

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectRepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectRepositoryManager.java
@@ -136,7 +136,7 @@ public class ProjectRepositoryManager {
                 entry.isDisabled(),
                 entry.getMeta());
 
-        Map<String, Object> ev = Events.Repository.repositoryCreated(projectId, repoId, entry.getName());
+        Map<String, Object> ev = Events.Repository.repositoryCreated(projectId, repoId, entry.getName(), !entry.isDisabled());
         externalEventResource.event(Events.CONCORD_EVENT, ev);
 
         if (doAuditLog) {
@@ -170,7 +170,10 @@ public class ProjectRepositoryManager {
                 secret == null ? null : secret.getId(),
                 entry.isDisabled());
 
-        Map<String, Object> ev = Events.Repository.repositoryUpdated(projectId, repoId, entry.getName());
+        Map<String, Object> ev = Events.Repository.repositoryUpdated(projectId,
+                repoId,
+                entry.getName(),
+                !entry.isDisabled());
         externalEventResource.event(Events.CONCORD_EVENT, ev);
 
         RepositoryEntry newEntry = repositoryDao.get(tx, projectId, repoId);

--- a/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
+++ b/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
@@ -4,9 +4,14 @@ configuration:
 flows:
   onChange:
   - log: "Refreshing repository... ${event}"
-  - task: repositoryRefresh
-    in:
-      repositoryInfo: ${event.repositoryInfo.stream().filter(r -> r.enabled).toList()}
+  - name: "Filter to enabled repositories"
+    expr: ${event.repositoryInfo.stream().filter(r -> r.enabled).toList()}
+    out: repoIdsToRefresh
+  - if: ${repoIdsToRefresh.size() > 0}
+    then:
+      - task: repositoryRefresh
+        in:
+          repositoryInfo: ${repoIdsToRefresh}
 
 triggers:
   - concord:

--- a/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
+++ b/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
@@ -6,7 +6,7 @@ flows:
   - log: "Refreshing repository... ${event}"
   - task: repositoryRefresh
     in:
-      repositoryInfo: ${event.repositoryInfo}
+      repositoryInfo: ${event.repositoryInfo.stream().filter(r -> r.enabled).toList()}
 
 triggers:
   - concord:


### PR DESCRIPTION
Fixes the repo search pattern. Was not including ssh urls.

In the repository refresh workflow, we previously filtered the trigger on enabled repos. But if there's a mix of enabled and disabled repos all of them would get processed.