### PR TITLE
concord-task: broken runtime-v2 methods/actions #486

### DIFF
--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTask.java
@@ -881,7 +881,11 @@ public class ConcordTask extends AbstractConcordTask {
 
     private static Action getAction(Context ctx) {
         String action = ContextUtils.assertString(ctx, ACTION_KEY);
-        return Action.valueOf(action.trim().toUpperCase());
+        try {
+            return Action.valueOf(action.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Unknown action: '" + action + "'. Available actions: " + Arrays.toString(Action.values()));
+        }
     }
 
     private static int getInstances(Map<String, Object> cfg) {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -32,7 +32,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -311,29 +310,28 @@ public class ConcordTaskCommon {
 
         handleResults(instances, payload.ignoreFailures());
 
-        boolean single = payload.jobs().size() == 1;
-
-        if (single) {
-            // if only one job was started put all variables at the top level of the jobOut object
-            // e.g. jobOut.someVar
-            Map<String, Object> out = results.get(0).out;
-            return TaskResult.success()
-                    .value("id", payload.jobs().get(0))
-                    .values(out);
-        } else {
-            // for multiple jobs save their variable into a nested map
-            // e.g. jobOut['PROCESSID'].someVar
-            HashMap<String, Object> vars = new HashMap<>();
-            for (Result r : results) {
-                String id = r.processEntry.getInstanceId().toString();
-                if (r.out != null) {
-                    vars.put(id, r.out);
-                }
+        HashMap<String, Object> vars = new HashMap<>();
+        for (Result r : results) {
+            String id = r.processEntry.getInstanceId().toString();
+            if (r.out != null) {
+                vars.put(id, r.out);
             }
-            return TaskResult.success()
-                    .value("ids", payload.jobs())
-                    .values(vars);
         }
+
+        TaskResult.SimpleResult result = TaskResult.success()
+                .value("ids", payload.jobs().stream().map(UUID::toString).collect(Collectors.toList()))
+                .values(vars);
+
+        boolean single = payload.jobs().size() == 1;
+        if (single) {
+            // for single job also put all variables at the top level of the result
+            String id = payload.jobs().get(0).toString();
+            Map<String, Object> out = results.get(0).out;
+            result.value("id", id)
+                    .values(out);
+        }
+
+        return result;
     }
 
     private Result continueAfterSuspend(String baseUrl, String apiKey, UUID processId, boolean collectOutVars) throws Exception {
@@ -481,16 +479,14 @@ public class ConcordTaskCommon {
             handleResults(result, in.ignoreFailures());
         }
 
+        TaskResult.SimpleResult result = TaskResult.success()
+                .value("ids", ids.stream().map(UUID::toString).collect(Collectors.toList()));
+
         boolean single = ids.size() == 1;
         if (single) {
-            return TaskResult.success()
-                    .value("id", ids.get(0).toString());
-        } else {
-            return TaskResult.success()
-                    .value("ids", ids.stream()
-                            .map(UUID::toString)
-                            .collect(Collectors.toList()));
+            result.value("id", ids.get(0).toString());
         }
+        return result;
     }
 
     private Future<UUID> forkOne(ForkStartParams in) {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -112,8 +112,12 @@ public class ConcordTaskCommon {
         });
     }
 
-    public void suspendForCompletion(List<UUID> ids) throws Exception {
-        suspend(new ResumePayload(null, null, false, ids, false), false);
+    public String suspendForCompletion(List<UUID> ids) throws Exception {
+        TaskResult result = suspend(new ResumePayload(null, null, false, ids, false), false);
+        if (!(result instanceof TaskResult.SuspendResult)) {
+            throw new RuntimeException("Invalid result type. This is most likely a bug.");
+        }
+        return ((TaskResult.SuspendResult) result).eventName();
     }
 
     public <T> Map<String, T> waitForCompletion(List<UUID> ids, long timeout, Function<ProcessEntry, T> processor) {
@@ -284,12 +288,12 @@ public class ConcordTaskCommon {
             }
 
             return TaskResult.success()
-                    .value("id", processId)
+                    .value("id", processId.toString())
                     .values(out);
         }
 
         return TaskResult.success()
-                .value("id", processId);
+                .value("id", processId.toString());
     }
 
     public TaskResult continueAfterSuspend(ResumePayload payload) throws Exception {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/v2/ConcordTaskV2.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/v2/ConcordTaskV2.java
@@ -21,12 +21,10 @@ package com.walmartlabs.concord.client.v2;
  */
 
 import com.walmartlabs.concord.client.*;
-import com.walmartlabs.concord.runtime.v2.sdk.ProjectInfo;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -40,27 +38,18 @@ import static com.walmartlabs.concord.client.ConcordTaskParams.ListSubProcesses;
 @SuppressWarnings("unused")
 public class ConcordTaskV2 implements ReentrantTask {
 
-    private final Variables defaults;
-    private final String sessionToken;
-    private final UUID instanceId;
     private final ApiClientFactory apiClientFactory;
-    private final ProjectInfo projectInfo;
-    private final Path workDir;
+    private final Context context;
 
     @Inject
     public ConcordTaskV2(ApiClientFactory apiClientFactory, Context context) {
-        this.defaults = context.defaultVariables();
-        this.sessionToken = context.processConfiguration().processInfo().sessionToken();
-        this.instanceId = context.processInstanceId();
         this.apiClientFactory = apiClientFactory;
-        this.projectInfo = context.processConfiguration().projectInfo();
-
-        this.workDir = context.workingDirectory();
+        this.context = context;
     }
 
     @Override
     public TaskResult execute(Variables in) throws Exception {
-        return delegate().execute(ConcordTaskParams.of(in, defaults.toMap()));
+        return delegate().execute(ConcordTaskParams.of(in, context.defaultVariables().toMap()));
     }
 
     @Override
@@ -81,9 +70,10 @@ public class ConcordTaskV2 implements ReentrantTask {
     }
 
     public void suspendForCompletion(List<String> ids) throws Exception {
-        delegate().suspendForCompletion(ids.stream()
+        String eventName = delegate().suspendForCompletion(ids.stream()
                 .map(UUID::fromString)
                 .collect(Collectors.toList()));
+        context.suspend(eventName);
     }
 
     public Map<String, ProcessEntry> waitForCompletion(List<String> ids) {
@@ -111,7 +101,10 @@ public class ConcordTaskV2 implements ReentrantTask {
     }
 
     private ConcordTaskCommon delegate() {
-        return new ConcordTaskCommon(sessionToken, apiClientFactory, instanceId, projectInfo.orgName(), workDir);
+        String sessionToken = context.processConfiguration().processInfo().sessionToken();
+        UUID instanceId = context.processInstanceId();
+        ProjectInfo projectInfo = context.processConfiguration().projectInfo();
+        return new ConcordTaskCommon(sessionToken, apiClientFactory, instanceId, projectInfo.orgName(), context.workingDirectory());
     }
 
     private static List<UUID> toUUIDs(List<String> ids) {

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/v2/ConcordTaskV2.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/v2/ConcordTaskV2.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.*;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -76,8 +77,16 @@ public class ConcordTaskV2 implements ReentrantTask {
         context.suspend(eventName);
     }
 
+    public Map<String, ProcessEntry> waitForCompletion(String id) {
+        return waitForCompletion(Collections.singletonList(id));
+    }
+
     public Map<String, ProcessEntry> waitForCompletion(List<String> ids) {
         return waitForCompletion(ids, -1);
+    }
+
+    public Map<String, ProcessEntry> waitForCompletion(String id, long timeout) {
+        return waitForCompletion(Collections.singletonList(id), timeout);
     }
 
     public Map<String, ProcessEntry> waitForCompletion(List<String> ids, long timeout) {
@@ -92,8 +101,16 @@ public class ConcordTaskV2 implements ReentrantTask {
         delegate().kill(new KillParams(new MapBackedVariables(cfg)));
     }
 
+    public Map<String, Map<String, Object>> getOutVars(String id) {
+        return getOutVars(Collections.singletonList(id));
+    }
+
     public Map<String, Map<String, Object>> getOutVars(List<String> ids) {
         return getOutVars(ids, -1);
+    }
+
+    public Map<String, Map<String, Object>> getOutVars(String id, long timeout) {
+        return getOutVars(Collections.singletonList(id), timeout);
     }
 
     public Map<String, Map<String, Object>> getOutVars(List<String> ids, long timeout) {


### PR DESCRIPTION
fixed:
- suspendForCompletion;
- returning Strings instead of UUIDs (I think these are small breaking change:);
- put fork id into `ids` variable;