### PR TITLE
runtime-v2: Support 'name' attribute for script calls

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
@@ -20,13 +20,14 @@ package com.walmartlabs.concord.runtime.v2.parser;
  * =====
  */
 
+import com.walmartlabs.concord.runtime.v2.Constants;
 import com.walmartlabs.concord.runtime.v2.model.ImmutableScriptCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.ScriptCall;
 import com.walmartlabs.concord.runtime.v2.model.ScriptCallOptions;
 import com.walmartlabs.concord.runtime.v2.model.WithItems;
 import io.takari.parc.Parser;
 
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.satisfyField;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.with;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.optional;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.options;
@@ -35,23 +36,32 @@ import static com.walmartlabs.concord.runtime.v2.parser.RetryGrammar.retryVal;
 
 public final class ScriptGrammar {
 
-    private static final Parser<Atom, ScriptCallOptions> scriptOptions =
-            with(ScriptCallOptions::builder,
-                    o -> options(
-                            optional("body", stringVal.map(o::body)),
-                            optional("in", mapVal.map(o::input)),
-                            optional("meta", mapVal.map(o::meta)),
-                            optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
-                            optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
-                            optional("retry", retryVal.map(o::retry)),
-                            optional("error", stepsVal.map(o::errorSteps))
-                    ))
-                    .map(ImmutableScriptCallOptions.Builder::build);
+    private static Parser<Atom, ScriptCallOptions> scriptOptions(String stepName) {
+        return with(() -> optionsBuilder(stepName),
+                o -> options(
+                        optional("body", stringVal.map(o::body)),
+                        optional("in", mapVal.map(o::input)),
+                        optional("meta", mapVal.map(o::meta)),
+                        optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
+                        optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
+                        optional("retry", retryVal.map(o::retry)),
+                        optional("error", stepsVal.map(o::errorSteps))
+                ))
+                .map(ImmutableScriptCallOptions.Builder::build);
+    }
+
+    private static ImmutableScriptCallOptions.Builder optionsBuilder(String stepName) {
+        ImmutableScriptCallOptions.Builder result = ImmutableScriptCallOptions.builder();
+        if (stepName != null) {
+            result.putMeta(Constants.SEGMENT_NAME, stepName);
+        }
+        return result;
+    }
 
     public static final Parser<Atom, ScriptCall> script =
-            satisfyField("script", YamlValueType.SCRIPT, a ->
-                    stringVal.bind(languageOrRef ->
-                            scriptOptions.map(options -> new ScriptCall(a.location, languageOrRef, options))));
+            namedStep("script", YamlValueType.SCRIPT, (stepName, a) ->
+                stringVal.bind(languageOrRef ->
+                        scriptOptions(stepName).map(options -> new ScriptCall(a.location, languageOrRef, options))));
 
     private ScriptGrammar() {
     }


### PR DESCRIPTION
Support name attribute for log segment metadata.

```yaml
- name: "Custom script segment name"
  script: groovy
  body: |
    log.info("Hello from customized script call")
```

![Screen Shot 2021-04-21 at 1 21 18 PM](https://user-images.githubusercontent.com/4554569/115602387-7f5bf000-a2a4-11eb-8dcd-8fdf663937d1.png)