### PR TITLE
runtime-v2: fix segment status parse

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/LocalProcessLog.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/LocalProcessLog.java
@@ -20,10 +20,13 @@ package com.walmartlabs.concord.agent.logging;
  * =====
  */
 
+import com.walmartlabs.concord.common.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -58,15 +61,8 @@ public class LocalProcessLog extends AbstractProcessLog {
     @Override
     public void log(InputStream src) throws IOException {
         Path f = logFile();
-        try (OutputStream dst = Files.newOutputStream(f, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(src))) {
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                dst.write(line.getBytes());
-                dst.write('\n');
-                dst.flush();
-            }
+        try (OutputStream dst = Files.newOutputStream(f, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+             IOUtils.copy(src, dst);
         }
     }
 

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentHeaderParser.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentHeaderParser.java
@@ -37,11 +37,17 @@ public class SegmentHeaderParser {
         int mark = -1;
         ImmutableHeader.Builder headerBuilder = Header.builder();
 
+        boolean continueParse = true;
         State state = State.FIND_HEADER;
         ByteBuffer bb = ByteBuffer.wrap(ab);
-        while (bb.remaining() > 0) {
+        while (continueParse) {
             switch (state) {
                 case FIND_HEADER: {
+                    if (bb.remaining() <= 0) {
+                        continueParse = false;
+                        break;
+                    }
+
                     char ch = (char) bb.get();
                     if (ch == '|') {
                         if (mark != -1) {
@@ -58,6 +64,11 @@ public class SegmentHeaderParser {
                     break;
                 }
                 case FIELD_DATA: {
+                    if (bb.remaining() <= 0) {
+                        continueParse = false;
+                        break;
+                    }
+
                     char ch = (char)bb.get();
                     if (ch == '|') {
                         state = State.END_FIELD;

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentedLogsConsumer.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentedLogsConsumer.java
@@ -63,8 +63,10 @@ public class SegmentedLogsConsumer implements Consumer<RedirectedProcessLog.Chun
             byte[] segmentBuffer = new byte[buffLength];
             fillBuffer(e.getValue(), ab, segmentBuffer);
 
-            // TODO: retry?
-            logAppender.appendLog(instanceId, e.getKey(), segmentBuffer);
+            if (segmentBuffer.length > 0) {
+                // TODO: retry?
+                logAppender.appendLog(instanceId, e.getKey(), segmentBuffer);
+            }
 
             LogSegmentStats stats = findStats(e.getValue());
             if (stats != null) {

--- a/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
+++ b/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
@@ -24,6 +24,7 @@ import com.google.common.primitives.Bytes;
 import com.walmartlabs.concord.agent.logging.SegmentHeaderParser;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +33,7 @@ import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Header;
 import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Position;
 import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Segment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SegmentHeaderParserTest {
 
@@ -181,6 +183,27 @@ public class SegmentHeaderParserTest {
         assertEquals(1, segments.size());
         assertEquals("he", msg(ab, segments.get(0)));
         assertEquals(0, invalidSegments.size());
+    }
+
+    /**
+     *
+     * |0|552|1|0|0|
+     */
+    @Test
+    public void testParseSegmentEndMarker() {
+        String log = "|0|552|1|0|0|";
+        byte[] ab = log.getBytes(StandardCharsets.UTF_8);
+
+        List<Segment> segments = new ArrayList<>();
+        List<Position> invalidSegments = new ArrayList<>();
+
+        int result = SegmentHeaderParser.parse(ab, segments, invalidSegments);
+
+        assertEquals(ab.length, result);
+        assertEquals(1, segments.size());
+        Segment s = segments.get(0);
+        assertEquals(0, s.header().length());
+        assertTrue(s.header().done());
     }
 
     private static String msg(byte[] ab, Segment segment) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/ConcordLogEncoder.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/ConcordLogEncoder.java
@@ -63,7 +63,6 @@ public class ConcordLogEncoder extends PatternLayoutEncoder {
         }
 
         Stats stats = processStats(segmentId, event);
-
         return String.format("|%d|%d|%s|%d|%d|", msgBytes.length, segmentId, (isDone(event) ? '1' : '0'), stats.warnings(), stats.errors()).getBytes();
     }
 
@@ -83,6 +82,9 @@ public class ConcordLogEncoder extends PatternLayoutEncoder {
 
         if (isDone(event)) {
             stats = statsHolder.remove(segmentId);
+            if (stats == null) {
+                stats = EMPTY_STATS;
+            }
         }
 
         return stats;

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -1018,7 +1018,8 @@ public class MainTest {
 
         byte[] log = run(runnerCfg);
 
-        assertLog(log, "\\|70\\|2\\|.*done!.*");
+        assertLog(log, Pattern.quote("|0|1|1|0|0||70|2|0|0|0|") + ".*done!.*");
+        assertLog(log, Pattern.quote("|0|2|1|0|0|"));
     }
 
     @Test


### PR DESCRIPTION
fixed an issue where a segment was marked as `running` but had already been `finished`.