### PR TITLE
server: fix concurrent process status update

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueDao.java
@@ -290,7 +290,7 @@ public class ProcessQueueDao extends AbstractDao {
                     .set(PROCESS_QUEUE.LAST_RUN_AT, createRunningAtValue(status))
                     .where(PROCESS_QUEUE.INSTANCE_ID.in(instanceIds));
 
-            if (expected != null) {
+            if (expected != null && !expected.isEmpty()) {
                 List<String> l = expected.stream()
                         .map(Enum::toString)
                         .collect(Collectors.toList());


### PR DESCRIPTION
fixes this test:
```
ExclusiveProcessIT.testExclusiveCancelOld:77 expected:<CANCELLED> but was:<FINISHED>
```

```
p1 history: [class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: fbacf84c-48c2-11ec-a9c0-0242c0a86003
01:59:06 [INFO ]     status: NEW
01:59:06 [INFO ]     changeDate: 2021-11-18T22:58:02.490Z
01:59:06 [INFO ] }, class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: fc4d75ba-48c2-11ec-a9c0-0242c0a86003
01:59:06 [INFO ]     status: ENQUEUED
01:59:06 [INFO ]     changeDate: 2021-11-18T22:58:03.540Z
01:59:06 [INFO ] }, class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: fc4d81d6-48c2-11ec-b176-0242c0a86003
01:59:06 [INFO ]     status: CANCELLED
01:59:06 [INFO ]     changeDate: 2021-11-18T22:58:03.543Z
01:59:06 [INFO ] }, class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: fc971dd2-48c2-11ec-b9ae-0242c0a86003
01:59:06 [INFO ]     status: STARTING
01:59:06 [INFO ]     changeDate: 2021-11-18T22:58:04.022Z
01:59:06 [INFO ] }, class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: fccb6bbe-48c2-11ec-bd08-0242c0a86003
01:59:06 [INFO ]     status: RUNNING
01:59:06 [INFO ]     changeDate: 2021-11-18T22:58:04.364Z
01:59:06 [INFO ] }, class ProcessStatusHistoryEntry {
01:59:06 [INFO ]     id: 21a7ab96-48c3-11ec-a9c0-0242c0a86003
01:59:06 [INFO ]     status: FINISHED
01:59:06 [INFO ]     changeDate: 2021-11-18T22:59:06.208Z
01:59:06 [INFO ] }]
```