### PR TITLE
runtime-v2: support for task `ignoreErrors` mode

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/TaskCallOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/TaskCallOptions.java
@@ -65,6 +65,11 @@ public interface TaskCallOptions extends StepOptions {
         return Collections.emptyList();
     }
 
+    @Value.Default
+    default boolean ignoreErrors() {
+        return false;
+    }
+
     static ImmutableTaskCallOptions.Builder builder() {
         return ImmutableTaskCallOptions.builder();
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/TaskGrammar.java
@@ -63,7 +63,8 @@ public final class TaskGrammar {
                         optional("withItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.SERIAL)))),
                         optional("parallelWithItems", nonNullVal.map(v -> o.withItems(WithItems.of(v, WithItems.Mode.PARALLEL)))),
                         optional("retry", retryVal.map(o::retry)),
-                        optional("error", stepsVal.map(o::errorSteps))
+                        optional("error", stepsVal.map(o::errorSteps)),
+                        optional("ignoreErrors", booleanVal.map(o::ignoreErrors))
                 ))
                 .map(ImmutableTaskCallOptions.Builder::build);
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/TaskCallStepSerializer.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/TaskCallStepSerializer.java
@@ -76,6 +76,8 @@ public class TaskCallStepSerializer extends StdSerializer<TaskCall> {
         writeNotEmptyObjectField("error", o.errorSteps(), gen);
         writeNotEmptyObjectField("meta", o.meta(), gen);
 
+        gen.writeObjectField("ignoreErrors", o.ignoreErrors());
+
         gen.writeEndObject();
     }
 }

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -785,7 +785,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test215() throws Exception {
         String msg =
-                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, in, meta, name, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
+                "(015.yml): Error @ line: 15, col: 14. Unknown options: ['trash' [STRING] @ line: 15, col: 14], expected: [error, ignoreErrors, in, meta, name, out, parallelWithItems, retry, withItems]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'task' @ line: 3, col: 7\n" +
                         "\t\t'main' @ line: 2, col: 3\n" +

--- a/runtime/v2/model/src/test/resources/serializer/taskCallStep.yml
+++ b/runtime/v2/model/src/test/resources/serializer/taskCallStep.yml
@@ -16,3 +16,4 @@ error:
 meta:
   meta-1: "v1"
   meta-2: "v2"
+ignoreErrors: false

--- a/runtime/v2/model/src/test/resources/serializer/taskCallStepOutExpr.yml
+++ b/runtime/v2/model/src/test/resources/serializer/taskCallStepOutExpr.yml
@@ -18,3 +18,4 @@ error:
 meta:
   meta-1: "v1"
   meta-2: "v2"
+ignoreErrors: false

--- a/runtime/v2/model/src/test/resources/serializer/taskCallStepParallel.yml
+++ b/runtime/v2/model/src/test/resources/serializer/taskCallStepParallel.yml
@@ -16,3 +16,4 @@ error:
 meta:
   meta-1: "v1"
   meta-2: "v2"
+ignoreErrors: false

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptor.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptor.java
@@ -72,7 +72,7 @@ public class TaskCallInterceptor {
         listeners.forEach(l -> l.onEvent(postEvent));
 
         if (error != null) {
-            throw error;
+            throw new TaskException(error);
         }
 
         return result;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskException.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskException.java
@@ -1,0 +1,33 @@
+package com.walmartlabs.concord.runtime.v2.runner.tasks;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public class TaskException extends Exception {
+
+    public TaskException(Exception cause) {
+        super(cause);
+    }
+
+    @Override
+    public synchronized Exception getCause() {
+        return (Exception) super.getCause();
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallCommand.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.runtime.v2.model.TaskCall;
 import com.walmartlabs.concord.runtime.v2.model.TaskCallOptions;
 import com.walmartlabs.concord.runtime.v2.runner.el.ExpressionEvaluator;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallInterceptor;
+import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskException;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskProviders;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.svm.Frame;
@@ -82,6 +83,8 @@ public class TaskCallCommand extends StepCommand<TaskCall> {
         try {
             result = interceptor.invoke(callContext, Method.of(t, "execute", Collections.singletonList(input)),
                     () -> t.execute(input));
+        } catch (TaskException e) {
+            result = TaskResult.fail(e.getCause());
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallUtils.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskCallUtils.java
@@ -52,6 +52,23 @@ public final class TaskCallUtils {
                 Map<String, Serializable> out = expressionEvaluator.evalAsMap(EvalContextFactory.global(ctx, vars), opts.outExpr());
                 out.forEach((k, v) -> ctx.variables().set(k, v));
             }
+
+            if (result instanceof TaskResult.SimpleFailResult) {
+                if (r.ok() || opts.ignoreErrors()) {
+                    return;
+                }
+
+                TaskResult.SimpleFailResult rr = (TaskResult.SimpleFailResult) r;
+                if (rr.cause() != null) {
+                    if (rr.cause() instanceof RuntimeException) {
+                        throw (RuntimeException)rr.cause();
+                    } else {
+                        throw new RuntimeException(rr.cause());
+                    }
+                } else {
+                    throw new RuntimeException("Error during execution of '" + taskName + "' task" + (r.error() != null ? ": " + r.error() : ""));
+                }
+            }
         } else {
             throw new IllegalArgumentException("Unknown result: '" + result.getClass() + "'");
         }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskResumeCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/TaskResumeCommand.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.runtime.v2.runner.vm;
 import com.walmartlabs.concord.runtime.v2.model.TaskCall;
 import com.walmartlabs.concord.runtime.v2.runner.logging.LogContext;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallInterceptor;
+import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskException;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskProviders;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.svm.Frame;
@@ -83,6 +84,8 @@ public class TaskResumeCommand extends StepCommand<TaskCall> {
         try {
             result = interceptor.invoke(callContext, TaskCallInterceptor.Method.of(rt, "resume", Collections.singletonList(event)),
                     () -> rt.resume(event));
+        } catch (TaskException e) {
+            result = TaskResult.fail(e.getCause());
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -44,7 +44,6 @@ import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskResultListener;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskV2Provider;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.sdk.Constants;
-import com.walmartlabs.concord.sdk.MapUtils;
 import com.walmartlabs.concord.svm.ExecutionListener;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.ThreadId;
@@ -218,6 +217,48 @@ public class MainTest {
 
         byte[] log = run();
         assertLog(log, ".*error occurred:.*boom!.*");
+    }
+
+    @Test
+    public void testTaskErrorBlock2() throws Exception {
+        deploy("faultyTask2");
+
+        save(ProcessConfiguration.builder().build());
+
+        byte[] log = run();
+        assertLog(log, ".*error occurred:.*boom!.*");
+    }
+
+    @Test
+    public void testTaskErrorOut() throws Exception {
+        deploy("faultyTaskOut");
+
+        save(ProcessConfiguration.builder().build());
+
+        byte[] log = run();
+        assertLog(log, ".*result.key: value.*");
+    }
+
+    @Test
+    public void testTaskIgnoreErrors() throws Exception {
+        deploy("taskIgnoreErrors");
+
+        save(ProcessConfiguration.builder().build());
+
+        byte[] log = run();
+        assertLog(log, ".*ok: false.*");
+        assertLog(log, ".*error:.*boom!.*");
+    }
+
+    @Test
+    public void testTaskIgnoreErrors2() throws Exception {
+        deploy("taskIgnoreErrors2");
+
+        save(ProcessConfiguration.builder().build());
+
+        byte[] log = run();
+        assertLog(log, ".*ok: false.*");
+        assertLog(log, ".*error:.*boom!.*");
     }
 
     @Test
@@ -1197,6 +1238,17 @@ public class MainTest {
     @Named("faultyTask")
     @SuppressWarnings("unused")
     static class FaultyTask implements Task {
+
+        @Override
+        public TaskResult execute(Variables input) {
+            return TaskResult.fail("boom!")
+                    .value("key", "value");
+        }
+    }
+
+    @Named("faultyTask2")
+    @SuppressWarnings("unused")
+    static class FaultyTask2 implements Task {
 
         @Override
         public TaskResult execute(Variables input) {

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/faultyTask2/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/faultyTask2/concord.yml
@@ -1,0 +1,5 @@
+flows:
+  default:
+    - task: faultyTask
+      error:
+        - log: "error occurred: ${lastError}"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/faultyTaskOut/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/faultyTaskOut/concord.yml
@@ -1,0 +1,6 @@
+flows:
+  default:
+    - task: faultyTask
+      out: result
+      error:
+        - log: "result.key: ${result.key}"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/taskIgnoreErrors/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/taskIgnoreErrors/concord.yml
@@ -1,0 +1,8 @@
+flows:
+  default:
+    - task: faultyTask
+      ignoreErrors: true
+      out: result
+
+    - log: "ok: ${result.ok}"
+    - log: "error: ${result.error}"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/taskIgnoreErrors2/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/taskIgnoreErrors2/concord.yml
@@ -1,0 +1,8 @@
+flows:
+  default:
+    - task: faultyTask2
+      ignoreErrors: true
+      out: result
+
+    - log: "ok: ${result.ok}"
+    - log: "error: ${result.error}"

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskResult.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/TaskResult.java
@@ -42,14 +42,25 @@ public interface TaskResult extends Serializable {
         return new SimpleResult(true, null, null);
     }
 
+    static SimpleFailResult fail(String error) {
+        return new SimpleFailResult(error);
+    }
+
+    static TaskResult fail(Exception e) {
+        return new SimpleFailResult(e);
+    }
+
+    @Deprecated
     static SimpleResult of(boolean success) {
         return new SimpleResult(success, null, null);
     }
 
+    @Deprecated
     static SimpleResult of(boolean success, String error) {
         return new SimpleResult(success, error, null);
     }
 
+    @Deprecated
     static SimpleResult of(boolean success, String error, Map<String, Object> values) {
         return new SimpleResult(success, error, values);
     }
@@ -61,6 +72,7 @@ public interface TaskResult extends Serializable {
      * @param message error message.
      * @return {@link TaskResult}
      */
+    @Deprecated
     static SimpleResult error(String message) {
         return new SimpleResult(false, message, null);
     }
@@ -144,6 +156,27 @@ public interface TaskResult extends Serializable {
                 result.put("error", error);
             }
             return result;
+        }
+    }
+
+    class SimpleFailResult extends SimpleResult {
+
+        private final Exception cause;
+
+        SimpleFailResult(Exception e) {
+            super(false, e.getMessage(), null);
+
+            this.cause = e;
+        }
+
+        SimpleFailResult(String error) {
+            super(false, error, null);
+
+            this.cause = null;
+        }
+
+        public Exception cause() {
+            return cause;
         }
     }
 


### PR DESCRIPTION
+ allows task to return variables even if the task failed