### PR TITLE
runtime-v2: better parser error message

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarV2.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/GrammarV2.java
@@ -185,6 +185,18 @@ public final class GrammarV2 {
         return m;
     }
 
+    public static YamlValue assertNotNull(YamlValue v) {
+        if (v.getType() != YamlValueType.NULL) {
+            return v;
+        }
+
+        throw new InvalidValueTypeException.Builder()
+                .location(v.getLocation())
+                .expected(YamlValueType.NON_NULL)
+                .actual(v.getType())
+                .build();
+    }
+
     private static Map<String, YamlValue> valueToMap(Seq<KV<String, YamlValue>> values) {
         if (values == null) {
             return Collections.emptyMap();
@@ -193,18 +205,6 @@ public final class GrammarV2 {
         Map<String, YamlValue> m = new LinkedHashMap<>();
         values.stream().forEach(kv -> m.put(kv.getKey(), kv.getValue()));
         return m;
-    }
-
-    private static void assertNotNull(YamlValue v) {
-        if (v.getType() != YamlValueType.NULL) {
-            return;
-        }
-
-        throw new InvalidValueTypeException.Builder()
-                .location(v.getLocation())
-                .expected(YamlValueType.NON_NULL)
-                .actual(v.getType())
-                .build();
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlObject.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlObject.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.assertNotNull;
+
 public class YamlObject extends YamlValue {
 
     private static final long serialVersionUID = 1L;
@@ -42,7 +44,7 @@ public class YamlObject extends YamlValue {
     public Map<String, Serializable> getValue() {
         Map<String, Serializable> result = new HashMap<>();
         for (Map.Entry<String, YamlValue> e : values.entrySet()) {
-            result.put(e.getKey(), e.getValue().getValue());
+            result.put(e.getKey(), assertNotNull(e.getValue()).getValue());
         }
         return result;
     }

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1857,6 +1857,17 @@ public class YamlErrorParserTest extends AbstractParserTest {
     }
 
     @Test
+    public void test1305_1() throws Exception {
+        String msg =
+                "(005_1.yml): Error @ line: 7, col: 7. Invalid value type, expected: NON_NULL, got: NULL. Remove attribute or complete the definition\n" +
+                        "\twhile processing steps:\n" +
+                        "\t'arguments' @ line: 6, col: 3\n" +
+                        "\t\t'configuration' @ line: 1, col: 1";
+
+        assertErrorMessage("errors/configuration/005_1.yml", msg);
+    }
+
+    @Test
     public void test1306() throws Exception {
         String msg =
                 "(006.yml): Error @ line: 8, col: 9. Unknown options: ['trash' [NULL] @ line: 8, col: 9], expected: [activeProfiles, arguments, debug, dependencies, entryPoint, events, exclusive, meta, out, processTimeout, requirements, runtime, template]. Remove invalid options and/or fix indentation\n" +

--- a/runtime/v2/model/src/test/resources/errors/configuration/005_1.yml
+++ b/runtime/v2/model/src/test/resources/errors/configuration/005_1.yml
@@ -1,0 +1,7 @@
+configuration:
+  entryPoint: "main-test"
+  dependencies:
+    - "d1"
+    - "d2"
+  arguments:
+    k:


### PR DESCRIPTION
concord.yml:
```
configuration:
  runtime: concord-v2
  arguments:
    k:
 ....
```

old message:
```
Error while loading a project file '005_1.yml', arguments value
```

new message:
```
(005_1.yml): Error @ line: 7, col: 7. Invalid value type, expected: NON_NULL, got: NULL. Remove attribute or complete the definition
	while processing steps:
       'arguments' @ line: 6, col: 3
       		'configuration' @ line: 1, col: 1
```