### PR TITLE
project: prune Docker volumes before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           docker rm -f $(docker ps -aq) || true
           docker system prune -af || true
           docker image prune -af || true
+          docker volume prune -f || true
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
I always forget that docker system prune doesn't remove old volumes.