### PR TITLE
runtime-v2: allow `null` values in configuration.arguments

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ConcordTaskIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ConcordTaskIT.java
@@ -380,6 +380,30 @@ public class ConcordTaskIT extends AbstractServerIT {
     }
 
     @Test
+    public void testSubWithNullArgValue() throws Exception {
+        byte[] payload = archive(ConcordTaskIT.class.getResource("concordSubWithNullArg").toURI());
+
+        StartProcessResponse parentSpr = start(payload);
+
+        ProcessApi processApi = new ProcessApi(getApiClient());
+        waitForCompletion(processApi, parentSpr.getInstanceId());
+
+        ProcessEntry processEntry = processApi.get(parentSpr.getInstanceId());
+        assertEquals(1, processEntry.getChildrenIds().size());
+
+        ProcessEntry child = processApi.get(processEntry.getChildrenIds().get(0));
+        assertNotNull(child);
+        assertEquals(ProcessEntry.StatusEnum.FINISHED, child.getStatus());
+
+        // ---
+
+        byte[] ab = getLog(child.getLogFileName());
+        assertLog(".*Child process, nullValue: ''.*", ab);
+        assertLog(".*Child process, nullValue == null: 'true'.*", ab);
+        assertLog(".*Child process, hasVariable\\('nullValue'\\): true.*", ab);
+    }
+
+    @Test
     public void testForkWithArguments() throws Exception {
         String orgName = "org_" + randomString();
 

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/concordSubWithNullArg/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/concordSubWithNullArg/concord.yml
@@ -1,0 +1,14 @@
+configuration:
+  runtime: concord-v2
+
+flows:
+  default:
+    - task: concord
+      in:
+        action: start
+        payload: myPayload
+        sync: true
+        suspend: true
+        arguments:
+          nullValue: ${null}
+    - log: "Done!"

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/concordSubWithNullArg/myPayload/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/concordSubWithNullArg/myPayload/concord.yml
@@ -1,0 +1,8 @@
+configuration:
+  runtime: concord-v2
+
+flows:
+  default:
+    - log: "Child process, nullValue: '${nullValue}'"
+    - log: "Child process, nullValue == null: '${nullValue == null}'"
+    - log: "Child process, hasVariable('nullValue'): ${hasVariable('nullValue')}"

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ProcessDefinitionConfiguration.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ProcessDefinitionConfiguration.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.runtime.v2.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.walmartlabs.concord.common.AllowNulls;
 import com.walmartlabs.concord.sdk.Constants;
 import org.immutables.value.Value;
 
@@ -68,6 +69,7 @@ public interface ProcessDefinitionConfiguration extends Serializable {
     }
 
     @Value.Default
+    @AllowNulls
     default Map<String, Object> arguments() {
         return Collections.emptyMap();
     }

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/AllowNulls.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/AllowNulls.java
@@ -1,0 +1,27 @@
+package com.walmartlabs.concord.runtime.v2.sdk;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
+public @interface AllowNulls {}

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ProcessConfiguration.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/ProcessConfiguration.java
@@ -59,6 +59,7 @@ public interface ProcessConfiguration extends Serializable {
     }
 
     @Value.Default
+    @AllowNulls
     default Map<String, Object> arguments() {
         return Collections.emptyMap();
     }


### PR DESCRIPTION
fix for "Process failed: Error while processing effective concord.yml: arguments value"