### PR TITLE
runtime-v2: fix MetadataProcessor exception when called after `exit` step

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -133,6 +133,27 @@ public class ProcessIT {
         assertEquals("default", pe.getMeta().get("entryPoint"));
     }
 
+    /**
+     * Test the process metadata with exit step.
+     */
+    @Test(timeout = DEFAULT_TEST_TIMEOUT)
+    public void testMetaWithExit() throws Exception {
+        Payload payload = new Payload()
+                .archive(ProcessIT.class.getResource("exitWithMeta").toURI())
+                .arg("name", "Concord");
+
+        ConcordProcess proc = concord.processes().start(payload);
+
+        ProcessEntry pe = proc.expectStatus(ProcessEntry.StatusEnum.FINISHED);
+
+        // ---
+
+        proc.assertLog(".*Hello, Concord!.*");
+
+        assertNotNull(pe.getMeta());
+        assertEquals("init-value", pe.getMeta().get("test"));
+    }
+
     @Test(timeout = DEFAULT_TEST_TIMEOUT)
     public void testOutVariables() throws Exception {
         Payload payload = new Payload()

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/exitWithMeta/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/exitWithMeta/concord.yml
@@ -1,0 +1,11 @@
+flows:
+  default:
+    - log: "Hello, ${name}!"
+    - exit
+
+configuration:
+  runtime: "concord-v2"
+  arguments:
+    name: "Concord"
+  meta:
+    test: "init-value"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/exitWithMeta/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/exitWithMeta/concord.yml
@@ -1,0 +1,5 @@
+flows:
+  default:
+    - log: "before exit"
+    - exit
+    - log: "after exit"

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
@@ -100,7 +100,7 @@ public class InMemoryState implements Serializable, State {
         synchronized (this) {
             List<Frame> l = this.frames.get(threadId);
             if (l == null) {
-                throw new IllegalStateException("Call frame doesn't exist: " + threadId);
+                return Collections.emptyList();
             }
 
             return Collections.unmodifiableList(new ArrayList<>(l));


### PR DESCRIPTION
```
flows:
  default:
    - log: "Hello"
    - exit

configuration:
  runtime: "concord-v2"
  meta:
    test: "INIT"
```

logs:
```
12:03:18 [ERROR] 
java.lang.IllegalStateException: Call frame doesn't exist: ThreadId{id=0}
	at com.walmartlabs.concord.svm.InMemoryState.getFrames(InMemoryState.java:103)
	at com.walmartlabs.concord.runtime.v2.runner.vm.VMUtils.getCombinedLocals(VMUtils.java:154)
	at com.walmartlabs.concord.runtime.v2.runner.MetadataProcessor.afterCommand(MetadataProcessor.java:93)
	at com.walmartlabs.concord.svm.ExecutionListenerHolder.fireAfterCommand(ExecutionListenerHolder.java:56)
	at com.walmartlabs.concord.svm.VM.eval(VM.java:140)
	at com.walmartlabs.concord.svm.VM.execute(VM.java:170)
	at com.walmartlabs.concord.svm.VM.start(VM.java:54)
	at com.walmartlabs.concord.runtime.v2.runner.Runner.start(Runner.java:86)
	at com.walmartlabs.concord.runtime.v2.runner.Main.start(Main.java:218)
	at com.walmartlabs.concord.runtime.v2.runner.Main.execute(Main.java:157)
	at com.walmartlabs.concord.runtime.v2.runner.Main.main(Main.java:100)
```