### PR TITLE
concord-console: fix for change visibility and renaming of secrets from UI

### DIFF
--- a/console2/src/api/org/secret/index.ts
+++ b/console2/src/api/org/secret/index.ts
@@ -153,42 +153,32 @@ export const deleteSecret = (
 
 export const renameSecret = (
     orgName: ConcordKey,
-    secretId: ConcordId,
-    secretName: ConcordKey
+    secretName: ConcordKey,
+    newSecretName: ConcordKey
 ): Promise<GenericOperationResult> => {
+    const data = new FormData();
+    data.append('name', newSecretName);
     const opts = {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            id: secretId,
-            name: secretName
-        })
+        body: data
     };
 
-    // TODO placeholder name as a workaround for swagger-maven-plugin issue
-    return fetchJson(`/api/v1/org/${orgName}/secret/todo`, opts);
+    return fetchJson(`/api/v2/org/${orgName}/secret/${secretName}`, opts);
 };
 
 export const updateSecretVisibility = (
     orgName: ConcordKey,
-    secretId: ConcordId,
+    secretName: ConcordKey,
     visibility: SecretVisibility
 ): Promise<GenericOperationResult> => {
+    const data = new FormData();
+    data.append('visibility', visibility);
     const opts = {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            id: secretId,
-            visibility
-        })
+        body: data
     };
-
-    // TODO placeholder name as a workaround for swagger-maven-plugin issue
-    return fetchJson(`/api/v1/org/${orgName}/secret/todo`, opts);
+    
+    return fetchJson(`/api/v2/org/${orgName}/secret/${secretName}`, opts);
 };
 
 export const updateSecretProject = (

--- a/console2/src/components/organisms/SecretActivity/index.tsx
+++ b/console2/src/components/organisms/SecretActivity/index.tsx
@@ -161,6 +161,7 @@ class SecretActivity extends React.PureComponent<Props> {
                     <SecretVisibilityActivity
                         orgName={data.orgName}
                         secretId={data.id}
+                        secretName={data.name}
                         visibility={data.visibility}
                     />
                 </Segment>

--- a/console2/src/components/organisms/SecretRenameActivity/index.tsx
+++ b/console2/src/components/organisms/SecretRenameActivity/index.tsx
@@ -40,7 +40,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-    rename: (orgName: ConcordKey, secretId: ConcordId, secretName: ConcordKey) => void;
+    rename: (orgName: ConcordKey, secretName: ConcordKey, newSecretName: ConcordKey) => void;
 }
 
 type Props = ExternalProps & StateProps & DispatchProps;
@@ -55,7 +55,7 @@ class SecretRenameActivity extends React.PureComponent<Props> {
                 <EntityRenameForm
                     originalName={secretName}
                     submitting={renaming}
-                    onSubmit={(values) => rename(orgName, secretId, values.name)}
+                    onSubmit={(values) => rename(orgName, secretName, values.name)}
                     inputPlaceholder="Secret name"
                     confirmationHeader="Rename the secret?"
                     confirmationContent="Are you sure you want to rename the secret?"
@@ -73,8 +73,8 @@ const mapStateToProps = ({ secrets }: { secrets: State }): StateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchProps => ({
-    rename: (orgName, secretId, secretName) =>
-        dispatch(actions.renameSecret(orgName, secretId, secretName))
+    rename: (orgName, secretName, newSecretName) =>
+        dispatch(actions.renameSecret(orgName, secretName, newSecretName))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SecretRenameActivity);

--- a/console2/src/components/organisms/SecretRenameActivity/index.tsx
+++ b/console2/src/components/organisms/SecretRenameActivity/index.tsx
@@ -47,7 +47,7 @@ type Props = ExternalProps & StateProps & DispatchProps;
 
 class SecretRenameActivity extends React.PureComponent<Props> {
     render() {
-        const { error, renaming, orgName, secretId, secretName, rename } = this.props;
+        const { error, renaming, orgName, secretName, rename } = this.props;
 
         return (
             <>

--- a/console2/src/components/organisms/SecretVisibilityActivity/index.tsx
+++ b/console2/src/components/organisms/SecretVisibilityActivity/index.tsx
@@ -30,6 +30,7 @@ import { RequestErrorMessage } from '../../molecules';
 interface ExternalProps {
     orgName: ConcordKey;
     secretId: ConcordId;
+    secretName: ConcordKey;
     visibility: SecretVisibility;
 }
 
@@ -39,7 +40,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-    update: (orgName: ConcordKey, secretId: ConcordId, visibility: SecretVisibility) => void;
+    update: (orgName: ConcordKey, secretId: ConcordId, secretName: ConcordKey, visibility: SecretVisibility) => void;
 }
 
 type Props = ExternalProps & StateProps & DispatchProps;
@@ -50,8 +51,8 @@ class ProjectRenameActivity extends React.PureComponent<Props> {
             return;
         }
 
-        const { update, orgName, secretId } = this.props;
-        update(orgName, secretId, SecretVisibility[value]);
+        const { update, orgName, secretName, secretId } = this.props;
+        update(orgName, secretId, secretName, SecretVisibility[value]);
     }
 
     render() {
@@ -92,8 +93,8 @@ const mapStateToProps = ({ secrets }: { secrets: State }): StateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchProps => ({
-    update: (orgName, secretId, visibility) =>
-        dispatch(actions.updateSecretVisibility(orgName, secretId, visibility))
+    update: (orgName, secretId, secretName, visibility) =>
+        dispatch(actions.updateSecretVisibility(orgName, secretId, secretName, visibility))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectRenameActivity);

--- a/console2/src/components/organisms/SecretVisibilityActivity/index.tsx
+++ b/console2/src/components/organisms/SecretVisibilityActivity/index.tsx
@@ -25,13 +25,16 @@ import { Form } from 'semantic-ui-react';
 import { ConcordId, ConcordKey, RequestError } from '../../../api/common';
 import { SecretVisibility } from '../../../api/org/secret';
 import { actions, State } from '../../../state/data/secrets';
-import { RequestErrorMessage } from '../../molecules';
+import { ButtonWithConfirmation, RequestErrorMessage } from '../../molecules';
+
+
 
 interface ExternalProps {
     orgName: ConcordKey;
     secretId: ConcordId;
     secretName: ConcordKey;
     visibility: SecretVisibility;
+    renderOverride?: React.ReactNode;
 }
 
 interface StateProps {
@@ -43,20 +46,33 @@ interface DispatchProps {
     update: (orgName: ConcordKey, secretId: ConcordId, secretName: ConcordKey, visibility: SecretVisibility) => void;
 }
 
+interface OwnState { 
+    newVisibility: SecretVisibility;
+}
+
 type Props = ExternalProps & StateProps & DispatchProps;
 
-class ProjectRenameActivity extends React.PureComponent<Props> {
+class ProjectRenameActivity extends React.PureComponent<Props, OwnState> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { newVisibility: this.props.visibility };
+    }
+    
     onChange(value: string | undefined) {
         if (!value) {
             return;
         }
-
-        const { update, orgName, secretName, secretId } = this.props;
-        update(orgName, secretId, secretName, SecretVisibility[value]);
+        
+        this.setState({ newVisibility: SecretVisibility[value] });
     }
-
+    
+    changeVisibility() {
+        const { update, orgName, secretName, secretId } = this.props;
+        update(orgName, secretId, secretName, this.state.newVisibility);
+    }
+    
     render() {
-        const { error, updating, visibility } = this.props;
+        const { error, updating, visibility, renderOverride } = this.props;
 
         return (
             <>
@@ -79,6 +95,16 @@ class ProjectRenameActivity extends React.PureComponent<Props> {
                             ]}
                             defaultValue={visibility}
                             onChange={(ev, data) => this.onChange(data.value as string)}
+                        />
+                        <ButtonWithConfirmation
+                            renderOverride={renderOverride}
+                            floated={'right'}
+                            disabled={visibility === this.state.newVisibility}
+                            content="Change"
+                            loading={updating}
+                            confirmationHeader="Change the visibility?"
+                            confirmationContent={`Are you sure you want to change the visibility to ${this.state.newVisibility}`}
+                            onConfirm={() => this.changeVisibility()}
                         />
                     </Form.Group>
                 </Form>

--- a/console2/src/state/data/secrets/index.ts
+++ b/console2/src/state/data/secrets/index.ts
@@ -416,6 +416,8 @@ function* onUpdateVisibility({ orgName, secretName, secretId, visibility }: Upda
             secretId,
             visibility
         });
+
+        yield put(pushHistory(`/org/${orgName}/secret/${secretName}`));
     } catch (e) {
         yield handleErrors(actionTypes.UPDATE_SECRET_VISIBLITY_RESPONSE, e);
     }

--- a/console2/src/state/data/secrets/index.ts
+++ b/console2/src/state/data/secrets/index.ts
@@ -133,13 +133,13 @@ export const actions = {
 
     renameSecret: (
         orgName: ConcordKey,
-        secretId: ConcordId,
-        secretName: ConcordKey
+        secretName: ConcordKey,
+        newSecretName: ConcordKey
     ): RenameSecretRequest => ({
         type: actionTypes.RENAME_SECRET_REQUEST,
         orgName,
-        secretId,
-        secretName
+        secretName,
+        newSecretName
     }),
 
     updateSecretVisibility: (
@@ -392,13 +392,13 @@ function* onDelete({ orgName, secretName }: DeleteSecretRequest) {
     }
 }
 
-function* onRename({ orgName, secretId, secretName }: RenameSecretRequest) {
+function* onRename({ orgName, secretName, newSecretName }: RenameSecretRequest) {
     try {
         const response: GenericOperationResult = yield call(
             apiRenameSecret,
             orgName,
-            secretId,
-            secretName
+            secretName,
+            newSecretName
         );
         yield put(genericResult(actionTypes.RENAME_SECRET_RESPONSE, response));
 

--- a/console2/src/state/data/secrets/index.ts
+++ b/console2/src/state/data/secrets/index.ts
@@ -145,11 +145,13 @@ export const actions = {
     updateSecretVisibility: (
         orgName: ConcordKey,
         secretId: ConcordId,
+        secretName: ConcordKey,
         visibility: SecretVisibility
     ): UpdateSecretVisibilityRequest => ({
         type: actionTypes.UPDATE_SECRET_VISIBLITY_REQUEST,
         orgName,
         secretId,
+        secretName,
         visibility
     }),
 
@@ -406,9 +408,9 @@ function* onRename({ orgName, secretId, secretName }: RenameSecretRequest) {
     }
 }
 
-function* onUpdateVisibility({ orgName, secretId, visibility }: UpdateSecretVisibilityRequest) {
+function* onUpdateVisibility({ orgName, secretName, secretId, visibility }: UpdateSecretVisibilityRequest) {
     try {
-        yield call(apiUpdateSecretVisibility, orgName, secretId, visibility);
+        yield call(apiUpdateSecretVisibility, orgName, secretName, visibility);
         yield put({
             type: actionTypes.UPDATE_SECRET_VISIBLITY_RESPONSE,
             secretId,

--- a/console2/src/state/data/secrets/types.ts
+++ b/console2/src/state/data/secrets/types.ts
@@ -66,8 +66,8 @@ export interface DeleteSecretRequest extends Action {
 
 export interface RenameSecretRequest extends Action {
     orgName: ConcordKey;
-    secretId: ConcordId;
     secretName: ConcordKey;
+    newSecretName: ConcordKey;
 }
 
 export interface UpdateSecretVisibilityRequest extends Action {

--- a/console2/src/state/data/secrets/types.ts
+++ b/console2/src/state/data/secrets/types.ts
@@ -73,6 +73,7 @@ export interface RenameSecretRequest extends Action {
 export interface UpdateSecretVisibilityRequest extends Action {
     orgName: ConcordKey;
     secretId: ConcordId;
+    secretName: ConcordKey;
     visibility: SecretVisibility;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70886332/184356612-e307f26a-08f2-498f-911f-2ad0e9f6716f.png)
![image](https://user-images.githubusercontent.com/70886332/184356640-ff7ea579-024c-4a06-b661-4caff905c24b.png)

after fix:
![image](https://user-images.githubusercontent.com/70886332/184357380-42b42725-b9ac-4741-b588-c18c6e439914.png)
