### PR TITLE
db: initialize with dynamic default agent token

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ServerConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ServerConfiguration.java
@@ -57,6 +57,9 @@ public class ServerConfiguration {
         log.info("Using the Server's websocket addresses: {}", (Object[]) websocketUrls);
 
         this.apiKey = cfg.getString("server.apiKey");
+        if (this.apiKey == null || this.apiKey.trim().isEmpty()) {
+            throw new IllegalArgumentException("Configuration is missing value for server.apiKey!");
+        }
 
         this.pingInterval = cfg.getDuration("server.websocketPingInterval", TimeUnit.MILLISECONDS);
         this.maxNoActivityPeriod = cfg.getDuration("server.websocketMaxNoActivityPeriod", TimeUnit.MILLISECONDS);

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -111,8 +111,9 @@ concord-agent {
 
 
         # API key to use
-        # as defined in server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.69.0.xml
-        apiKey = "O+JMYwBsU797EKtlRQYu+Q"
+        # Generated on Server first start or defined in server.conf at db.changeLogParameters.defaultAgentToken
+        # IMPORTANT! After initialization, create a new token via API and delete initial token
+        apiKey = ""
 
         # maximum time interval without a heartbeat before the process fails
         maxNoHeartbeatInterval = "5 minutes"

--- a/docker-images/compose/concord.conf
+++ b/docker-images/compose/concord.conf
@@ -3,6 +3,10 @@ concord-server {
         url = "jdbc:postgresql://concord-db:5432/postgres"
         appPassword = "q1q1q1q1"
         inventoryPassword = "q1q1q1q1"
+
+        changeLogParameters {
+            defaultAgentToken = "cTJxMnEycTI="  # base64 of 'q2q2q2q2'
+        }
     }
 
     secretStore {
@@ -16,9 +20,6 @@ concord-agent {
     server {
         apiBaseUrl = "http://concord-server:8001"
         websocketUrl = "ws://concord-server:8001/websocket"
-    }
-
-    docker {
-        host = "tcp://concord-dind:6666"
+        apiKey = "cTJxMnEycTI="
     }
 }

--- a/docker-images/server.conf
+++ b/docker-images/server.conf
@@ -2,6 +2,10 @@ concord-server {
     db {
         appPassword = "q1"
         inventoryPassword = "q1"
+
+        changeLogParameters {
+            defaultAgentToken = "cTJxMnEycTI="  # base64 of 'q2q2q2q2'
+        }
     }
 
     secretStore {
@@ -23,3 +27,8 @@ concord-server {
     }
 }
 
+concord-agent {
+    server {
+        apiKey = "cTJxMnEycTI="
+    }
+}

--- a/it/console/pom.xml
+++ b/it/console/pom.xml
@@ -242,9 +242,11 @@
                                                 <volume>${settings.localRepository}:/host/.m2/repository:ro</volume>
                                                 <volume>${basedir}/src/test/resources/console.conf:/opt/concord/console/nginx/app.conf:ro</volume>
                                                 <volume>${basedir}/src/test/resources/mvn.json:/opt/concord/conf/mvn.json:ro</volume>
+                                                <volume>${basedir}/src/test/resources/agent.conf:/opt/concord/conf/agent.conf:ro</volume>
                                             </bind>
                                         </volumes>
                                         <env>
+                                            <CONCORD_CFG_FILE>/opt/concord/conf/agent.conf</CONCORD_CFG_FILE>
                                             <CONCORD_DOCKER_LOCAL_MODE>false</CONCORD_DOCKER_LOCAL_MODE>
                                             <CONCORD_MAVEN_CFG>/opt/concord/conf/mvn.json</CONCORD_MAVEN_CFG>
                                             <CONCORD_TMP_DIR>${tmp.dir}</CONCORD_TMP_DIR>

--- a/it/console/src/test/resources/agent.conf
+++ b/it/console/src/test/resources/agent.conf
@@ -1,0 +1,5 @@
+concord-agent {
+    server {
+        apiKey = "cTJxMnEycTI="
+    }
+}

--- a/it/console/src/test/resources/server.conf
+++ b/it/console/src/test/resources/server.conf
@@ -2,6 +2,7 @@ concord-server {
     db {
         changeLogParameters {
             defaultAdminToken = "cTFxMXExcTE="
+            defaultAgentToken = "cTJxMnEycTI="
         }
     }
 

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
@@ -252,7 +252,7 @@ public class FormIT {
     }
 
     private static void startCustomFormSession(ConcordRule concord, UUID instanceId, String formName) throws Exception {
-        URL url = new URL(concord.apiUrlPrefix() + "/api/service/custom_form/" + instanceId + "/" + formName + "/start");
+        URL url = new URL(concord.apiBaseUrl() + "/api/service/custom_form/" + instanceId + "/" + formName + "/start");
         HttpURLConnection http = (HttpURLConnection)url.openConnection();
         http.setRequestProperty("Authorization", concord.environment().apiToken());
         http.setRequestMethod("POST");
@@ -266,7 +266,7 @@ public class FormIT {
 
     @SuppressWarnings("unchecked")
     private static Map<String, Object> getDataJs(ConcordRule concord, UUID instanceId, String formName) throws Exception {
-        URL url = new URL(concord.apiUrlPrefix() + "/forms/" + instanceId + "/" + formName + "/form/data.js");
+        URL url = new URL(concord.apiBaseUrl() + "/forms/" + instanceId + "/" + formName + "/form/data.js");
         HttpURLConnection http = (HttpURLConnection)url.openConnection();
         http.setRequestProperty("Authorization", concord.environment().apiToken());
         http.connect();

--- a/it/server/src/test/resources/agent.conf
+++ b/it/server/src/test/resources/agent.conf
@@ -7,4 +7,8 @@ concord-agent {
     capabilities = {
         type = "test"
     }
+
+    server {
+        apiKey = "cTJxMnEycTI="
+    }
 }

--- a/it/server/src/test/resources/server.conf
+++ b/it/server/src/test/resources/server.conf
@@ -2,6 +2,7 @@ concord-server {
     db {
         changeLogParameters {
             defaultAdminToken = "cTFxMXExcTE="
+            defaultAgentToken = "cTJxMnEycTI="
         }
     }
 

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -98,5 +98,6 @@
     <include file="v1.81.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.83.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.85.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.86.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.69.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.69.0.xml
@@ -6,17 +6,35 @@
 
     <property name="concordAgentUserId" value="d4f123c1-f8d4-40b2-8a12-b8947b9ce2d8"/>
 
-    <changeSet id="69000" author="ybrigo@gmail.com">
+    <!-- moved to v1.86.0.xml (no more hard-coded default token) -->
+<!--    <changeSet id="69000" author="ybrigo@gmail.com">
+            <insert tableName="USERS">
+                <column name="USER_ID">${concordAgentUserId}</column>
+                <column name="USERNAME">concordAgent</column>
+                <column name="USER_TYPE">LOCAL</column>
+            </insert>
+
+            <insert tableName="API_KEYS">
+                &lt;!&ndash; "O+JMYwBsU797EKtlRQYu+Q" &ndash;&gt;
+                <column name="API_KEY">1sw9eLZ41EOK4w/iV3jFnn6cqeAMeFtxfazqVY04koY</column>
+                <column name="USER_ID">${concordAgentUserId}</column>
+            </insert>
+        </changeSet> -->
+
+    <!-- Create agent user when not exist -->
+    <changeSet id="69001" author="benjamin.broadaway@walmart.com.com">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(USER_ID)
+                from USERS
+                where user_id = '${concordAgentUserId}';
+            </sqlCheck>
+        </preConditions>
+
         <insert tableName="USERS">
             <column name="USER_ID">${concordAgentUserId}</column>
             <column name="USERNAME">concordAgent</column>
             <column name="USER_TYPE">LOCAL</column>
-        </insert>
-        
-        <insert tableName="API_KEYS">
-            <!-- "O+JMYwBsU797EKtlRQYu+Q" -->
-            <column name="API_KEY">1sw9eLZ41EOK4w/iV3jFnn6cqeAMeFtxfazqVY04koY</column>
-            <column name="USER_ID">${concordAgentUserId}</column>
         </insert>
     </changeSet>
 

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.70.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.70.0.xml
@@ -4,21 +4,21 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <property name="concordRunnerUserId" value="2599c604-1384-4660-a767-8bc03baa7a31"/>
+<!--    <property name="concordRunnerUserId" value="2599c604-1384-4660-a767-8bc03baa7a31"/>
 
-    <changeSet id="70000" author="ybrigo@gmail.com">
-        <insert tableName="USERS">
-            <column name="USER_ID">${concordRunnerUserId}</column>
-            <column name="USERNAME">concordRunner</column>
-            <column name="USER_TYPE">LOCAL</column>
-        </insert>
-        
-        <insert tableName="API_KEYS">
-            <!-- "Gz0q/DeGlH8Zs7QJMj1v8g" -->
-            <column name="API_KEY">DrRt3j6G7b6GHY/Prddu4voyKyZa17iFkEj99ac0q/A</column>
-            <column name="USER_ID">${concordRunnerUserId}</column>
-        </insert>
-    </changeSet>
+        <changeSet id="70000" author="ybrigo@gmail.com">
+            <insert tableName="USERS">
+                <column name="USER_ID">${concordRunnerUserId}</column>
+                <column name="USERNAME">concordRunner</column>
+                <column name="USER_TYPE">LOCAL</column>
+            </insert>
+
+            <insert tableName="API_KEYS">
+                &lt;!&ndash; "Gz0q/DeGlH8Zs7QJMj1v8g" &ndash;&gt;
+                <column name="API_KEY">DrRt3j6G7b6GHY/Prddu4voyKyZa17iFkEj99ac0q/A</column>
+                <column name="USER_ID">${concordRunnerUserId}</column>
+            </insert>
+        </changeSet> -->
 
     <changeSet id="70100" author="ybrigo@gmail.com">
         <addColumn tableName="PROCESS_QUEUE">

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.45.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.45.0.xml
@@ -4,16 +4,18 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="1450000" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
-        <sql>
-            delete from API_KEYS where KEY_ID = 'd5165ca8-e8de-11e6-9bf5-136b5db23c32'
-        </sql>
+<!-- moved to v1.86.0.xml -->
+<!--    <changeSet id="1450000" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
+            <sql>
+                delete from API_KEYS where KEY_ID = 'd5165ca8-e8de-11e6-9bf5-136b5db23c32'
+            </sql>
 
-        <customChange class="com.walmartlabs.concord.server.liquibase.ext.ApiTokenCreator">
-            <!-- default admin user ID -->
-            <param name="userId" value="230c5c9c-d9a7-11e6-bcfd-bb681c07b26c"/>
-            <!-- value from concord-server.conf -->
-            <param name="token" value="${defaultAdminToken}"/>
-        </customChange>
-    </changeSet>
+            <customChange class="com.walmartlabs.concord.server.liquibase.ext.ApiTokenCreator">
+                &lt;!&ndash; default admin user ID &ndash;&gt;
+                <param name="userId" value="230c5c9c-d9a7-11e6-bcfd-bb681c07b26c"/>
+                <param name="username" value="admin"/>
+                &lt;!&ndash; value from concord-server.conf &ndash;&gt;
+                <param name="token" value="${defaultAdminToken}"/>
+            </customChange>
+        </changeSet> -->
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <property name="concordAdminUserId" value="230c5c9c-d9a7-11e6-bcfd-bb681c07b26c"/>
+    <property name="concordAgentUserId" value="d4f123c1-f8d4-40b2-8a12-b8947b9ce2d8"/>
+    <property name="concordRunnerUserId" value="2599c604-1384-4660-a767-8bc03baa7a31"/>
+
+    <!-- delete old hard-coded default admin API token -->
+    <changeSet id="1860000" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
+        <sql>
+            delete from API_KEYS where KEY_ID = 'd5165ca8-e8de-11e6-9bf5-136b5db23c32'
+        </sql>
+    </changeSet>
+
+    <!-- Set initial admin API token when not exist  -->
+    <changeSet id="1860100" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(key_id)
+                from API_KEYS
+                where user_id = '${concordAdminUserId}';
+            </sqlCheck>
+        </preConditions>
+
+        <customChange class="com.walmartlabs.concord.server.liquibase.ext.ApiTokenCreator">
+            <!-- default admin user ID -->
+            <param name="userId" value="${concordAdminUserId}"/>
+            <param name="username" value="admin"/>
+            <!-- value from concord-server.conf -->
+            <param name="token" value="${defaultAdminToken}"/>
+        </customChange>
+    </changeSet>
+
+    <!-- Set initial agent API token when not exist  -->
+    <changeSet id="1860300" author="benjamin.broadaway@walmart.com" runInTransaction="false" context="!codegen">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(key_id)
+                from API_KEYS
+                    join users u ON api_keys.user_id = u.user_id
+                where lower(USERNAME) = lower('concordAgent');
+            </sqlCheck>
+        </preConditions>
+
+        <customChange class="com.walmartlabs.concord.server.liquibase.ext.ApiTokenCreator">
+            <!-- default agent user id from v0.69.0.xml -->
+            <param name="userId" value="${concordAgentUserId}"/>
+            <param name="username" value="concordAgent"/>
+            <!-- value from concord-server.conf -->
+            <param name="token" value="${defaultAgentToken}"/>
+        </customChange>
+    </changeSet>
+
+    <!-- Delete runner API tokens and user when exist  -->
+    <changeSet id="1860400" author="benjamin.broadaway@walmart.com" runInTransaction="false" context="!codegen">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                select count(USER_ID)
+                from USERS
+                where lower(USERNAME) = lower('concordRunner');
+            </sqlCheck>
+        </preConditions>
+
+        <sql>
+            delete from API_KEYS where USER_ID = '${concordRunnerUserId}'
+        </sql>
+
+        <sql>
+            delete from USERS where USER_ID = '${concordRunnerUserId}'
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -83,6 +83,12 @@ concord-server {
             # applied only once on the first DB migration
             defaultAdminToken = ""
 
+            # the default agent API token value
+            # must be a valid base64 value
+            # if empty a new random token will be generated
+            # applied only once on the first DB migration
+            defaultAgentToken = ""
+
             # some migrations can be done faster if the DB user has the SUPERUSER role
             superuserAvailable = "true"
 

--- a/server/liquibase-ext/src/main/java/com/walmartlabs/concord/server/liquibase/ext/ApiTokenCreator.java
+++ b/server/liquibase-ext/src/main/java/com/walmartlabs/concord/server/liquibase/ext/ApiTokenCreator.java
@@ -35,7 +35,7 @@ import java.security.SecureRandom;
 import java.util.Base64;
 
 /**
- * Generates a new admin API token.
+ * Generates a new API token for a given user.
  */
 public class ApiTokenCreator implements CustomSqlChange, CustomSqlRollback {
 
@@ -43,6 +43,7 @@ public class ApiTokenCreator implements CustomSqlChange, CustomSqlRollback {
 
     private String token;
     private String userId;
+    private String username;
 
     public void setUserId(String userId) {
         this.userId = userId;
@@ -50,6 +51,10 @@ public class ApiTokenCreator implements CustomSqlChange, CustomSqlRollback {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     @Override
@@ -78,7 +83,7 @@ public class ApiTokenCreator implements CustomSqlChange, CustomSqlRollback {
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println();
-        System.out.println("Admin API token created: " + token);
+        System.out.println("API token created for user '" + username + "': " + token);
         System.out.println();
         System.out.println("(don't forget to remove it in production)");
         System.out.println();

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -103,7 +103,7 @@
         <sshd.version>1.6.0</sshd.version>
         <swagger.version>1.5.20</swagger.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
-        <testcontainers.concord.version>0.0.33</testcontainers.concord.version>
+        <testcontainers.concord.version>0.0.39</testcontainers.concord.version>
         <testcontainers.version>1.15.1</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <wiremock.version>2.26.1</wiremock.version>

--- a/vagrant/agent.conf
+++ b/vagrant/agent.conf
@@ -4,5 +4,7 @@ concord-agent {
     server {
         apiBaseUrl = "http://server:8001"
         websocketUrl = "ws://server:8001/websocket"
+
+        apiKey = "cTJxMnEycTI="
     }
 }

--- a/vagrant/server.conf
+++ b/vagrant/server.conf
@@ -2,6 +2,10 @@ concord-server {
     db {
         appPassword = "q1"
         inventoryPassword = "q1"
+
+        changeLogParameters {
+            defaultAgentToken = "cTJxMnEycTI="  # base64 of 'q2q2q2q2'
+        }
     }
 
     secretStore {


### PR DESCRIPTION
- Initialize DB without a hard-coded default agent API token:  New DBs will now initialize with a random or config-provided default API token. Existing DBs that update to the next version will not be cleaned up--so if anyone is actually still using the old hard-coded tokens they need to manually rotate the agent API token in their agent config.
- Modify dev scripts (docker-compose, vagrant) to handle agent API token
- Remove `concordRunner` user and tokens: It's not used