### PR TITLE
concord-task: return process id/ids for start/startExternal/fork actions

### DIFF
--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -283,11 +283,14 @@ public class ConcordTaskCommon {
             if (!in.outVars().isEmpty()) {
                 out = getOutVars(in.baseUrl(), in.apiKey(), processId);
             }
+            
             return TaskResult.success()
+                    .value("id", processId)
                     .values(out);
         }
 
-        return TaskResult.success();
+        return TaskResult.success()
+                .value("id", processId);
     }
 
     public TaskResult continueAfterSuspend(ResumePayload payload) throws Exception {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -283,7 +283,7 @@ public class ConcordTaskCommon {
             if (!in.outVars().isEmpty()) {
                 out = getOutVars(in.baseUrl(), in.apiKey(), processId);
             }
-            
+
             return TaskResult.success()
                     .value("id", processId)
                     .values(out);
@@ -315,6 +315,7 @@ public class ConcordTaskCommon {
             // e.g. jobOut.someVar
             Map<String, Object> out = results.get(0).out;
             return TaskResult.success()
+                    .value("id", payload.jobs().get(0))
                     .values(out);
         } else {
             // for multiple jobs save their variable into a nested map
@@ -327,6 +328,7 @@ public class ConcordTaskCommon {
                 }
             }
             return TaskResult.success()
+                    .value("ids", payload.jobs())
                     .values(vars);
         }
     }
@@ -476,10 +478,16 @@ public class ConcordTaskCommon {
             handleResults(result, in.ignoreFailures());
         }
 
-        return TaskResult.success()
-                .value("forks", ids.stream()
-                        .map(UUID::toString)
-                        .collect(Collectors.toList()));
+        boolean single = ids.size() == 1;
+        if (single) {
+            return TaskResult.success()
+                    .value("id", ids.get(0).toString());
+        } else {
+            return TaskResult.success()
+                    .value("ids", ids.stream()
+                            .map(UUID::toString)
+                            .collect(Collectors.toList()));
+        }
     }
 
     private Future<UUID> forkOne(ForkStartParams in) {


### PR DESCRIPTION
start/starExternal result:
```
{ok=true, threadId=0, id=05c9b1ed-fc9b-4ab5-ad66-3725bf2ea951}
```

single fork result:
```
{ok=true, threadId=0, id=0933608a-8299-4bd5-93e8-b72aa433f347}
```

multi fork:
```
{ok=true, threadId=0, ids=[0101a794-6f95-4d04-adaf-37279daf4f71, 4a40fdb6-dd9d-43e4-87ee-332d3a4af4f4, edcf7f8f-11ac-4130-ac81-b8ab479cee18]}
```