### PR TITLE
runtime-v1, runtime-v2: add support for *.yaml files

### DIFF
--- a/it/runtime-v1/pom.xml
+++ b/it/runtime-v1/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>concord-common-it</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -479,6 +479,15 @@ public class ProcessIT {
         onFailureProc.assertLog(".*Last error was:.*PropertyNotFoundException.*");
     }
 
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void testYamlRootFile() throws Exception {
+        ConcordProcess proc = concord.processes().start(new Payload()
+                .archive(resource("yamlRootFile")));
+
+        proc.expectStatus(StatusEnum.FINISHED);
+        proc.assertLog(".*Hello!*");
+    }
+
     @SuppressWarnings("unchecked")
     private static void assertProcessErrorMessage(ProcessEntry p, String expected) {
         assertNotNull(p);

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -485,7 +485,7 @@ public class ProcessIT {
                 .archive(resource("yamlRootFile")));
 
         proc.expectStatus(StatusEnum.FINISHED);
-        proc.assertLog(".*Hello!*");
+        proc.assertLog(".*Hello, Concord!*");
     }
 
     @SuppressWarnings("unchecked")

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord.yaml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord.yaml
@@ -1,3 +1,3 @@
 flows:
   default:
-    - log: "Hello!"
+    - log: "Hello, ${name}!"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord.yaml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord.yaml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - log: "Hello!"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord/extra.yaml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/yamlRootFile/concord/extra.yaml
@@ -1,0 +1,3 @@
+configuration:
+  arguments:
+    name: "Concord"

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -399,6 +399,6 @@ public class ProcessIT {
 
         ConcordProcess proc = concord.processes().start(payload);
         proc.expectStatus(ProcessEntry.StatusEnum.FINISHED);
-        proc.assertLog(".*Hello!*");
+        proc.assertLog(".*Hello, Concord!*");
     }
 }

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -391,4 +391,14 @@ public class ProcessIT {
 
         proc.expectStatus(ProcessEntry.StatusEnum.TIMED_OUT);
     }
+
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void testYamlRootFile() throws Exception {
+        Payload payload = new Payload()
+                .archive(ProcessIT.class.getResource("yamlRootFile").toURI());
+
+        ConcordProcess proc = concord.processes().start(payload);
+        proc.expectStatus(ProcessEntry.StatusEnum.FINISHED);
+        proc.assertLog(".*Hello!*");
+    }
 }

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord.yaml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord.yaml
@@ -1,0 +1,6 @@
+configuration:
+  runtime: "concord-v2"
+
+flows:
+  default:
+    - log: "Hello!"

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord.yaml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord.yaml
@@ -3,4 +3,4 @@ configuration:
 
 flows:
   default:
-    - log: "Hello!"
+    - log: "Hello, ${name}!"

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord/extra.concord.yaml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/yamlRootFile/concord/extra.concord.yaml
@@ -1,0 +1,3 @@
+configuration:
+  arguments:
+    name: "Concord"

--- a/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ProjectLoader.java
+++ b/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ProjectLoader.java
@@ -110,41 +110,6 @@ public class ProjectLoader {
         return com.walmartlabs.concord.project.ProjectLoader.isConcordFileExists(path);
     }
 
-    private static boolean isV2(Path workDir) {
-        for (String filename : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
-            Path src = workDir.resolve(filename);
-            try {
-                if (Files.exists(src)) {
-                    ObjectMapper om = new ObjectMapper(new YAMLFactory());
-                    try (InputStream in = Files.newInputStream(src)) {
-                        JsonNode n = om.readTree(in);
-
-                        n = n.get(Constants.Request.CONFIGURATION_KEY);
-                        if (n == null) {
-                            continue;
-                        }
-
-                        n = n.get(Constants.Request.RUNTIME_KEY);
-                        if (n == null) {
-                            continue;
-                        }
-
-                        // TODO constants
-                        String s = n.textValue();
-                        if (s != null && "concord-v2".equals(n.textValue())) {
-                            return true;
-                        }
-                    }
-                }
-
-            } catch (IOException e) {
-                log.warn("isV2 ['{}'] -> error while reading a Concord file {}: {}", workDir, src, e.getMessage());
-            }
-        }
-
-        return false;
-    }
-
     public static String getRuntimeType(Path workDir, String defaultType) throws IOException {
         for (String filename : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
             Path src = workDir.resolve(filename);

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Resources.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Resources.java
@@ -42,7 +42,7 @@ public interface Resources extends Serializable {
 
     @Value.Default
     default List<String> concord() {
-        return Collections.singletonList("glob:concord/{**/,}{*.,}concord.yml");
+        return Collections.singletonList("glob:concord/{**/,}{*.,}concord.{yml,yaml}");
     }
 
     static ImmutableResources.Builder builder() {

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectLoaderV2Test.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectLoaderV2Test.java
@@ -134,6 +134,6 @@ public class ProjectLoaderV2Test {
         assertNotNull("name3", pd.forms().get("myForm").fields().get(0).name());
 
         // resources: should be collected from ALL *.concord.yml
-        assertEquals(ImmutableList.of("glob:concord/{**/,}{*.,}concord.yml", "glob:tmp/1.yml"), pd.resources().concord());
+        assertEquals(ImmutableList.of("glob:concord/{**/,}{*.,}concord.{yml,yaml}", "glob:tmp/1.yml"), pd.resources().concord());
     }
 }

--- a/runtime/v2/model/src/test/resources/multiProjectFile/concord.yml
+++ b/runtime/v2/model/src/test/resources/multiProjectFile/concord.yml
@@ -41,7 +41,7 @@ publicFlows:
 
 resources:
   concord:
-    - "glob:concord/{**/,}{*.,}concord.yml"
+    - "glob:concord/{**/,}{*.,}concord.{yml,yaml}"
 
 triggers:
   - github:

--- a/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
+++ b/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
@@ -44,4 +44,4 @@ forms:
       type: "string*"
 resources:
   concord:
-  - "glob:concord/{**/,}{*.,}concord.yml"
+  - "glob:concord/{**/,}{*.,}concord.{yml,yaml}"

--- a/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
+++ b/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
@@ -329,7 +329,12 @@ public class Constants {
         /**
          * Files that the runtime considers "root" project files.
          */
-        public static final String[] PROJECT_ROOT_FILE_NAMES = {".concord.yml", "concord.yml"};
+        public static final String[] PROJECT_ROOT_FILE_NAMES = {
+                ".concord.yml",
+                "concord.yml",
+                ".concord.yaml",
+                "concord.yaml"
+        };
 
         /**
          * Directory which contains payload data.


### PR DESCRIPTION
Allows `*.yaml` extension for the root project file.
For the runtime v2, load `concord/*.yaml` as well.
