### PR TITLE
server: runtime-v2 custom forms file field fix

### DIFF
--- a/it/console/src/test/resources/com/walmartlabs/concord/it/console/customForm/concord.yml
+++ b/it/console/src/test/resources/com/walmartlabs/concord/it/console/customForm/concord.yml
@@ -8,8 +8,10 @@ flows:
 
   - form: testForm
     values:
-      testValue: "${requestInfo.query.testValue}"
+      testValue: "${testValue}"
+  - log: "uploaded contents: ${resource.asJson(testForm.f)}"
 
 forms:
   testForm:
   - x: { type: "string?", allow: "${yamlObj.values}" }
+  - f: { type: "file" }

--- a/it/console/src/test/resources/com/walmartlabs/concord/it/console/customForm/forms/testForm/index.html
+++ b/it/console/src/test/resources/com/walmartlabs/concord/it/console/customForm/forms/testForm/index.html
@@ -7,9 +7,35 @@
 </head>
 <body>
 <div id="testValue"></div>
+<form id="theForm" method="post" enctype="multipart/form-data">
+    <input name="x" id="x" type="text"/>
+    <input name="f" id="f" type="file"/>
+    <button name="submit" id="submitButton" type="submit">Submit</button>
+</form>
 
 <script type="text/javascript">
     document.getElementById('testValue').innerHTML = data.values.testValue;
+
+    const populate = () => {
+      document.getElementById('theForm').action = data.submitUrl;
+      document.getElementById('x').value = "value_2";
+
+      // set file value
+      let contents = [JSON.stringify({ "hello":"world" })];
+      let contentsBlob = new Blob(contents, { type: 'application/octet-stream' });
+      let file = new File([contentsBlob],
+        'upload.json',
+        {
+          type:"application/octet-stream",
+          lastModified: new Date().getTime()
+        },
+        'utf-8');
+      let container = new DataTransfer();
+      container.items.add(file);
+      document.getElementById('f').files = container.files;
+    };
+
+    populate();
 </script>
 </body>
 </html>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/console/CustomFormServiceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/console/CustomFormServiceV2.java
@@ -199,7 +199,7 @@ public class CustomFormServiceV2 {
         try {
             Map<String, Object> m = new HashMap<>();
             try {
-                m = FormUtils.convert(new ExternalFileFormValidatorLocaleV2(processKey, formName, stateManager), form, data);
+                m = formService.convertData(processKey, formName, data);
 
                 FormSubmitResult r = formService.submit(processKey, formName, m);
                 if (r.isValid()) {


### PR DESCRIPTION
File upload in runtime-v2 custom forms is broken. The submitted data is being converted twice. the first conversion writes the uploaded file to a temp directory for upload to process_state (that's good). But the second run ends up overwriting the file with the filename as the contents.

Solution is to only convert once, which is what non-custom form service and runtime-v1 do.