### PR TITLE
server: throw error on null teams list in bulk access update

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ProjectIT.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.it.server;
  * =====
  */
 
+import com.walmartlabs.concord.ApiException;
 import com.walmartlabs.concord.client.*;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.sdk.Constants;
@@ -365,6 +366,72 @@ public class ProjectIT extends AbstractServerIT {
         input.put("repo", repoName);
 
         start(input);
+    }
+
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void testBulkAccessUpdate() throws Exception {
+        String orgName = "org_" + randomString();
+
+        OrganizationsApi orgApi = new OrganizationsApi(getApiClient());
+        orgApi.createOrUpdate(new OrganizationEntry().setName(orgName));
+
+        // ---
+
+        String projectName = "project_" + randomString();
+
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setName(projectName));
+
+        // ---
+
+        String teamName = "team_" + randomString();
+        TeamsApi teamsApi = new TeamsApi(getApiClient());
+        CreateTeamResponse teamResp = teamsApi.createOrUpdate(orgName, new TeamEntry()
+                .setName(teamName));
+
+        // --- Typical one-or-more teams bulk access update
+
+        List<ResourceAccessEntry> teams = new ArrayList<>(1);
+        teams.add(new ResourceAccessEntry()
+                .setOrgName(orgName)
+                .setTeamId(teamResp.getId())
+                .setTeamName(teamName)
+                .setLevel(ResourceAccessEntry.LevelEnum.OWNER));
+        GenericOperationResult addTeamsResult = projectsApi.updateAccessLevel_0(orgName, projectName, teams);
+        assertNotNull(addTeamsResult);
+        assertTrue(addTeamsResult.isOk());
+
+        List<ResourceAccessEntry> currentTeams = projectsApi.getAccessLevel(orgName, projectName);
+        assertNotNull(currentTeams);
+        assertEquals(1, currentTeams.size());
+
+        // --- Empty teams list clears all
+
+        GenericOperationResult clearTeamsResult = projectsApi.updateAccessLevel_0(orgName, projectName, Collections.emptyList());
+        assertNotNull(clearTeamsResult);
+        assertTrue(clearTeamsResult.isOk());
+
+        currentTeams = projectsApi.getAccessLevel(orgName, projectName);
+        assertNotNull(currentTeams);
+        assertEquals(0, currentTeams.size());
+
+        // --- Null list not allowed, throws error
+
+        try {
+            projectsApi.updateAccessLevel_0(orgName, projectName, null);
+        } catch (ApiException expected) {
+            assertEquals(400, expected.getCode());
+            assertTrue(expected.getResponseBody().contains("List of teams is null"));
+        } catch (Exception e) {
+            fail("Expected ApiException. Got " + e.getClass().toString());
+        }
+
+        // ---
+
+        teamsApi.delete(orgName, teamName);
+        projectsApi.delete(orgName, projectName);
+        orgApi.delete(orgName, "yes");
     }
 
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/jsonstore/JsonStoreResource.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.common.validation.ConcordKey;
 import com.walmartlabs.concord.server.GenericOperationResult;
 import com.walmartlabs.concord.server.OperationResult;
 import com.walmartlabs.concord.server.org.ResourceAccessEntry;
+import com.walmartlabs.concord.server.sdk.ConcordApplicationException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -37,6 +38,7 @@ import javax.inject.Singleton;
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.List;
 
@@ -159,6 +161,10 @@ public class JsonStoreResource implements Resource {
     public GenericOperationResult updateAccessLevel(@ApiParam @PathParam("orgName") @ConcordKey String orgName,
                                                     @ApiParam @PathParam("storeName") @ConcordKey String storeName,
                                                     @ApiParam @Valid Collection<ResourceAccessEntry> entries) {
+
+        if (entries == null) {
+            throw new ConcordApplicationException("List of teams is null.", Response.Status.BAD_REQUEST);
+        }
 
         storeManager.updateAccessLevel(orgName, storeName, entries, true);
         return new GenericOperationResult(OperationResult.UPDATED);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/ProjectResource.java
@@ -314,6 +314,10 @@ public class ProjectResource implements Resource {
             throw new ConcordApplicationException("Project not found: " + projectName, Status.NOT_FOUND);
         }
 
+        if (entries == null) {
+            throw new ConcordApplicationException("List of teams is null.", Status.BAD_REQUEST);
+        }
+
         accessManager.updateAccessLevel(projectId, entries, true);
 
         return new GenericOperationResult(OperationResult.UPDATED);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretResource.java
@@ -296,6 +296,10 @@ public class SecretResource implements Resource {
             throw new ConcordApplicationException("Secret not found: " + secretName, Status.NOT_FOUND);
         }
 
+        if (entries == null) {
+            throw new ConcordApplicationException("List of teams is null.", Status.BAD_REQUEST);
+        }
+
         secretManager.updateAccessLevel(secretId, entries, true);
 
         return new GenericOperationResult(OperationResult.UPDATED);


### PR DESCRIPTION
Empty list is okay for effectively removing all teams from resource access. No list (null) currently results in a 500 error from failed DB query. It'd be better to throw a bad request error before getting to the DB.