### PR TITLE
concord-parent: support for apple M1 silicon 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dependencies:
 - [Git](https://git-scm.com/) 2.18+
 - [Java 8](https://adoptopenjdk.net/)
 - [Docker Community Edition](https://www.docker.com/community-edition)
-- (Optional) [NodeJS and NPM](https://nodejs.org/en/download/) (Node 14 or greater)
+- (Optional) [NodeJS and NPM](https://nodejs.org/en/download/) (Node 16 or greater)
 
 ```shell
 git clone ...
@@ -58,6 +58,16 @@ Use the `jdk11` profile:
 ```
 
 This command builds binaries and Docker images using JDK 11.
+
+### Apple M1 Silicon (aarch64)
+
+Use the `jdk8-aarch64` profile:
+
+```
+./mvnw clean install -DskipTests -Pdocker -Pjdk8-aarch64
+```
+
+This command builds binaries and Docker images using JDK 8 for arm64 architecture.
 
 ### Integration tests
 

--- a/docker-images/compose/docker-compose.yml
+++ b/docker-images/compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       CONCORD_CFG_FILE: "/concord.conf"
   concord-dind:
-    image: "docker:stable-dind"
+    image: "docker:dind"
     privileged: true
     volumes:
       - "agent-tmp:/tmp"

--- a/docker-images/pom.xml
+++ b/docker-images/pom.xml
@@ -97,5 +97,11 @@
                 <jdk.url>https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9/OpenJDK16U-jdk_x64_linux_hotspot_16.0.1_9.tar.gz</jdk.url>
             </properties>
         </profile>
+        <profile>
+            <id>jdk8-aarch64</id>
+            <properties>
+                <jdk.url>https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_aarch64_linux_hotspot_8u292b10.tar.gz</jdk.url>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/docker-images/run_dev.sh
+++ b/docker-images/run_dev.sh
@@ -62,7 +62,7 @@ docker run -d \
 --name dind \
 --privileged \
 --mount source=concordAgentTmp,target=/tmp \
-docker:stable-dind \
+docker:dind \
 dockerd -H tcp://0.0.0.0:6666 --bip=10.11.13.1/24
 
 docker run -d \

--- a/it/server/pom.xml
+++ b/it/server/pom.xml
@@ -20,7 +20,7 @@
         <db.image>library/postgres</db.image>
         <deps.dir.src.mount>${project.basedir}/target/deps</deps.dir.src.mount>
         <deps.dir>${project.basedir}/target/deps</deps.dir>
-        <dind.image>docker:stable-dind</dind.image>
+        <dind.image>docker:dind</dind.image>
         <docker.daemon.addr>tcp://127.0.0.1:2375</docker.daemon.addr>
         <docker.host.addr>localhost</docker.host.addr>
         <is.docker.profile>false</is.docker.profile>

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,13 @@
 
         <jdk.version>1.8.0</jdk.version>
 
-        <docker.plugin.version>0.30.0</docker.plugin.version>
+        <docker.plugin.version>0.38.1</docker.plugin.version>
         <jooq.version>3.13.4</jooq.version>
         <liquibase.version>3.5.1
         </liquibase.version> <!-- the newer versions (up to 3.5.3) have incorrect mappings for PG's blob/bytea -->
         <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
-        <node.version>14.16.0</node.version>
+        <node.version>14.17.1</node.version>
+        <frontend.plugin.version>1.12.0</frontend.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -186,7 +187,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>${frontend.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <liquibase.version>3.5.1
         </liquibase.version> <!-- the newer versions (up to 3.5.3) have incorrect mappings for PG's blob/bytea -->
         <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
-        <node.version>14.17.1</node.version>
+        <node.version>16.13.1</node.version>
         <frontend.plugin.version>1.12.0</frontend.plugin.version>
     </properties>
 


### PR DESCRIPTION
front end maven plugin up - [details](https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md#1110)
docker maven plugin up - [details](https://github.com/fabric8io/docker-maven-plugin/issues/1257)
Node version up - [details](https://github.com/nvm-sh/nvm#install--update-script)

mvn build using [docker desktop for macos](https://www.docker.com/products/docker-desktop) needs following workaround
```
brew install socat
socat TCP-LISTEN:2375,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock &
export DOCKER_HOST=tcp://127.0.0.1:2375
```