### PR TITLE
concord-server: remove log call for github event in repository refresh flow

### DIFF
--- a/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
+++ b/server/impl/src/main/resources/com/walmartlabs/concord/server/org/triggers/concord.yml
@@ -3,7 +3,6 @@ configuration:
 
 flows:
   onChange:
-  - log: "Refreshing repository... ${event}"
   - name: "Filter to enabled repositories"
     expr: ${event.repositoryInfo.stream().filter(r -> r.enabled).toList()}
     out: repoIdsToRefresh


### PR DESCRIPTION
Remove redundant info that adds up to a whole lot of logging data in a busy concord instance. Same info is still available in the UI on the process status tab.