### PR TITLE
runtime-v2: log exception as a single error line

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -101,10 +101,10 @@ public class Main {
 
             System.exit(0);
         } catch (MultiException e) {
-            System.err.println(e.getMessage());
+            log.error(e.getMessage());
             System.exit(1);
         } catch (Throwable t) {
-            t.printStackTrace(System.err);
+            log.error("", t);
             System.exit(1);
         }
     }


### PR DESCRIPTION
before:
```
22:15:18 [ERROR] com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException: boo
22:15:18 [ERROR] 	at com.walmartlabs.concord.plugins.throwex.ThrowExceptionTaskV2.execute(ThrowExceptionTaskV2.java:41)
22:15:18 [ERROR] 	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallCommand.lambda$0(TaskCallCommand.java:84)
....
```

<img width="1153" alt="Screenshot 2021-04-21 at 17 08 39" src="https://user-images.githubusercontent.com/980726/115567907-6ebb7200-a2c4-11eb-9517-b99d02016b01.png">


after:
```
17:06:43 [ERROR] 
com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException: boo
	at com.walmartlabs.concord.plugins.throwex.ThrowExceptionTaskV2.execute(ThrowExceptionTaskV2.java:41)
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallCommand.lambda$0(TaskCallCommand.java:84)
```

<img width="1145" alt="Screenshot 2021-04-21 at 17 09 44" src="https://user-images.githubusercontent.com/980726/115567936-7549e980-a2c4-11eb-825b-ef25dbd95aea.png">
