### PR TITLE
concord-cli: re-use the DependencyManager instance

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -221,7 +221,7 @@ public class Run implements Callable<Integer> {
                 runnerCfg,
                 () -> cfg,
                 new ProcessDependenciesModule(targetDir, runnerCfg.dependencies()),
-                new CliServicesModule(secretStoreDir, targetDir, new VaultProvider(vaultDir, vaultId)))
+                new CliServicesModule(secretStoreDir, targetDir, new VaultProvider(vaultDir, vaultId), dependencyManager))
                 .create();
 
         Runner runner = injector.getInstance(Runner.class);


### PR DESCRIPTION
Make the CLI use a single configured instance of `DependencyManager`.
Before this change, the runtime was getting it's own instance with the default settings -- i.e. the cacheDir was not configured in the expected way.