### PR TITLE
runtime-v2: allow the `name` attribute anywhere in the step definition

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ExpressionGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ExpressionGrammar.java
@@ -56,7 +56,8 @@ public final class ExpressionGrammar {
                 o -> options(
                         optional("error", stepsVal.map(o::errorSteps)),
                         optional("out", exprCallOutOption(o)),
-                        optional("meta", mapVal.map(o::putAllMeta))
+                        optional("meta", mapVal.map(o::putAllMeta)),
+                        optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v)))
                 ))
                 .map(ImmutableExpressionOptions.Builder::build);
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FlowCallGrammar.java
@@ -51,6 +51,7 @@ public final class FlowCallGrammar {
                         optional("in", flowCallInOption(o)),
                         optional("out", flowCallOutOption(o)),
                         optional("meta", mapVal.map(o::putAllMeta)),
+                        optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v))),
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
                         optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
                         optional("retry", retryVal.map(o::retry)),

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarOptions.java
@@ -203,7 +203,7 @@ public final class GrammarOptions {
     private static final Parser<Atom, List<KV<String, YamlValue>>> unparsedOptionsVal =
             many1(fieldValue).map(Seq::toList);
 
-    public static final Parser<Atom, Set<String>> allOptionKeys =
+    private static final Parser<Atom, Set<String>> allOptionKeys =
             many1(fieldValue).map(v -> v.stream().map(KV::getKey).collect(Collectors.toSet()));
 
     private GrammarOptions() {

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarOptions.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.runtime.v2.parser;
  */
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.walmartlabs.concord.runtime.v2.Constants;
 import com.walmartlabs.concord.runtime.v2.exception.MandatoryFieldNotFoundException;
 import com.walmartlabs.concord.runtime.v2.exception.UnknownOptionException;
 import io.takari.parc.Input;
@@ -35,8 +36,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.*;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.mapVal;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.value;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.*;
 import static io.takari.parc.Combinators.*;
 
 public final class GrammarOptions {
@@ -45,6 +45,14 @@ public final class GrammarOptions {
             with(ImmutableSimpleOptions::builder,
                     o -> options(
                             optional("meta", mapVal.map(o::meta))
+                    ))
+                    .map(ImmutableSimpleOptions.Builder::build);
+
+    public static final Parser<Atom, SimpleOptions> namedOptions =
+            with(ImmutableSimpleOptions::builder,
+                    o -> options(
+                            optional("meta", mapVal.map(o::meta)),
+                            optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v)))
                     ))
                     .map(ImmutableSimpleOptions.Builder::build);
 
@@ -195,7 +203,7 @@ public final class GrammarOptions {
     private static final Parser<Atom, List<KV<String, YamlValue>>> unparsedOptionsVal =
             many1(fieldValue).map(Seq::toList);
 
-    private static final Parser<Atom, Set<String>> allOptionKeys =
+    public static final Parser<Atom, Set<String>> allOptionKeys =
             many1(fieldValue).map(v -> v.stream().map(KV::getKey).collect(Collectors.toSet()));
 
     private GrammarOptions() {

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GroupOfStepsGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GroupOfStepsGrammar.java
@@ -47,7 +47,8 @@ public final class GroupOfStepsGrammar {
                         optional("error", stepsVal.map(o::errorSteps)),
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
                         optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
-                        optional("meta", mapVal.map(o::putAllMeta))
+                        optional("meta", mapVal.map(o::putAllMeta)),
+                        optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v)))
                 ))
                 .map(ImmutableGroupOfStepsOptions.Builder::build);
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/LogGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/LogGrammar.java
@@ -24,7 +24,7 @@ import com.walmartlabs.concord.runtime.v2.model.TaskCall;
 import io.takari.parc.Parser;
 
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.simpleOptions;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.namedOptions;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.anyVal;
 import static com.walmartlabs.concord.runtime.v2.parser.TaskGrammar.optionsWithStepName;
 
@@ -33,7 +33,7 @@ public final class LogGrammar {
     public static final Parser<Atom, TaskCall> logStep =
             namedStep("log", YamlValueType.TASK, (stepName, a) ->
                     anyVal.bind(msg ->
-                            simpleOptions.map(options -> new TaskCall(a.location, "log", optionsWithStepName(stepName)
+                            namedOptions.map(options -> new TaskCall(a.location, "log", optionsWithStepName(stepName)
                                     .putInput("msg", msg)
                                     .putAllMeta(options.meta())
                                     .build()))));

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ScriptGrammar.java
@@ -44,6 +44,7 @@ public final class ScriptGrammar {
                         optional("body", stringVal.map(o::body)),
                         optional("in", scriptCallInOption(o)),
                         optional("meta", mapVal.map(o::meta)),
+                        optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v))),
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
                         optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
                         optional("retry", retryVal.map(o::retry)),

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
@@ -59,6 +59,7 @@ public final class TaskGrammar {
                         optional("in", taskCallInOption(o)),
                         optional("out", taskCallOutOption(o)),
                         optional("meta", mapVal.map(o::putAllMeta)),
+                        optional("name", stringVal.map(v -> o.putMeta(Constants.SEGMENT_NAME, v))),
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
                         optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
                         optional("retry", retryVal.map(o::retry)),

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ThrowGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ThrowGrammar.java
@@ -24,7 +24,7 @@ import com.walmartlabs.concord.runtime.v2.model.TaskCall;
 import io.takari.parc.Parser;
 
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.namedStep;
-import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.simpleOptions;
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarOptions.namedOptions;
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.anyVal;
 import static com.walmartlabs.concord.runtime.v2.parser.TaskGrammar.optionsWithStepName;
 
@@ -32,7 +32,7 @@ public final class ThrowGrammar {
 
     public static final Parser<Atom, TaskCall> throwStep =
             namedStep("throw", YamlValueType.TASK, (stepName, a) -> anyVal.bind(e ->
-                    simpleOptions.map(options ->
+                    namedOptions.map(options ->
                             new TaskCall(a.location, "throw", optionsWithStepName(stepName)
                                     .putInput("exception", e)
                                     .build()))));

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -785,7 +785,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test215() throws Exception {
         String msg =
-                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, in, meta, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
+                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, in, meta, name, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'task' @ line: 3, col: 7\n" +
                         "\t\t'main' @ line: 2, col: 3\n" +
@@ -839,8 +839,9 @@ public class YamlErrorParserTest extends AbstractParserTest {
         String msg =
                 "(019.yml): Error @ line: 3, col: 13. Invalid value type, expected: STRING, got: INT\n" +
                         "\twhile processing steps:\n" +
-                        "\t'main' @ line: 2, col: 3\n" +
-                        "\t\t'flows' @ line: 1, col: 1";
+                        "\t'name' @ line: 3, col: 7\n" +
+                        "\t\t'main' @ line: 2, col: 3\n" +
+                        "\t\t\t'flows' @ line: 1, col: 1";
 
         assertErrorMessage("errors/tasks/019.yml", msg);
     }
@@ -1031,7 +1032,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test315() throws Exception {
         String msg =
-                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, in, meta, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
+                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, in, meta, name, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'call' @ line: 3, col: 7\n" +
                         "\t\t'main' @ line: 2, col: 3\n" +
@@ -1320,7 +1321,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test703() throws Exception {
         String msg =
-                "(003.yml): Error @ line: 5, col: 13. Unknown options: ['trash' [NULL] @ line: 5, col: 13], expected: [error, meta, out, parallelWithItems, withItems]. Remove invalid options and/or fix indentation\n" +
+                "(003.yml): Error @ line: 5, col: 13. Unknown options: ['trash' [NULL] @ line: 5, col: 13], expected: [error, meta, name, out, parallelWithItems, withItems]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'try' @ line: 3, col: 7\n" +
                         "\t\t'main' @ line: 2, col: 3\n" +
@@ -1371,7 +1372,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test707() throws Exception {
         String msg =
-                "(007.yml): Error @ line: 11, col: 13. Unknown options: ['trash' [NULL] @ line: 11, col: 13], expected: [error, meta, out, parallelWithItems, withItems]. Remove invalid options and/or fix indentation\n" +
+                "(007.yml): Error @ line: 11, col: 13. Unknown options: ['trash' [NULL] @ line: 11, col: 13], expected: [error, meta, name, out, parallelWithItems, withItems]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'try' @ line: 3, col: 7\n" +
                         "\t\t'main' @ line: 2, col: 3\n" +
@@ -2222,7 +2223,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
 
     @Test
     public void test1702() throws Exception {
-        String msg = "(002.yml): Error @ line: 4, col: 14. Unknown options: ['body1' [STRING] @ line: 4, col: 14], expected: [body, error, in, meta, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
+        String msg = "(002.yml): Error @ line: 4, col: 14. Unknown options: ['body1' [STRING] @ line: 4, col: 14], expected: [body, error, in, meta, name, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
                 "\twhile processing steps:\n" +
                 "\t'script' @ line: 3, col: 7\n" +
                 "\t\t'main' @ line: 2, col: 3\n" +

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.project.runtime.v2.parser;
 import com.walmartlabs.concord.forms.FormField.Cardinality;
 import com.walmartlabs.concord.imports.Import;
 import com.walmartlabs.concord.imports.Imports;
+import com.walmartlabs.concord.runtime.v2.Constants;
 import com.walmartlabs.concord.runtime.v2.model.*;
 import com.walmartlabs.concord.runtime.v2.parser.StepOptions;
 import org.junit.Test;
@@ -94,6 +95,25 @@ public class YamlOkParserTest extends AbstractParserTest {
         // input
         assertEquals(0, t.getOptions().input().size());
         assertEquals("${inExpr}", t.getOptions().inputExpression());
+    }
+
+    @Test
+    public void test000_2() throws Exception {
+        ProcessDefinition pd = load("000.2.yml");
+
+        List<Step> main = pd.flows().get("main");
+
+        assertEquals(1, main.size());
+
+        assertTrue(main.get(0) instanceof TaskCall);
+        TaskCall t = (TaskCall) main.get(0);
+        assertEquals("log", t.getName());
+
+        // options
+        assertNotNull(t.getOptions());
+
+        // name
+        assertEquals("Test name", t.getOptions().meta().get(Constants.SEGMENT_NAME));
     }
 
     // Full Call Flow Definition Test

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -107,13 +107,20 @@ public class YamlOkParserTest extends AbstractParserTest {
 
         assertTrue(main.get(0) instanceof TaskCall);
         TaskCall t = (TaskCall) main.get(0);
-        assertEquals("log", t.getName());
+        assertEquals("project", t.getName());
 
         // options
         assertNotNull(t.getOptions());
 
         // name
         assertEquals("Test name", t.getOptions().meta().get(Constants.SEGMENT_NAME));
+
+        // input
+        assertNotNull(t.getOptions().input());
+
+        assertEquals("ProjectName", t.getOptions().input().get("name"));
+        assertEquals("Default", t.getOptions().input().get("org"));
+        assertEquals("create", t.getOptions().input().get("action"));
     }
 
     // Full Call Flow Definition Test

--- a/runtime/v2/model/src/test/resources/000.2.yml
+++ b/runtime/v2/model/src/test/resources/000.2.yml
@@ -1,0 +1,4 @@
+flows:
+  main:
+    - log: "Log message"
+      name: "Test name"

--- a/runtime/v2/model/src/test/resources/000.2.yml
+++ b/runtime/v2/model/src/test/resources/000.2.yml
@@ -1,4 +1,8 @@
 flows:
   main:
-    - log: "Log message"
+    - task: project
+      in:
+        action: create
+        org: Default
+        name: ProjectName
       name: "Test name"

--- a/runtime/v2/model/src/test/resources/000.yml
+++ b/runtime/v2/model/src/test/resources/000.yml
@@ -1,7 +1,7 @@
 flows:
   main:
-    - name: "Boo"
-      task: "boo"
+    - task: "boo"
+      name: "Boo"
       out: "result"
       in:
         k: "v"


### PR DESCRIPTION
```
flows:
  default:
    - log: "me"
      name: Test
```