### PR TITLE
server: adding support of ldap groups for Roles

### DIFF
--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -104,5 +104,6 @@
     <include file="v1.91.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.94.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.95.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.96.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.96.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.96.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="1960000" author="amith.k.b@walmart.com">
+        <createTable tableName="ROLE_LDAP_GROUPS">
+            <column name="ROLE_ID" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+            <column name="LDAP_GROUP" type="varchar(1024)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="ROLE_LDAP_GROUPS" columnNames="ROLE_ID, LDAP_GROUP"/>
+    </changeSet>
+
+    <changeSet id="1960010" author="amith.k.b@walmart.com">
+        <createView viewName="V_USER_ROLES" replaceIfExists="true">
+            select USER_ID, ROLE_ID
+            from USER_ROLES
+            union
+            select distinct ulg.USER_ID, rlg.ROLE_ID
+            from ROLE_LDAP_GROUPS rlg, USER_LDAP_GROUPS ulg
+            where
+            ulg.LDAP_GROUP = rlg.LDAP_GROUP
+            and not exists(select 1 from USER_ROLES ur where ur.USER_ID = ulg.USER_ID and ur.ROLE_ID = rlg.ROLE_ID)
+        </createView>
+    </changeSet>
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/role/RoleDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/role/RoleDao.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server.role;
 
 import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
+import com.walmartlabs.concord.server.jooq.tables.RoleLdapGroups;
 import com.walmartlabs.concord.server.user.RoleEntry;
 import org.jooq.*;
 
@@ -29,8 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.*;
 
-import static com.walmartlabs.concord.server.jooq.Tables.PERMISSIONS;
-import static com.walmartlabs.concord.server.jooq.Tables.ROLE_PERMISSIONS;
+import static com.walmartlabs.concord.server.jooq.Tables.*;
 import static com.walmartlabs.concord.server.jooq.tables.Roles.ROLES;
 import static org.jooq.impl.DSL.*;
 
@@ -40,6 +40,11 @@ public class RoleDao extends AbstractDao {
     @Inject
     protected RoleDao(@MainDB Configuration cfg) {
         super(cfg);
+    }
+
+    @Override
+    public void tx(Tx t) {
+        super.tx(t);
     }
 
     public RoleEntry get(UUID id) {
@@ -124,6 +129,30 @@ public class RoleDao extends AbstractDao {
                 .fetch(RoleDao::toEntry);
     }
 
+    public void upsertLdapGroup(DSLContext tx, UUID roleId, String ldapGroup) {
+        tx.insertInto(ROLE_LDAP_GROUPS)
+                .columns(ROLE_LDAP_GROUPS.ROLE_ID, ROLE_LDAP_GROUPS.LDAP_GROUP)
+                .values(roleId, ldapGroup)
+                .onConflict(ROLE_LDAP_GROUPS.ROLE_ID, ROLE_LDAP_GROUPS.LDAP_GROUP)
+                .doNothing()
+                .execute();
+    }
+    
+    public void removeLdapGroups(DSLContext tx, UUID roleId) {
+        tx.deleteFrom(ROLE_LDAP_GROUPS)
+                .where(ROLE_LDAP_GROUPS.ROLE_ID.eq(roleId))
+                .execute();
+    }
+
+    public List<String> listLdapGroups(UUID roleId) {
+        RoleLdapGroups r = ROLE_LDAP_GROUPS.as("r");
+        return txResult(tx -> tx.select(r.LDAP_GROUP)
+                .from(r)
+                .where(r.ROLE_ID.eq(roleId))
+                .orderBy(r.LDAP_GROUP)
+                .fetch(r.LDAP_GROUP));
+    }
+    
     private static RoleEntry toEntry(Record3<UUID, String, String[]> e) {
         return new RoleEntry(e.value1(), e.value2(), new HashSet<>(Arrays.asList(e.value3())));
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
@@ -292,8 +292,8 @@ public class UserDao extends AbstractDao {
                         select(ROLE_PERMISSIONS.PERMISSION_ID).from(ROLE_PERMISSIONS)
                                 .where(ROLE_PERMISSIONS.ROLE_ID.in(ROLES.ROLE_ID))));
 
-        SelectConditionStep<Record1<UUID>> roleIds = select(USER_ROLES.ROLE_ID).from(USER_ROLES)
-                .where(USER_ROLES.USER_ID
+        SelectConditionStep<Record1<UUID>> roleIds = select(V_USER_ROLES.ROLE_ID).from(V_USER_ROLES)
+                .where(V_USER_ROLES.USER_ID
                         .eq(r.get(USERS.USER_ID)));
 
         List<RoleEntry> roles = tx.select(ROLES.ROLE_ID, ROLES.ROLE_NAME,


### PR DESCRIPTION
Support of ldap group for roles

API endpoints
* Add LDAP group for a role
```
PUT  - /api/v1/role/<roleName>/ldapGroups
body: ["group1", "group2"...]
```
* List LDAP groups for a role
```
GET - /api/v1/role/<roleName>/ldapGroups
```

With this access for `concordAdmin` can be managed by LDAP groups