### PR TITLE
it: fix flaky CronIT

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.client.*;
 import com.walmartlabs.concord.common.IOUtils;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +44,7 @@ public class CronIT extends AbstractServerIT {
 
     // we need extra time for cron to fire up the processes
     @Test
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
     public void testProfiles() throws Exception {
         Path tmpDir = createTempDir();
 
@@ -78,8 +81,6 @@ public class CronIT extends AbstractServerIT {
         waitForTriggers(orgName, projectName, repoName, 2);
 
         // ---
-
-        ProcessV2Api processV2Api = new ProcessV2Api(getApiClient());
 
         Set<String> expectedPatterns = new HashSet<>();
         expectedPatterns.add(".*Hello, AAA!.*");

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.it.server;
  * =====
  */
 
+import com.walmartlabs.concord.ApiException;
 import com.walmartlabs.concord.client.*;
 import com.walmartlabs.concord.common.IOUtils;
 import org.eclipse.jgit.api.Git;
@@ -31,6 +32,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.walmartlabs.concord.common.IOUtils.grep;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -76,7 +79,7 @@ public class CronIT extends AbstractServerIT {
 
         // ---
 
-        ProcessApi processApi = new ProcessApi(getApiClient());
+        ProcessV2Api processV2Api = new ProcessV2Api(getApiClient());
 
         Set<String> expectedPatterns = new HashSet<>();
         expectedPatterns.add(".*Hello, AAA!.*");
@@ -85,10 +88,15 @@ public class CronIT extends AbstractServerIT {
         while (true) {
             Thread.sleep(1000);
 
-            List<ProcessEntry> processes = processApi.list(orgName, projectName, null, null, null, null, null, null, null, null, null);
-            if (processes.size() != 2) {
+            List<ProcessEntry> aaaProcesses = listCronProcesses(orgName, projectName, repoName, "AAA");
+            List<ProcessEntry> bbbProcesses = listCronProcesses(orgName, projectName, repoName, "BBB");
+
+            if (aaaProcesses.isEmpty() || bbbProcesses.isEmpty()) {
                 continue;
             }
+
+            List<ProcessEntry> processes = Stream.concat(aaaProcesses.stream(), bbbProcesses.stream())
+                    .collect(Collectors.toList());
 
             for (ProcessEntry e : processes) {
                 assertNotEquals(ProcessEntry.StatusEnum.FAILED, e.getStatus());
@@ -108,9 +116,17 @@ public class CronIT extends AbstractServerIT {
             }
         }
 
-        // ---
+        // --- clean up
 
         projectsApi.delete(orgName, projectName);
+    }
+
+    private List<ProcessEntry> listCronProcesses(String o, String p, String r, String tag) throws ApiException {
+        ProcessV2Api processV2Api = new ProcessV2Api(getApiClient());
+
+        return processV2Api.list(null, o, null, p, null, r, null, null,
+                Collections.singletonList(tag), null, "cron", null, null, null, null);
+
     }
 
     private List<TriggerEntry> waitForTriggers(String orgName, String projectName, String repoName, int expectedCount) throws Exception {

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/cronProfiles/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/cronProfiles/concord.yml
@@ -7,10 +7,14 @@ profiles:
     configuration:
       arguments:
         msg: "AAA"
+      tags:
+        - "AAA"
   bbb:
     configuration:
       arguments:
         msg: "BBB"
+      tags:
+        - "BBB"
 
 triggers:
 - cron:


### PR DESCRIPTION
Unlucky timing can make this test wind up with 1 or 3+ processes which really confuses things when inspecting a combined list of processes. We aren't really looking for 2 processes--we want 1 processes from each trigger/profile (3 will work as long as at least 1 is from either profile).

This change locates the processes based on tags set in their profiles. It also bumps the test timeout to 4 minutes. Sometimes the default 2 minutes isn't enough to 1) let the ConcordSystem process fire and detect/refresh the repo trigger and 2) wait till next cron fire and 3) execute two processes to `FINISHED`