### PR TITLE
ansible: stats file for flow with multiple playbooks

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
@@ -177,8 +177,12 @@ public abstract class AbstractServerIT {
 
     @SuppressWarnings("unchecked")
     protected Map<String, Object> fromJson(File f) throws IOException {
+        return fromJson(f, Map.class);
+    }
+
+    protected <T> T fromJson(File f, Class<T> classOfT) throws IOException {
         try (Reader r = new FileReader(f)) {
-            return getApiClient().getJSON().getGson().fromJson(r, Map.class);
+            return getApiClient().getJSON().getGson().fromJson(r, classOfT);
         }
     }
 

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AttachmentRbacIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AttachmentRbacIT.java
@@ -124,7 +124,7 @@ public class AttachmentRbacIT extends AbstractServerIT {
         log.info("The initiator shall be able to list attachments");
         List<String> attachments = processApi.listAttachments(spr.getInstanceId());
         assertNotNull(attachments, "Attachments shall not be null for initiator");
-        assertSame(1, attachments.size(), "Attachment size shall be 1 for initiator");
+        assertSame(2, attachments.size(), "Attachment size shall be 2 for initiator");
 
         File file = processApi.downloadAttachment(spr.getInstanceId(), attachments.get(0));
         assertNotNull(file, "File object shall not be null for initiator");
@@ -154,7 +154,7 @@ public class AttachmentRbacIT extends AbstractServerIT {
         resetApiKey();
         attachments = processApi.listAttachments(spr.getInstanceId());
         assertNotNull(attachments, "Attachments shall not be null for admin");
-        assertSame(1, attachments.size(), "Attachment size shall be 1 for admin");
+        assertSame(2, attachments.size(), "Attachment size shall be 2 for admin");
 
         file = processApi.downloadAttachment(spr.getInstanceId(), attachments.get(0));
         assertNotNull(file, "File object shall not be null for admin");
@@ -187,8 +187,8 @@ public class AttachmentRbacIT extends AbstractServerIT {
 
         attachments = processApi.listAttachments(spr.getInstanceId());
         assertNotNull(attachments, "Attachments shall not be null for non-admin who is a owner");
-        assertSame(1, attachments.size(),
-                "Attachment size shall be 1 for non-admin who is a owner");
+        assertSame(2, attachments.size(),
+                "Attachment size shall be 2 for non-admin who is a owner");
 
         file = processApi.downloadAttachment(spr.getInstanceId(), attachments.get(0));
         assertNotNull(file, "File object shall not be null for non-admin who is a owner");

--- a/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_trace.py
+++ b/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_trace.py
@@ -30,7 +30,7 @@ class CallbackModule(CallbackBase):
         self.base_dir = os.environ['_CONCORD_ATTACHMENTS_DIR']
 
     def log(self, data):
-        target_dir = self.base_dir;
+        target_dir = self.base_dir
         mkdir_p(target_dir)
 
         target_filename = target_dir + "/ansible_stats.json"
@@ -38,6 +38,25 @@ class CallbackModule(CallbackBase):
         target_file.write(json.dumps(data, indent=2))
 
         print("Trace saved to:", target_filename)
+
+        entry = {'playbook': self.playbook._file_name, 'stats': data}
+
+        target_filename = target_dir + "/ansible_stats_v2.json"
+        if not os.path.isfile(target_filename):
+            with open(target_filename, mode='w') as f:
+                f.write(json.dumps([entry], indent=2))
+        else:
+            with open(target_filename) as f:
+                stats = json.load(f)
+
+            stats.append(entry)
+            with open(target_filename, mode='w') as f:
+                f.write(json.dumps(stats, indent=2))
+
+        print("Trace saved to:", target_filename)
+
+    def v2_playbook_on_start(self, playbook):
+        self.playbook = playbook
 
     def playbook_on_stats(self, stats):
         self.log(ConcordAnsibleStats.build_stats_data(stats))

--- a/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_trace.py
+++ b/plugins/tasks/ansible/src/main/resources/com/walmartlabs/concord/plugins/ansible/callback/concord_trace.py
@@ -28,6 +28,9 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         super(CallbackModule, self).__init__()
         self.base_dir = os.environ['_CONCORD_ATTACHMENTS_DIR']
+        self.eventCorrelationId = None
+        if "CONCORD_EVENT_CORRELATION_ID" in os.environ:
+            self.eventCorrelationId = os.environ['CONCORD_EVENT_CORRELATION_ID']
 
     def log(self, data):
         target_dir = self.base_dir
@@ -39,7 +42,9 @@ class CallbackModule(CallbackBase):
 
         print("Trace saved to:", target_filename)
 
-        entry = {'playbook': self.playbook._file_name, 'stats': data}
+        entry = {'playbook': self.playbook._file_name,
+                 'eventCorrelationId': self.eventCorrelationId,
+                 'stats': data}
 
         target_filename = target_dir + "/ansible_stats_v2.json"
         if not os.path.isfile(target_filename):


### PR DESCRIPTION
new file `ansible_stats_v2.json`:
```
[ {
  "stats" : {
    "ok" : [ "127.0.0.1" ],
    "failures" : [ ],
    "unreachable" : [ ],
    "changed" : [ ],
    "skipped" : [ ]
  },
  "exitCode" : 0,
  "playbook" : "playbook/hello.yml",
  "eventCorrelationId" : "9bb13aad-70cf-414a-a8f4-a8387e0a6e35"
}, {
  "stats" : {
    "ok" : [ "127.0.0.1" ],
    "failures" : [ ],
    "unreachable" : [ ],
    "changed" : [ ],
    "skipped" : [ ]
  },
  "exitCode" : 0,
  "playbook" : "playbook/hello2.yml",
  "eventCorrelationId" : "0fdd2f9b-c7a4-4225-8a7f-47a17bbed174"
} ]
```