### PR TITLE
agent: allow ignore artifact descriptor repositories

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
@@ -48,6 +48,8 @@ public class AgentConfiguration {
     private final Path dependencyCacheDir;
     private final Path dependencyListsDir;
     private final Duration dependencyResolveTimeout;
+    private final boolean dependencyStrictRepositories;
+
     private final Path payloadDir;
     private final Path workDirBase;
 
@@ -69,6 +71,8 @@ public class AgentConfiguration {
         this.dependencyCacheDir = getOrCreatePath(cfg, "dependencyCacheDir");
         this.dependencyListsDir = getOrCreatePath(cfg, "dependencyListsDir");
         this.dependencyResolveTimeout = cfg.hasPath("dependencyResolveTimeout") ? cfg.getDuration("dependencyResolveTimeout") : null;
+        this.dependencyStrictRepositories = cfg.hasPath("dependencyStrictRepositories") && cfg.getBoolean("dependencyStrictRepositories");
+
         this.payloadDir = getOrCreatePath(cfg, "payloadDir");
         this.workDirBase = getOrCreatePath(cfg, "workDirBase");
 
@@ -99,6 +103,10 @@ public class AgentConfiguration {
 
     public Duration getDependencyResolveTimeout() {
         return dependencyResolveTimeout;
+    }
+
+    public boolean dependencyStrictRepositories() {
+        return dependencyStrictRepositories;
     }
 
     public Path getPayloadDir() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManagerConfigurationProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/guice/AgentDependencyManagerConfigurationProvider.java
@@ -39,6 +39,9 @@ public class AgentDependencyManagerConfigurationProvider implements Provider<Dep
 
     @Override
     public DependencyManagerConfiguration get() {
-        return DependencyManagerConfiguration.of(cfg.getDependencyCacheDir());
+        return DependencyManagerConfiguration.builder()
+                .cacheDir(cfg.getDependencyCacheDir())
+                .strictRepositories(cfg.dependencyStrictRepositories())
+                .build();
     }
 }

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -28,6 +28,10 @@ concord-agent {
     # timeout to resolve process dependencies
     dependencyResolveTimeout = "10 minutes"
 
+    # use repositories from `CONCORD_MAVEN_CFG` file only
+    # (allow/ignore repositories from artifact descriptor)
+    dependencyStrictRepositories = false
+
     # base directory to store the process payload
     # created automatically if not specified
     payloadDir = "payload"

--- a/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
+++ b/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
@@ -69,6 +69,7 @@ public class DependencyManager {
     private final List<RemoteRepository> repositories;
     private final Object mutex = new Object();
     private final RepositorySystem maven;
+    private final boolean strictRepositories;
 
     @Inject
     public DependencyManager(DependencyManagerConfiguration cfg) throws IOException {
@@ -81,6 +82,7 @@ public class DependencyManager {
         log.info("init -> using repositories: {}", cfg.repositories());
         this.repositories = toRemote(cfg.repositories());
         this.maven = RepositorySystemFactory.create();
+        this.strictRepositories = cfg.strictRepositories();
     }
 
     public Collection<DependencyEntity> resolve(Collection<URI> items) throws IOException {
@@ -274,6 +276,7 @@ public class DependencyManager {
     private DefaultRepositorySystemSession newRepositorySystemSession(RepositorySystem system, ProgressNotifier progressNotifier) {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
         session.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
+        session.setIgnoreArtifactDescriptorRepositories(strictRepositories);
 
         LocalRepository localRepo = new LocalRepository(localCacheDir.toFile());
         session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));

--- a/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManagerConfiguration.java
+++ b/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManagerConfiguration.java
@@ -45,6 +45,11 @@ public interface DependencyManagerConfiguration {
     Path cacheDir();
 
     @Value.Default
+    default boolean strictRepositories() {
+        return false;
+    }
+
+    @Value.Default
     default List<MavenRepository> repositories() {
         return DependencyManagerRepositories.get();
     }


### PR DESCRIPTION
new agent configuration parameter:
```
# use repositories from `CONCORD_MAVEN_CFG` file only
# (allow/ignore repositories from artifact descriptor)
dependencyStrictRepositories = true|false
```