### PR TITLE
runtime-v2: copy variables in try block into parent frame

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/VMUtils.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/VMUtils.java
@@ -27,6 +27,7 @@ import com.walmartlabs.concord.svm.Frame;
 import com.walmartlabs.concord.svm.FrameType;
 import com.walmartlabs.concord.svm.State;
 import com.walmartlabs.concord.svm.ThreadId;
+import com.walmartlabs.concord.svm.Utils;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -163,13 +164,7 @@ public final class VMUtils {
      * Only {@link Serializable} values are allowed.
      */
     public static void putLocal(Frame frame, String key, Object value) {
-        if (value instanceof Serializable || value == null) {
-            frame.setLocal(key, (Serializable) value);
-            return;
-        }
-
-        String msg = "Can't set a non-serializable local variable: %s -> %s";
-        throw new IllegalStateException(String.format(msg, key, value.getClass()));
+        Utils.putLocal(frame, key, value);
     }
 
     /**

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/errorBlockScoping/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/errorBlockScoping/concord.yml
@@ -1,0 +1,23 @@
+configuration:
+  runtime: "concord-v2"
+
+flows:
+  default:
+    - call: anotherFlow
+      out:
+        - myVar
+    - log: "Hello, ${myVar}!"
+
+  anotherFlow:
+    - try:
+        - call: createMyVar
+          out:
+            - myVar
+        - throw: kapow! kamblamo!
+      error:
+        - log: "caught an error"
+    - log: "myVar should exist: ${myVar}"
+
+  createMyVar:
+    - set:
+        myVar: 'world'

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/CopyVariablesCommand.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/CopyVariablesCommand.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.runtime.v2.runner.vm;
+package com.walmartlabs.concord.svm;
 
 /*-
  * *****
@@ -56,10 +56,15 @@ public class CopyVariablesCommand implements Command {
         Frame effectiveSourceFrame = sourceFrame != null ? sourceFrame : frame;
         Frame effectiveTargetFrame = targetFrame != null ? targetFrame : frame;
 
+        if (effectiveSourceFrame == effectiveTargetFrame) {
+            throw new IllegalStateException("Can't copy variables: the source frame and the target frame are the same. " +
+                    "This is most likely a bug.");
+        }
+
         for (String variable : variables) {
             if (effectiveSourceFrame.hasLocal(variable)) {
                 Serializable value = effectiveSourceFrame.getLocal(variable);
-                VMUtils.putLocal(effectiveTargetFrame, variable, value);
+                Utils.putLocal(effectiveTargetFrame, variable, value);
             }
         }
     }

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
@@ -105,8 +105,7 @@ public interface State extends Serializable {
     Map<ThreadId, String> getEventRefs();
 
     /**
-     * Sets an error for the specified thread. Those errors are used to propagate unhandled
-     * exceptions from child threads to the parent thread with a {@link com.walmartlabs.concord.svm.commands.Join}.
+     * Sets an error for the specified thread. Used during the thread unwinding.
      */
     void setThreadError(ThreadId threadId, Exception error);
 

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Utils.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Utils.java
@@ -42,11 +42,11 @@ public final class Utils {
     /**
      * Returns the parent frame of the current frame of the specified thread.
      */
-    public static Frame assertParentFrame(State state, ThreadId threadId) {
+    public static Frame getParentFrame(State state, ThreadId threadId) {
         // we assume that the parent frame is the frame before the current one in the stack
         List<Frame> frames = state.getFrames(threadId);
         if (frames.size() < 2) {
-            throw new IllegalStateException("The parent frame doesn't exist");
+            return null;
         }
         return frames.get(1);
     }

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Utils.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Utils.java
@@ -1,0 +1,56 @@
+package com.walmartlabs.concord.svm;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.Serializable;
+import java.util.List;
+
+public final class Utils {
+
+    /**
+     * Puts a local variable into the specified frame.
+     * Only {@link Serializable} values are allowed.
+     */
+    public static void putLocal(Frame frame, String key, Object value) {
+        if (value instanceof Serializable || value == null) {
+            frame.setLocal(key, (Serializable) value);
+            return;
+        }
+
+        String msg = "Can't set a non-serializable local variable: %s -> %s";
+        throw new IllegalStateException(String.format(msg, key, value.getClass()));
+    }
+
+    /**
+     * Returns the parent frame of the current frame of the specified thread.
+     */
+    public static Frame assertParentFrame(State state, ThreadId threadId) {
+        // we assume that the parent frame is the frame before the current one in the stack
+        List<Frame> frames = state.getFrames(threadId);
+        if (frames.size() < 2) {
+            throw new IllegalStateException("The parent frame doesn't exist");
+        }
+        return frames.get(1);
+    }
+
+    private Utils() {
+    }
+}

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/VM.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/VM.java
@@ -203,11 +203,13 @@ public class VM {
                 // remove the current frame after the error handling code is done
                 frame.push(new PopFrameCommand());
 
-                // copy all variables from the inner frame into the outer frame
+                // copy all variables from the inner frame into the outer frame (if exists)
                 // e.g. all values created before the error
-                List<String> variables = new ArrayList<>(frame.getLocals().keySet());
-                Frame target = Utils.assertParentFrame(state, threadId);
-                frame.push(new CopyVariablesCommand(variables, frame, target));
+                Frame target = Utils.getParentFrame(state, threadId);
+                if (target != null) {
+                    List<String> variables = new ArrayList<>(frame.getLocals().keySet());
+                    frame.push(new CopyVariablesCommand(variables, frame, target));
+                }
 
                 // save the exception as a local frame variable, so it can be retrieved
                 // by the error handling code


### PR DESCRIPTION
Variables in `try` blocks created before the error must be visible in the outer block (the block that contains the `try`
block).

Copy inner frame (the try block's body) variables into the outer block when the thread is unwinding.