### PR TITLE
explicitly specify initialBranch for git tests

### DIFF
--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/GitUtils.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/GitUtils.java
@@ -55,7 +55,7 @@ public final class GitUtils {
         Path repo = tmp.resolve(leaf);
         Files.createDirectories(repo);
 
-        Git.init().setBare(true).setDirectory(repo.toFile()).call();
+        Git.init().setInitialBranch("master").setBare(true).setDirectory(repo.toFile()).call();
 
         // clone the repository into a new directory
         Path workdir = createTempDir(baseTmpDir);

--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
@@ -86,7 +86,7 @@ public final class ITUtils {
         Path tmpDir = createTempDir();
         IOUtils.copy(src, tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/CronIT.java
@@ -191,7 +191,7 @@ public class CronIT extends AbstractServerIT {
         File src = new File(TriggersRefreshIT.class.getResource(initResource).toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
         return tmpDir.toAbsolutePath().toString();

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ExternalImportsIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ExternalImportsIT.java
@@ -532,7 +532,7 @@ public class ExternalImportsIT extends AbstractServerIT {
             Files.write(p, s.replace(find, replace).getBytes());
         }
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
         repo.branchCreate().setName("main").call();

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/GeneralTriggerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/GeneralTriggerIT.java
@@ -40,7 +40,7 @@ public class GeneralTriggerIT extends AbstractGeneralTriggerIT {
         File src = new File(TriggersRefreshIT.class.getResource("generalExclusiveTrigger").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -94,7 +94,7 @@ public class GeneralTriggerIT extends AbstractGeneralTriggerIT {
         File src = new File(TriggersRefreshIT.class.getResource("generalTriggerWithExclusiveCfg").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -149,7 +149,7 @@ public class GeneralTriggerIT extends AbstractGeneralTriggerIT {
         File src = new File(TriggersRefreshIT.class.getResource("generalTriggerWithExclusiveOverride").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/GeneralTriggerV2IT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/GeneralTriggerV2IT.java
@@ -45,7 +45,7 @@ public class GeneralTriggerV2IT extends AbstractGeneralTriggerIT {
         File src = new File(TriggersRefreshIT.class.getResource(yamlPath).toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/GitBranchesIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/GitBranchesIT.java
@@ -48,7 +48,7 @@ public class GitBranchesIT extends AbstractServerIT {
     @BeforeEach
     public void setUp() throws Exception {
         Path bareRepo = createTempDir();
-        Git.init().setBare(true).setDirectory(bareRepo.toFile()).call();
+        Git.init().setInitialBranch("master").setBare(true).setDirectory(bareRepo.toFile()).call();
 
         Path workdir = createTempDir();
         Git git = Git.cloneRepository()

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/GitHubNonOrgEventIt.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/GitHubNonOrgEventIt.java
@@ -46,7 +46,7 @@ public class GitHubNonOrgEventIt extends AbstractServerIT {
         File src = new File(GitHubNonOrgEventIt.class.getResource("githubNonRepoEvent").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/GitRepositoryIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/GitRepositoryIT.java
@@ -45,7 +45,7 @@ public class GitRepositoryIT extends AbstractServerIT {
     @BeforeEach
     public void setUp() throws Exception {
         Path bareRepo = createTempDir();
-        Git.init().setBare(true).setDirectory(bareRepo.toFile()).call();
+        Git.init().setInitialBranch("master").setBare(true).setDirectory(bareRepo.toFile()).call();
 
         Path workdir = createTempDir();
         Git git = Git.cloneRepository()

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ProcessCountIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ProcessCountIT.java
@@ -46,7 +46,7 @@ public class ProcessCountIT extends AbstractServerIT {
         File src = new File(TriggersRefreshIT.class.getResource("processCount").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ProjectIT.java
@@ -46,7 +46,8 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("project").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
+
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -72,6 +73,10 @@ public class ProjectIT extends AbstractServerIT {
         assertLog(".*" + greeting + ".*", ab);
     }
 
+    private static Git initRepo(Path initDir) throws Exception {
+        return Git.init().setInitialBranch("master").setDirectory(initDir.toFile()).call();
+    }
+
     @Test
     public void testEntryPointFromYml() throws Exception {
         Path tmpDir = createTempDir();
@@ -79,7 +84,8 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("projectEntryPoint").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
+
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -108,7 +114,8 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("project").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
+
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -160,7 +167,8 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("project").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
+
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -208,7 +216,8 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("project-triggers").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
+
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -244,7 +253,7 @@ public class ProjectIT extends AbstractServerIT {
         File src = new File(ProjectIT.class.getResource("repositoryValidation").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = initRepo(tmpDir);
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 
@@ -277,7 +286,7 @@ public class ProjectIT extends AbstractServerIT {
             File src = new File(ProjectIT.class.getResource("repositoryValidationEmptyFlow").toURI());
             IOUtils.copy(src.toPath(), tmpDir);
 
-            Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+            Git repo = initRepo(tmpDir);
             repo.add().addFilepattern(".").call();
             repo.commit().setMessage("import").call();
 
@@ -311,7 +320,7 @@ public class ProjectIT extends AbstractServerIT {
             File src = new File(ProjectIT.class.getResource("repositoryValidationEmptyForm").toURI());
             IOUtils.copy(src.toPath(), tmpDir);
 
-            Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+            Git repo = initRepo(tmpDir);
             repo.add().addFilepattern(".").call();
             repo.commit().setMessage("import").call();
 
@@ -345,7 +354,7 @@ public class ProjectIT extends AbstractServerIT {
             File src = new File(ProjectIT.class.getResource("ProcessDisabledRepo").toURI());
             IOUtils.copy(src.toPath(), tmpDir);
 
-            Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+            Git repo = initRepo(tmpDir);
             repo.add().addFilepattern(".").call();
             repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
@@ -157,7 +157,7 @@ public class TemplateIT extends AbstractServerIT {
                 .replace("{{ template }}", "file://" + templatePath.toAbsolutePath().toString());
         Files.write(concordYml, s.getBytes());
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TriggerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TriggerIT.java
@@ -126,7 +126,7 @@ public class TriggerIT extends AbstractServerIT {
         File src = new File(TriggerIT.class.getResource(repoResource).toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TriggersRefreshIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TriggersRefreshIT.java
@@ -46,7 +46,7 @@ public class TriggersRefreshIT extends AbstractServerIT {
         File src = new File(TriggersRefreshIT.class.getResource("triggerRepo").toURI());
         IOUtils.copy(src.toPath(), tmpDir);
 
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         repo.commit().setMessage("import").call();
 

--- a/repository/src/test/java/com/walmartlabs/concord/repository/GitClientFetchTest.java
+++ b/repository/src/test/java/com/walmartlabs/concord/repository/GitClientFetchTest.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.common.TemporaryPath;
 import com.walmartlabs.concord.sdk.Secret;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRefNameException;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,11 +60,10 @@ public class GitClientFetchTest {
     public void testFetch1() throws Exception {
         Path tmpDir = IOUtils.createTempDir("test");
 
-        File src = new File(GitClientFetchTest.class.getResource("/test4").toURI());
-        IOUtils.copy(src.toPath(), tmpDir);
+        IOUtils.copy(resourceToPath("/test4"), tmpDir);
 
         // init repo
-        Git repo = Git.init().setDirectory(tmpDir.toFile()).call();
+        Git repo = Git.init().setInitialBranch("master").setDirectory(tmpDir.toFile()).call();
         repo.add().addFilepattern(".").call();
         RevCommit initialCommit = commit(repo, "import");
 

--- a/repository/src/test/java/com/walmartlabs/concord/repository/GitUtils.java
+++ b/repository/src/test/java/com/walmartlabs/concord/repository/GitUtils.java
@@ -42,7 +42,7 @@ public final class GitUtils {
         Path repo = tmp.resolve("test");
         Files.createDirectories(repo);
 
-        Git.init().setBare(true).setDirectory(repo.toFile()).call();
+        Git.init().setInitialBranch("master").setBare(true).setDirectory(repo.toFile()).call();
 
         // clone the repository into a new directory
         Path workdir = Files.createTempDirectory("workDir");


### PR DESCRIPTION
in the latest version jgit reads the branch from the configuration:

```
			builder.setInitialBranch(StringUtils.isEmptyOrNull(initialBranch)
					? SystemReader.getInstance().getUserConfig().getString(
							ConfigConstants.CONFIG_INIT_SECTION, null,
							ConfigConstants.CONFIG_KEY_DEFAULT_BRANCH)
					: initialBranch);
```