### PR TITLE
http-tasks: update log message to avoid issues with license-maven-plugin

### DIFF
--- a/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/SimpleHttpClient.java
+++ b/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/SimpleHttpClient.java
@@ -341,7 +341,7 @@ public class SimpleHttpClient {
             c.setProxy(proxyHost);
 
             if (cfg.getProxyUser() != null) {
-                log.info("Using proxy auth: {}:******", cfg.getProxyUser());
+                log.info("Using proxy auth: {}:***", cfg.getProxyUser());
 
                 CredentialsProvider proxyCredsProvider = new BasicCredentialsProvider();
                 proxyCredsProvider.setCredentials(


### PR DESCRIPTION
Fixes
```
[WARNING] skip failed file : Could not extract header on file /home/ibodrov/prj/walmartlabs/concord/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/SimpleHttpClient.java for reason Can only have one file header start tag : *****
org.codehaus.mojo.license.header.InvalideFileHeaderException: Could not extract header on file /home/ibodrov/prj/walmartlabs/concord/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/SimpleHttpClient.java for reason Can only have one fi
le header start tag : *****
```