### PR TITLE
server: fix out vars processing and restrictions (alternative)

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesIT.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class OutVariablesIT extends AbstractServerIT {
 
     @Test
-    public void test() throws Exception {
+    public void testRequestParamAndPredefined() throws Exception {
         byte[] payload = archive(ProcessIT.class.getResource("out").toURI());
         String[] out = {"x", "y.some.boolean", "z"};
 
@@ -67,7 +67,6 @@ public class OutVariablesIT extends AbstractServerIT {
 
         assertEquals(123, data.get("x"));
     }
-
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> getOutVars(UUID instanceId) throws Exception {

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
@@ -21,17 +21,46 @@ package com.walmartlabs.concord.it.server;
  */
 
 import com.walmartlabs.concord.ApiException;
-import com.walmartlabs.concord.client.ProjectEntry;
-import com.walmartlabs.concord.client.ProjectsApi;
+import com.walmartlabs.concord.client.*;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
-import static org.junit.jupiter.api.Assertions.fail;
+import static com.walmartlabs.concord.it.common.ServerClient.assertLog;
+import static com.walmartlabs.concord.it.common.ServerClient.waitForCompletion;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OutVariablesProjectIT extends AbstractServerIT {
+
+    @Test
+    public void testOutVars() throws Exception {
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+
+        String orgName = "Default";
+        String projectName = "project_" + System.currentTimeMillis();
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
+                .setOutVariablesMode(ProjectEntry.OutVariablesModeEnum.EVERYONE)
+                .setName(projectName));
+
+        // ---
+
+        byte[] payload = archive(ProcessIT.class.getResource("example").toURI());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("org", orgName);
+        input.put("project", projectName);
+        input.put("archive", payload);
+        input.put("out", "myName,myBool");
+        StartProcessResponse spr = start(input);
+
+        ProcessEntry pe = waitForCompletion(new ProcessApi(getApiClient()), spr.getInstanceId());
+        Map<String, Object> out = (Map<String, Object>) pe.getMeta().get("out");
+        assertEquals(true, out.get("myBool"));
+    }
 
     @Test
     public void testReject() throws Exception {
@@ -40,6 +69,7 @@ public class OutVariablesProjectIT extends AbstractServerIT {
         String orgName = "Default";
         String projectName = "project_" + System.currentTimeMillis();
         projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
                 .setName(projectName));
 
         // ---
@@ -51,10 +81,45 @@ public class OutVariablesProjectIT extends AbstractServerIT {
             input.put("org", orgName);
             input.put("project", projectName);
             input.put("archive", payload);
-            input.put("out", "x,y,z");
+            input.put("out", "myName,myBool");
             start(input);
             fail("should fail");
         } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("The project is not accepting custom out variables"));
+        }
+    }
+
+    @Test
+    public void testRejectFromRequest() throws Exception {
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+
+        String orgName = "Default";
+        String projectName = "project_" + System.currentTimeMillis();
+        projectsApi.createOrUpdate(orgName, new ProjectEntry()
+                .setAcceptsRawPayload(true)
+                .setName(projectName));
+
+        // ---
+        byte[] payload = archive(ProcessIT.class.getResource("example").toURI());
+        try {
+            Map<String, Object> input = new HashMap<>();
+            input.put("org", orgName);
+            input.put("project", projectName);
+            input.put("archive", payload);
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("out", Collections.singletonList("myName"));
+            input.put("request", cfg);
+            start(input);
+
+            StartProcessResponse spr = start(input);
+            ProcessEntry pe = waitForCompletion(new ProcessApi(getApiClient()), spr.getInstanceId());
+
+            assertEquals(ProcessEntry.StatusEnum.FAILED, pe.getStatus());
+            byte[] ab = getLog(pe.getLogFileName());
+            assertLog(".*The project is not accepting custom out variables.*", ab);
+
+        } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("The project is not accepting custom out variables"));
         }
     }
 }

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/OutVariablesProjectIT.java
@@ -54,11 +54,15 @@ public class OutVariablesProjectIT extends AbstractServerIT {
         input.put("org", orgName);
         input.put("project", projectName);
         input.put("archive", payload);
-        input.put("out", "myName,myBool");
+        input.put("out", "myName");
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("out", Collections.singletonList("myBool"));
+        input.put("request", cfg);
         StartProcessResponse spr = start(input);
 
         ProcessEntry pe = waitForCompletion(new ProcessApi(getApiClient()), spr.getInstanceId());
         Map<String, Object> out = (Map<String, Object>) pe.getMeta().get("out");
+        assertEquals("world", out.get("myName"));
         assertEquals(true, out.get("myBool"));
     }
 

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/example/_main.json
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/example/_main.json
@@ -1,6 +1,7 @@
 {
   "entryPoint": "main",
   "arguments": {
-    "myName": "world"
+    "myName": "world",
+    "myBool": true
   }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadBuilder.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadBuilder.java
@@ -233,6 +233,11 @@ public final class PayloadBuilder {
         }
 
         Set<String> s = payload.getHeader(Payload.OUT_EXPRESSIONS);
+
+        if (s == null) {
+            s = new HashSet<>(out.length);
+        }
+
         s.addAll(Arrays.asList(out));
         payload = payload.putHeader(Payload.OUT_EXPRESSIONS, s);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/EnqueueProcessPipeline.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/EnqueueProcessPipeline.java
@@ -53,6 +53,7 @@ public class EnqueueProcessPipeline extends Pipeline {
                 ProcessDefinitionProcessor.class,
                 SessionTokenProcessor.class,
                 ConfigurationProcessor.class,
+                AssertOutVariablesProcessor.class,
                 ExclusiveGroupProcessor.class,
                 EntryPointProcessor.class,
                 TagsExtractingProcessor.class,

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AssertOutVariablesProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/AssertOutVariablesProcessor.java
@@ -32,6 +32,7 @@ import com.walmartlabs.concord.server.user.UserManager;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.core.Response.Status;
+import java.util.Set;
 import java.util.UUID;
 
 @Named
@@ -53,7 +54,9 @@ public class AssertOutVariablesProcessor implements PayloadProcessor {
 
     @Override
     public Payload process(Chain chain, Payload payload) {
-        if (payload.getHeader(Payload.OUT_EXPRESSIONS) == null) {
+        Set<String> outVars = payload.getHeader(Payload.OUT_EXPRESSIONS);
+
+        if (outVars == null || outVars.isEmpty()) {
             return chain.process(payload);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ConfigurationProcessor.java
@@ -42,10 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Responsible for preparing the process' {@code configuration} object.
@@ -89,6 +86,10 @@ public class ConfigurationProcessor implements PayloadProcessor {
         // determine the active profile names
         List<String> activeProfiles = ProcessConfigurationUtils.getActiveProfiles(payloadCfg, attachedCfg, workspaceCfg, projectCfg, orgCfg);
         payload = payload.putHeader(Payload.ACTIVE_PROFILES, activeProfiles);
+
+        // consolidate out variables
+        Set<String> outVars = new HashSet<>(ProcessConfigurationUtils.getOutVars(payloadCfg, attachedCfg, workspaceCfg));
+        payload = payload.putHeader(Payload.OUT_EXPRESSIONS, outVars);
 
         // merged profile data
         Map<String, Object> profileCfg = getProfileCfg(payload, activeProfiles);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/OutVariablesSettingProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/OutVariablesSettingProcessor.java
@@ -35,7 +35,7 @@ public class OutVariablesSettingProcessor implements PayloadProcessor {
     @Override
     public Payload process(Chain chain, Payload payload) {
         Set<String> outExpr = payload.getHeader(Payload.OUT_EXPRESSIONS);
-        if (outExpr == null) {
+        if (outExpr == null || outExpr.isEmpty()) {
             return chain.process(payload);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/cfg/ProcessConfigurationUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/cfg/ProcessConfigurationUtils.java
@@ -83,6 +83,28 @@ public final class ProcessConfigurationUtils {
         return DEFAULT_PROFILES;
     }
 
+    @SafeVarargs
+    public static Set<String> getOutVars(Map<String, Object> ... mm) {
+        for (Map<String, Object> m : mm) {
+            Object o = m.get(Constants.Request.OUT_EXPRESSIONS_KEY);
+
+            if (o == null) {
+                continue;
+            }
+
+            if (o instanceof List) {
+                return new HashSet<>(assertListType("out", removeNulls((List<String>) o), String.class));
+            } else if (o instanceof String) {
+                return new HashSet<>(Arrays.asList(((String) o).split(",")));
+            } else {
+                throw new IllegalArgumentException("Invalid '" + Constants.Request.OUT_EXPRESSIONS_KEY +
+                        "' value. Expected JSON array, got: " + o);
+            }
+        }
+
+        return Collections.emptySet();
+    }
+
     private static Map<String, Object> createProjectInfo(Payload payload, ProjectEntry projectEntry) {
         if (projectEntry == null) {
             Map<String, Object> m = new HashMap<>();

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/cfg/ProcessConfigurationUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/cfg/ProcessConfigurationUtils.java
@@ -84,7 +84,10 @@ public final class ProcessConfigurationUtils {
     }
 
     @SafeVarargs
+    @SuppressWarnings("unchecked")
     public static Set<String> getOutVars(Map<String, Object> ... mm) {
+        Set<String> outVars = new HashSet<>();
+
         for (Map<String, Object> m : mm) {
             Object o = m.get(Constants.Request.OUT_EXPRESSIONS_KEY);
 
@@ -93,16 +96,16 @@ public final class ProcessConfigurationUtils {
             }
 
             if (o instanceof List) {
-                return new HashSet<>(assertListType("out", removeNulls((List<String>) o), String.class));
+                outVars.addAll(assertListType("out", removeNulls((List<String>) o), String.class));
             } else if (o instanceof String) {
-                return new HashSet<>(Arrays.asList(((String) o).split(",")));
+                outVars.addAll(Arrays.asList(((String) o).split(",")));
             } else {
                 throw new IllegalArgumentException("Invalid '" + Constants.Request.OUT_EXPRESSIONS_KEY +
                         "' value. Expected JSON array, got: " + o);
             }
         }
 
-        return Collections.emptySet();
+        return outVars;
     }
 
     private static Map<String, Object> createProjectInfo(Payload payload, ProjectEntry projectEntry) {


### PR DESCRIPTION
Alternative to https://github.com/walmartlabs/concord/pull/608

Pros and cons...This approach doesn't double-parse the project. Instead it double-checks out variables.
1. Checks for out variables given in direct request parameters (e.g. `curl https://.../api/v1/process?out=myVarA,myVarB`) in the `NewProcessPipeline`
2. _After_ the project is parsed in `EnqueueProcessPipeline`, all the `out` variables are consolidated and the check is made again for out variables being added in a project that doesn't allow it.

The main difference is that the process entry gets created here and fails immediately if it fails on the second check. In https://github.com/walmartlabs/concord/pull/608, the process entry never gets created at all.