### PR TITLE
ansible: fix retry file persistance

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AnsibleRetryIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AnsibleRetryIT.java
@@ -52,7 +52,7 @@ public class AnsibleRetryIT extends AbstractServerIT {
 
         // retrieve the retry file
 
-        File r = processApi.downloadAttachment(pir.getInstanceId(), "ansible.retry");
+        File r = processApi.downloadAttachment(pir.getInstanceId(), "hello.retry");
         assertNotNull(r);
     }
 }

--- a/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleTask.java
+++ b/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/AnsibleTask.java
@@ -227,7 +227,7 @@ public class AnsibleTask {
         }
 
         String playbookName = getString(args, TaskParams.PLAYBOOK_KEY.getKey());
-        String retryFile = getNameWithoutExtension(playbookName + ".retry");
+        String retryFile = getNameWithoutExtension(playbookName) + ".retry";
 
         Path src = workDir.resolve(retryFile);
         if (!Files.exists(src)) {
@@ -236,7 +236,7 @@ public class AnsibleTask {
         }
 
         Path dst = workDir.resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
-                .resolve(TaskParams.LAST_RETRY_FILE.getKey());
+                .resolve(src.getFileName());
         Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
         log.info("The retry file was saved as: {}", workDir.relativize(dst));
     }

--- a/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/TaskParams.java
+++ b/plugins/tasks/ansible/src/main/java/com/walmartlabs/concord/plugins/ansible/TaskParams.java
@@ -79,6 +79,7 @@ public enum TaskParams implements HasKey {
 
     INVENTORY_KEY("inventory"),
 
+    @Deprecated
     LAST_RETRY_FILE("ansible.retry"),
 
     LIMIT_KEY("limit"),


### PR DESCRIPTION
- Fix bug where ansible plugin copied the playbook instead of the `.retry` file to `_attachments/`.
- Use the actual retry file name rather than hard-coded retry file name. Useful if multiple playbooks are run and need to be retried.