### PR TITLE
runtime-v2: project document support for suspendTimeout

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -408,10 +408,19 @@ public class ProcessIT extends AbstractTest {
     }
 
     @Test
-    public void testSuspendTimeout() throws Exception {
+    public void testSuspendTimeoutFromPayload() throws Exception {
         Payload payload = new Payload()
                 .parameter("suspendTimeout", "PT1S")
                 .archive(resource("form"));
+
+        ConcordProcess proc = concord.processes().start(payload);
+        expectStatus(proc, ProcessEntry.StatusEnum.TIMED_OUT);
+    }
+
+    @Test
+    public void testSuspendTimeout() throws Exception {
+        Payload payload = new Payload()
+                .archive(resource("formWithTimeout"));
 
         ConcordProcess proc = concord.processes().start(payload);
         expectStatus(proc, ProcessEntry.StatusEnum.TIMED_OUT);

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/formWithTimeout/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/formWithTimeout/concord.yml
@@ -1,0 +1,13 @@
+configuration:
+  runtime: "concord-v2"
+  suspendTimeout: "PT1S"
+
+flows:
+  default:
+    - form: myForm
+      fields:
+        - firstName: { type: "string" }
+        - lastName: { type: "string" }
+        - age: { type: "int" }
+
+    - log: "myForm: ${myForm}"

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ProcessDefinitionConfiguration.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ProcessDefinitionConfiguration.java
@@ -91,6 +91,9 @@ public interface ProcessDefinitionConfiguration extends Serializable {
     Duration processTimeout();
 
     @Nullable
+    Duration suspendTimeout();
+
+    @Nullable
     ExclusiveMode exclusive();
 
     @Value.Default

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
@@ -77,6 +77,7 @@ public final class ConfigurationGrammar {
                                     optional("meta", mapVal.map(o::meta)),
                                     optional("requirements", mapVal.map(o::requirements)),
                                     optional("processTimeout", durationVal.map(o::processTimeout)),
+                                    optional("suspendTimeout", durationVal.map(o::suspendTimeout)),
                                     optional("activeProfiles", stringArrayVal.map(o::activeProfiles)),
                                     optional("exclusive", exclusiveVal.map(o::exclusive)),
                                     optional("events", eventsVal.map(o::events)),

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectLoaderV2Test.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/ProjectLoaderV2Test.java
@@ -96,8 +96,11 @@ public class ProjectLoaderV2Test {
         // configuration.requirements: should be collected from ROOT concord.yml
         assertEquals(Collections.singletonMap("req", "concord.yml"), cfg.requirements());
 
-        // configuration.requirements: should be collected from ROOT concord.yml
+        // configuration.processTimeout: should be collected from ROOT concord.yml
         assertEquals("PT1H", cfg.processTimeout().toString());
+
+        // configuration.suspendTimeout: should be collected from ROOT concord.yml
+        assertEquals("PT26H", cfg.suspendTimeout().toString());
 
         // configuration.out: should be collected from ROOT concord.yml
         assertEquals(Collections.singletonList("from-root"), cfg.out());

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1881,7 +1881,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1306() throws Exception {
         String msg =
-                "(006.yml): Error @ line: 8, col: 9. Unknown options: ['trash' [NULL] @ line: 8, col: 9], expected: [activeProfiles, arguments, debug, dependencies, entryPoint, events, exclusive, meta, out, processTimeout, requirements, runtime, template]. Remove invalid options and/or fix indentation\n" +
+                "(006.yml): Error @ line: 8, col: 9. Unknown options: ['trash' [NULL] @ line: 8, col: 9], expected: [activeProfiles, arguments, debug, dependencies, entryPoint, events, exclusive, meta, out, processTimeout, requirements, runtime, suspendTimeout, template]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'configuration' @ line: 1, col: 1";
 
@@ -2350,6 +2350,17 @@ public class YamlErrorParserTest extends AbstractParserTest {
                         "\t\t\t'configuration' @ line: 1, col: 1";
 
         assertErrorMessage("errors/configuration/022.yml", msg);
+    }
+
+    @Test
+    public void test1904() throws Exception {
+        String msg =
+                "(023.yml): Error @ line: 11, col: 19. Invalid value type, expected: ISO 8601 DURATION, got: STRING. Error info: Text cannot be parsed to a Duration\n" +
+                        "\twhile processing steps:\n" +
+                        "\t'suspendTimeout' @ line: 11, col: 3\n" +
+                        "\t\t'configuration' @ line: 1, col: 1";
+
+        assertErrorMessage("errors/configuration/023.yml", msg);
     }
 
     private void assertErrorMessage(String resource, String expectedError) throws Exception {

--- a/runtime/v2/model/src/test/resources/errors/configuration/023.yml
+++ b/runtime/v2/model/src/test/resources/errors/configuration/023.yml
@@ -1,0 +1,26 @@
+configuration:
+  entryPoint: "main-test"
+  dependencies:
+    - "d1"
+    - "d2"
+  arguments:
+    k: "v"
+  requirements:
+    k: "v"
+  processTimeout: "PT1H"
+  suspendTimeout: "PT"
+  exclusive:
+    group: "X"
+    mode: "cancel"
+  events:
+    recordTaskInVars: true
+    inVarsBlacklist:
+      - "password"
+      - "apiToken"
+      - "apiKey"
+    recordTaskOutVars: true
+    outVarsBlacklist:
+      - "FOO"
+    recordTaskMeta: true
+    metaBlacklist:
+      - "apiKey"

--- a/runtime/v2/model/src/test/resources/multiProjectFile/concord.yml
+++ b/runtime/v2/model/src/test/resources/multiProjectFile/concord.yml
@@ -35,6 +35,7 @@ configuration:
   requirements:
     req: "concord.yml"
   processTimeout: "PT1H"
+  suspendTimeout: "PT26H"
   out:
     - "from-root"
 

--- a/runtime/v2/model/src/test/resources/multiProjectFile/concord/1.concord.yml
+++ b/runtime/v2/model/src/test/resources/multiProjectFile/concord/1.concord.yml
@@ -23,3 +23,4 @@ configuration:
     nested:
       value: "123"
   processTimeout: "PT2H"
+  suspendTimeout: "PT26H"


### PR DESCRIPTION
We _do_ support `suspendTimeout` if it's provided in a process start payload, project configuration, or policy, but not directly in `concord.yml` . This fixes that.