### PR TITLE
runtime-v1/v2: event configuration option to evaluate checkpoint names

### DIFF
--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
@@ -36,8 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -58,6 +56,15 @@ public final class ITUtils {
             }
         }
         return out.toByteArray();
+    }
+
+    public static URI resourceToURI(Class<?> klass, String resource) throws URISyntaxException {
+        URL url = klass.getResource(resource);
+        if (url == null) {
+            throw new RuntimeException("Resource not found: " + resource);
+        }
+
+        return url.toURI();
     }
 
     public static String resourceToString(Class<?> klass, String resource) throws Exception {
@@ -94,11 +101,14 @@ public final class ITUtils {
     }
 
     public static String randomString() {
+        return System.currentTimeMillis() + "_" + randomString(6);
+    }
+
+    public static String randomString(int length) {
         StringBuilder b = new StringBuilder();
-        b.append(System.currentTimeMillis()).append("_");
 
         Random rng = ThreadLocalRandom.current();
-        for (int i = 0; i < 6; i++) {
+        for (int i = 0; i < length; i++) {
             int n = rng.nextInt(RANDOM_CHARS.length);
             b.append(RANDOM_CHARS[n]);
         }

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
@@ -161,6 +161,10 @@ public abstract class AbstractServerIT {
         return ITUtils.randomString();
     }
 
+    protected static String randomString(int length) {
+        return ITUtils.randomString(length);
+    }
+
     protected static String randomPwd() {
         return ITUtils.randomPwd();
     }

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/checkpointsEventInterpolation/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/checkpointsEventInterpolation/concord.yml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - checkpoint: "test ${x}"

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/EventConfiguration.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/EventConfiguration.java
@@ -38,6 +38,7 @@ public class EventConfiguration {
     private boolean recordTaskInVars = false;
     private boolean recordTaskOutVars = false;
     private boolean truncateOutVars = true;
+    private boolean evalCheckpointNames = false;
     private Collection<String> inVarsBlacklist = DEFAULT_IN_VARS_BLACKLIST;
     private Collection<String> outVarsBlacklist = Collections.emptyList();
     private int truncateMaxStringLength = 1024;
@@ -122,5 +123,13 @@ public class EventConfiguration {
 
     public void setTruncateMaxDepth(int truncateMaxDepth) {
         this.truncateMaxDepth = truncateMaxDepth;
+    }
+
+    public void setEvalCheckpointNames(boolean evalCheckpointNames) {
+        this.evalCheckpointNames = evalCheckpointNames;
+    }
+
+    public boolean isEvalCheckpointNames() {
+        return this.evalCheckpointNames;
     }
 }

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/TaskEventInterceptor.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/TaskEventInterceptor.java
@@ -136,12 +136,11 @@ public class TaskEventInterceptor implements TaskInterceptor {
         return t.getIn().stream()
                 .filter(v -> v.getTarget().equals("checkpointName"))
                 .map(v -> {
-                    String name;
+                    String name = v.getSourceExpression();
+
                     if (cfg.isEvalCheckpointNames()) {
-                        String evaluated = ContextUtils.getString(ctx, "checkpointName", v.getSourceExpression());
+                        String evaluated = ContextUtils.getString(ctx, "checkpointName", name);
                         name = ObjectTruncater.truncate(evaluated, 128, 1, 1).toString();
-                    } else {
-                        name = v.getSourceExpression();
                     }
 
                     return "Checkpoint: " + name;

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/TaskEventInterceptor.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/TaskEventInterceptor.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.walmartlabs.concord.runner.ContextUtils;
 import com.walmartlabs.concord.runtime.common.ObjectTruncater;
+import com.walmartlabs.concord.sdk.ContextUtils;
 import com.walmartlabs.concord.sdk.Context;
 import io.takari.bpm.api.ExecutionContext;
 import io.takari.bpm.api.ExecutionException;
@@ -137,11 +137,11 @@ public class TaskEventInterceptor implements TaskInterceptor {
                 .filter(v -> v.getTarget().equals("checkpointName"))
                 .map(v -> {
                     String name;
-                    if (!cfg.isEvalCheckpointNames()) {
-                        name = v.getSourceExpression();
-                    } else {
-                        String evaluated = (String) ctx.interpolate(v.getSourceExpression());
+                    if (cfg.isEvalCheckpointNames()) {
+                        String evaluated = ContextUtils.getString(ctx, "checkpointName", v.getSourceExpression());
                         name = ObjectTruncater.truncate(evaluated, 128, 1, 1).toString();
+                    } else {
+                        name = v.getSourceExpression();
                     }
 
                     return "Checkpoint: " + name;

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ConcordJsonSchemaGenerator.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ConcordJsonSchemaGenerator.java
@@ -21,11 +21,7 @@ package com.walmartlabs.concord.runtime.v2;
  */
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -35,16 +31,8 @@ import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 import com.kjetland.jackson.jsonSchema.SubclassesResolver;
 import com.kjetland.jackson.jsonSchema.SubclassesResolverImpl;
 import com.walmartlabs.concord.imports.Imports;
-import com.walmartlabs.concord.runtime.v2.model.Form;
-import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
-import com.walmartlabs.concord.runtime.v2.model.ProcessDefinitionConfiguration;
-import com.walmartlabs.concord.runtime.v2.model.Step;
-import com.walmartlabs.concord.runtime.v2.model.Trigger;
-import com.walmartlabs.concord.runtime.v2.schema.ImportsMixIn;
-import com.walmartlabs.concord.runtime.v2.schema.ProcessDefinitionConfigurationMixIn;
-import com.walmartlabs.concord.runtime.v2.schema.ProcessDefinitionMixIn;
-import com.walmartlabs.concord.runtime.v2.schema.StepMixIn;
-import com.walmartlabs.concord.runtime.v2.schema.TriggerMixIn;
+import com.walmartlabs.concord.runtime.v2.model.*;
+import com.walmartlabs.concord.runtime.v2.schema.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -81,7 +69,7 @@ public class ConcordJsonSchemaGenerator {
 
         // remove invalid required primitive attributes
         removeRequired(path(jsonSchema, "definitions/ProcessDefinitionConfiguration"), "debug");
-        removeRequired(path(jsonSchema, "definitions/EventConfiguration"), "recordEvents", "recordTaskInVars", "truncateInVars", "truncateMaxStringLength", "truncateMaxArrayLength", "truncateMaxDepth", "recordTaskOutVars", "truncateOutVars", "recordTaskMeta", "truncateMeta");
+        removeRequired(path(jsonSchema, "definitions/EventConfiguration"), "evalCheckpointNames", "recordEvents", "recordTaskInVars", "truncateInVars", "truncateMaxStringLength", "truncateMaxArrayLength", "truncateMaxDepth", "recordTaskOutVars", "truncateOutVars", "recordTaskMeta", "truncateMeta");
         removeRequired(path(jsonSchema, "definitions/TaskCall"), "ignoreErrors");
 
         // remove invalid Object definition

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/EventConfiguration.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/EventConfiguration.java
@@ -155,6 +155,14 @@ public interface EventConfiguration extends Serializable {
     }
 
     /**
+     * Enable/disable evaluation of checkpoint names.
+     */
+    @Value.Default
+    default boolean evalCheckpointNames() {
+        return false;
+    }
+
+    /**
      * metadata in the blacklist won't be recorded.
      */
     @Value.Default

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
@@ -60,7 +60,8 @@ public final class ConfigurationGrammar {
                                     optional("outVarsBlacklist", stringArrayVal.map(o::outVarsBlacklist)),
                                     optional("recordTaskMeta", booleanVal.map(o::recordTaskMeta)),
                                     optional("truncateMeta", booleanVal.map(o::truncateMeta)),
-                                    optional("metaBlacklist", stringArrayVal.map(o::metaBlacklist))))
+                                    optional("metaBlacklist", stringArrayVal.map(o::metaBlacklist)),
+                                    optional("evalCheckpointNames", booleanVal.map(o::evalCheckpointNames))))
                             .map(ImmutableEventConfiguration.Builder::build));
 
     private static final Parser<Atom, EventConfiguration> eventsVal =

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -2028,7 +2028,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1318() throws Exception {
         String msg =
-                "(018.yml): Error @ line: 26, col: 11. Unknown options: ['trash' [NULL] @ line: 26, col: 11], expected: [inVarsBlacklist, metaBlacklist, outVarsBlacklist, recordEvents, recordTaskInVars, recordTaskMeta, recordTaskOutVars, truncateInVars, truncateMaxArrayLength, truncateMaxDepth, truncateMaxStringLength, truncateMeta, truncateOutVars]. Remove invalid options and/or fix indentation\n" +
+                "(018.yml): Error @ line: 26, col: 11. Unknown options: ['trash' [NULL] @ line: 26, col: 11], expected: [evalCheckpointNames, inVarsBlacklist, metaBlacklist, outVarsBlacklist, recordEvents, recordTaskInVars, recordTaskMeta, recordTaskOutVars, truncateInVars, truncateMaxArrayLength, truncateMaxDepth, truncateMaxStringLength, truncateMeta, truncateOutVars]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'events' @ line: 14, col: 3\n" +
                         "\t\t'configuration' @ line: 1, col: 1";

--- a/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
+++ b/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
@@ -19,6 +19,7 @@ configuration:
     - "vaultPassword"
     recordTaskMeta: false
     truncateMeta: true
+    evalCheckpointNames: false
 flows:
   flow1:
   - checkpoint: "chp1"

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/EventRecordingExecutionListener.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/EventRecordingExecutionListener.java
@@ -128,11 +128,11 @@ public class EventRecordingExecutionListener implements ExecutionListener {
             return "Set variables";
         } else if (step instanceof Checkpoint) {
             String name;
-            if (!eventConfiguration.evalCheckpointNames()) {
-                name = ((Checkpoint) step).getName();
-            } else {
+            if (eventConfiguration.evalCheckpointNames()) {
                 String evaluated = interpolator.apply(((Checkpoint) step).getName());
                 name = (String) ObjectTruncater.truncate(evaluated, 128, 1, 1);
+            } else {
+                name = ((Checkpoint) step).getName();
             }
 
             return "Checkpoint: " + name;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/EventRecordingExecutionListener.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/remote/EventRecordingExecutionListener.java
@@ -127,12 +127,11 @@ public class EventRecordingExecutionListener implements ExecutionListener {
         } else if (step instanceof SetVariablesStep) {
             return "Set variables";
         } else if (step instanceof Checkpoint) {
-            String name;
+            String name = ((Checkpoint) step).getName();
+
             if (eventConfiguration.evalCheckpointNames()) {
-                String evaluated = interpolator.apply(((Checkpoint) step).getName());
-                name = (String) ObjectTruncater.truncate(evaluated, 128, 1, 1);
-            } else {
-                name = ((Checkpoint) step).getName();
+                String evaluated = interpolator.apply(name);
+                name = evaluated == null ? name : (String) ObjectTruncater.truncate(evaluated, 128, 1, 1);
             }
 
             return "Checkpoint: " + name;

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointExpr/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/checkpointExpr/concord.yml
@@ -1,3 +1,8 @@
 flows:
   default:
     - checkpoint: "test_${x}"
+
+  resourceExpr:
+    - set:
+        jsonString: '{"k": "${x}"}'
+    - checkpoint: "test_${resource.fromJsonString(jsonString).k}"


### PR DESCRIPTION
This is a little trickier than it seems at first. The process process event recorder doesn't get direct access to the checkpoint name when it's created--it gets the value from the YAML file which is typically a hard-coded string, but may be an expression. The PR exposes an option in the runner config to enable evaluation of expressions in checkpoint names. It's off by default.

In runtime-v2, it's limited to only expressions using variables. If a checkpoint name's expression is uses a task call, e.g. `- checkpoint: ${resource.asJson('myList.json')[0]}`, then the expression will evaluate to `null` and fallback to the default from-the-yaml value.