### PR TITLE
smtp-tasks: Read default params in runtime-v2

### DIFF
--- a/plugins/tasks/smtp/src/main/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2.java
+++ b/plugins/tasks/smtp/src/main/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2.java
@@ -20,13 +20,15 @@ package com.walmartlabs.concord.plugins.smtp;
  * =====
  */
 
-import com.walmartlabs.concord.runtime.v2.sdk.*;
+import com.walmartlabs.concord.runtime.v2.sdk.Context;
+import com.walmartlabs.concord.runtime.v2.sdk.Task;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import com.walmartlabs.concord.runtime.v2.sdk.Variables;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 @Named("smtp")
@@ -41,10 +43,8 @@ public class SmtpTaskV2 implements Task {
 
     @Override
     public TaskResult execute(Variables input) throws Exception {
-        Map<String, Object> smtp = getCfg(ctx, input, ctx.defaultVariables().toMap(),
-                Constants.SMTP_PARAMS_KEY, Constants.SMTP_KEY);
-        Map<String, Object> mail = getCfg(ctx, input, ctx.defaultVariables().toMap(),
-                Constants.MAIL_PARAMS_KEY, Constants.MAIL_KEY);
+        Map<String, Object> smtp = getCfg(ctx, input, Constants.SMTP_PARAMS_KEY, Constants.SMTP_KEY);
+        Map<String, Object> mail = getCfg(ctx, input, Constants.MAIL_PARAMS_KEY, Constants.MAIL_KEY);
         Path baseDir = ctx.workingDirectory();
         Object scope = getScope(ctx, mail);
         boolean debug = input.getBoolean(Constants.DEBUG_KEY, false);
@@ -58,12 +58,10 @@ public class SmtpTaskV2 implements Task {
         return SmtpTaskUtils.getScope(mailParams, ctxParams);
     }
 
-    private Map<String, Object> getCfg(Context ctx, Variables input,
-                                       Map<String, Object> defaults, String a, String b) {
-        Variables vars = merge(input, defaults);
-        Map<String, Object> m = getMap(ctx, vars, a);
+    private Map<String, Object> getCfg(Context ctx, Variables input, String a, String b) {
+        Map<String, Object> m = getMap(ctx, input, a);
         if (m == null) {
-            m = getMap(ctx, vars, b);
+            m = getMap(ctx, input, b);
         }
 
         return m;
@@ -74,12 +72,10 @@ public class SmtpTaskV2 implements Task {
         if (m == null) {
             m = ctx.variables().getMap(s, null);
         }
-        return m;
-    }
 
-    public static Variables merge(Variables variables, Map<String, Object> defaults) {
-        Map<String, Object> variablesMap = new HashMap<>(defaults != null ? defaults : Collections.emptyMap());
-        variablesMap.putAll(variables.toMap());
-        return new MapBackedVariables(variablesMap);
+        if (m == null) {
+            m = ctx.defaultVariables().getMap(s, null);
+        }
+        return m;
     }
 }

--- a/plugins/tasks/smtp/src/test/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2Test.java
+++ b/plugins/tasks/smtp/src/test/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2Test.java
@@ -24,6 +24,7 @@ import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
 import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -42,30 +43,85 @@ public class SmtpTaskV2Test {
     @Rule
     public final GreenMailRule mailServer = new GreenMailRule(ServerSetupTest.SMTP);
 
-    @Test
-    public void test() throws Exception {
-        int port = mailServer.getSmtp().getPort();
+    @After
+    public void cleanup() {
+        mailServer.reset();
+    }
 
+    @Test
+    public void testWithPolicyDefaults() throws Exception {
         Map<String, Object> smtpParams = new HashMap<>();
         smtpParams.put("host", "localhost");
-        smtpParams.put("port", port);
+        smtpParams.put("port", mailServer.getSmtp().getPort());
 
         Map<String, Object> mail = new HashMap<>();
         mail.put("from", "me@localhost");
         mail.put("to", "you@localhost");
-        mail.put("message", "Hello!");
+        mail.put("message", "Default vars from policy.");
 
         Context ctx = mock(Context.class);
         when(ctx.workingDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
-        when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", smtpParams)));
+        when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", smtpParams)));
 
         SmtpTaskV2 t = new SmtpTaskV2(ctx);
         t.execute(new MapBackedVariables(Collections.singletonMap("mail", mail)));
 
         MimeMessage[] messages = mailServer.getReceivedMessages();
         assertEquals(1, messages.length);
-        assertEquals("Hello!\r\n", messages[0].getContent());
+        assertEquals("Default vars from policy.\r\n", messages[0].getContent());
+    }
 
-        mailServer.reset();
+    @Test
+    public void testWithProcessDefaults() throws Exception {
+        Map<String, Object> smtpParams = new HashMap<>();
+        smtpParams.put("host", "localhost");
+        smtpParams.put("port", mailServer.getSmtp().getPort());
+
+        Map<String, Object> mail = new HashMap<>();
+        mail.put("from", "me@localhost");
+        mail.put("to", "you@localhost");
+        mail.put("message", "Default vars from process arguments.");
+
+        Context ctx = mock(Context.class);
+        when(ctx.workingDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
+        when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", smtpParams)));
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
+
+        SmtpTaskV2 t = new SmtpTaskV2(ctx);
+        t.execute(new MapBackedVariables(Collections.singletonMap("mail", mail)));
+
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertEquals(1, messages.length);
+        assertEquals("Default vars from process arguments.\r\n", messages[0].getContent());
+    }
+
+    @Test
+    public void testWithBothDefaults() throws Exception {
+        Map<String, Object> policyDefaults = new HashMap<>();
+        policyDefaults.put("host", "badserver");
+        policyDefaults.put("port", -1);
+
+        // Process arg defaults override policy defaults
+        Map<String, Object> processArgsDefaults = new HashMap<>();
+        processArgsDefaults.put("host", "localhost");
+        processArgsDefaults.put("port", mailServer.getSmtp().getPort());
+
+        Map<String, Object> mail = new HashMap<>();
+        mail.put("from", "me@localhost");
+        mail.put("to", "you@localhost");
+        mail.put("message", "Default vars from process arguments.");
+
+        Context ctx = mock(Context.class);
+        when(ctx.workingDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
+        when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", processArgsDefaults)));
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", policyDefaults)));
+
+        SmtpTaskV2 t = new SmtpTaskV2(ctx);
+        t.execute(new MapBackedVariables(Collections.singletonMap("mail", mail)));
+
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertEquals(1, messages.length);
+        assertEquals("Default vars from process arguments.\r\n", messages[0].getContent());
     }
 }


### PR DESCRIPTION
Example policy config:
```json
{
  "defaultProcessCfg": {
    "processTimeout": "PT6H",
    "defaultTaskVariables": {
      "smtp": {
        "smtpParams": {
          "host": "my-smtp.example.com",
          "port": 25
        }
      }
    }
  }
}
```