### PR TITLE
targetplatform: update jackson-databind version to address CVE

### DIFF
--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -48,7 +48,7 @@
         <httpmime.version>4.5.11</httpmime.version>
         <immutables.version>2.8.8</immutables.version>
         <ini4j.version>0.5.4</ini4j.version>
-        <jackson.databind.version>2.10.2</jackson.databind.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson.jsonschema.version>1.0.39</jackson.jsonschema.version>
         <jackson.version>2.10.2</jackson.version>
         <javax.annotations.api.version>1.3.2</javax.annotations.api.version>


### PR DESCRIPTION
With regard to [GHSA-288c-cq4h-88gq](https://github.com/advisories/GHSA-288c-cq4h-88gq).