### PR TITLE
server: fix out vars processing and restrictions

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
@@ -21,17 +21,45 @@ package com.walmartlabs.concord.it.server;
  */
 
 import com.walmartlabs.concord.ApiException;
-import com.walmartlabs.concord.client.ProjectEntry;
-import com.walmartlabs.concord.client.ProjectsApi;
+import com.walmartlabs.concord.client.*;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
-import static org.junit.jupiter.api.Assertions.fail;
+import static com.walmartlabs.concord.it.common.ServerClient.waitForCompletion;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OutVariablesProjectIT extends AbstractServerIT {
+
+    @Test
+    public void testOutVars() throws Exception {
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+
+        String orgName = "Default";
+        String projectName = "project_" + System.currentTimeMillis();
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
+                .setOutVariablesMode(ProjectEntry.OutVariablesModeEnum.EVERYONE)
+                .setName(projectName));
+
+        // ---
+
+        byte[] payload = archive(ProcessIT.class.getResource("example").toURI());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("org", orgName);
+        input.put("project", projectName);
+        input.put("archive", payload);
+        input.put("out", "myName,myBool");
+        StartProcessResponse spr = start(input);
+
+        ProcessEntry pe = waitForCompletion(new ProcessApi(getApiClient()), spr.getInstanceId());
+        Map<String, Object> out = (Map<String, Object>) pe.getMeta().get("out");
+        assertEquals(true, out.get("myBool"));
+    }
 
     @Test
     public void testReject() throws Exception {
@@ -40,6 +68,7 @@ public class OutVariablesProjectIT extends AbstractServerIT {
         String orgName = "Default";
         String projectName = "project_" + System.currentTimeMillis();
         projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
                 .setName(projectName));
 
         // ---
@@ -51,10 +80,40 @@ public class OutVariablesProjectIT extends AbstractServerIT {
             input.put("org", orgName);
             input.put("project", projectName);
             input.put("archive", payload);
-            input.put("out", "x,y,z");
+            input.put("out", "myName,myBool");
             start(input);
             fail("should fail");
         } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("The project is not accepting custom out variables"));
+        }
+    }
+
+    @Test
+    public void testRejectFromRequest() throws Exception {
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+
+        String orgName = "Default";
+        String projectName = "project_" + System.currentTimeMillis();
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
+                .setName(projectName));
+
+        // ---
+
+        byte[] payload = archive(ProcessIT.class.getResource("example").toURI());
+
+        try {
+            Map<String, Object> input = new HashMap<>();
+            input.put("org", orgName);
+            input.put("project", projectName);
+            input.put("archive", payload);
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("out", Collections.singletonList("myName"));
+            input.put("request", cfg);
+            start(input);
+            fail("should fail");
+        } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("The project is not accepting custom out variables"));
         }
     }
 }

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/example/_main.json
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/example/_main.json
@@ -1,6 +1,7 @@
 {
   "entryPoint": "main",
   "arguments": {
-    "myName": "world"
+    "myName": "world",
+    "myBool": true
   }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadBuilder.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadBuilder.java
@@ -233,6 +233,11 @@ public final class PayloadBuilder {
         }
 
         Set<String> s = payload.getHeader(Payload.OUT_EXPRESSIONS);
+
+        if (s == null) {
+            s = new HashSet<>(out.length);
+        }
+
         s.addAll(Arrays.asList(out));
         payload = payload.putHeader(Payload.OUT_EXPRESSIONS, s);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AttachmentStoringProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AttachmentStoringProcessor.java
@@ -26,6 +26,7 @@ import com.walmartlabs.concord.server.org.project.ProjectDao;
 import com.walmartlabs.concord.server.org.project.ProjectEntry;
 import com.walmartlabs.concord.server.process.Payload;
 import com.walmartlabs.concord.server.process.ProcessException;
+import com.walmartlabs.concord.server.process.pipelines.processors.cfg.ProcessConfigurationUtils;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -45,7 +46,7 @@ public class AttachmentStoringProcessor implements PayloadProcessor {
      * Attachments used by the server. They should not be added to the workspace.
      */
     private static final Set<String> SYSTEM_ATTACHMENT_NAMES = ImmutableSet.of(Payload.WORKSPACE_ARCHIVE.name(),
-            ConfigurationProcessor.REQUEST_ATTACHMENT_KEY.name());
+            ProcessConfigurationUtils.REQUEST_ATTACHMENT_KEY.name());
 
     private static final Pattern RAW_PAYLOAD_PATTERN = Pattern.compile("^(concord|flows)[/.](.*)(yml|yaml)$");
 


### PR DESCRIPTION
The existing tests were broken in the bad way (passed but for the wrong reasons).

The out-vars restrictions haven't been applying to `out` vars specified in a `request` file which is how the concord plugin passes them to child processes.