### PR TITLE
db: delete hard-coded API token

### DIFF
--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
@@ -35,7 +35,7 @@
     </changeSet>
 
     <!-- delete old hard-coded default agent API token -->
-    <changeSet id="1860200" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
+    <changeSet id="1860200" author="benjamin.broadaway@walmart.com" runInTransaction="false" context="!codegen">
         <sql>
             delete from API_KEYS
             where USER_ID = '${concordAgentUserId}'

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.86.0.xml
@@ -34,6 +34,15 @@
         </customChange>
     </changeSet>
 
+    <!-- delete old hard-coded default agent API token -->
+    <changeSet id="1860200" author="ybrigo@gmail.com" runInTransaction="false" context="!codegen">
+        <sql>
+            delete from API_KEYS
+            where USER_ID = '${concordAgentUserId}'
+            and API_KEY = '1sw9eLZ41EOK4w/iV3jFnn6cqeAMeFtxfazqVY04koY'
+        </sql>
+    </changeSet>
+
     <!-- Set initial agent API token when not exist  -->
     <changeSet id="1860300" author="benjamin.broadaway@walmart.com" runInTransaction="false" context="!codegen">
         <preConditions onFail="MARK_RAN">


### PR DESCRIPTION
Breaking change for systems that have never rotated the default Agent API token (😖).