### PR TITLE
smtp: cfg from default variables fix

### DIFF
--- a/plugins/tasks/smtp/src/main/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2.java
+++ b/plugins/tasks/smtp/src/main/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2.java
@@ -58,23 +58,23 @@ public class SmtpTaskV2 implements Task {
         return SmtpTaskUtils.getScope(mailParams, ctxParams);
     }
 
-    private Map<String, Object> getCfg(Context ctx, Variables input, String a, String b) {
+    private static Map<String, Object> getCfg(Context ctx, Variables input, String a, String b) {
         Map<String, Object> m = getMap(ctx, input, a);
         if (m == null) {
             m = getMap(ctx, input, b);
         }
 
+        if (m == null) {
+            return ctx.defaultVariables().toMap();
+        }
+
         return m;
     }
 
-    private Map<String, Object> getMap(Context ctx, Variables input, String s) {
+    private static Map<String, Object> getMap(Context ctx, Variables input, String s) {
         Map<String, Object> m = input.getMap(s, null);
         if (m == null) {
             m = ctx.variables().getMap(s, null);
-        }
-
-        if (m == null) {
-            m = ctx.defaultVariables().getMap(s, null);
         }
         return m;
     }

--- a/plugins/tasks/smtp/src/test/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2Test.java
+++ b/plugins/tasks/smtp/src/test/java/com/walmartlabs/concord/plugins/smtp/SmtpTaskV2Test.java
@@ -62,7 +62,7 @@ public class SmtpTaskV2Test {
         Context ctx = mock(Context.class);
         when(ctx.workingDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
         when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
-        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", smtpParams)));
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(smtpParams));
 
         SmtpTaskV2 t = new SmtpTaskV2(ctx);
         t.execute(new MapBackedVariables(Collections.singletonMap("mail", mail)));
@@ -115,7 +115,7 @@ public class SmtpTaskV2Test {
         Context ctx = mock(Context.class);
         when(ctx.workingDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
         when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", processArgsDefaults)));
-        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.singletonMap("smtpParams", policyDefaults)));
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(policyDefaults));
 
         SmtpTaskV2 t = new SmtpTaskV2(ctx);
         t.execute(new MapBackedVariables(Collections.singletonMap("mail", mail)));


### PR DESCRIPTION
now we can define default variables as:
```
smtp:
   host:  ..
   port: ...
```
instead of: 
```
smtp:
   smtpParams:
      host: ...
      port: ...
```