### PR TITLE
concord-cli: ensure absolute target dir

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
@@ -59,6 +59,8 @@ public class Lint implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        targetDir = targetDir.normalize().toAbsolutePath();
+
         if (!Files.isDirectory(targetDir)) {
             throw new IllegalArgumentException("Not a directory: " + targetDir);
         }

--- a/cli/src/test/java/com/walmartlabs/concord/cli/AbstractTest.java
+++ b/cli/src/test/java/com/walmartlabs/concord/cli/AbstractTest.java
@@ -1,0 +1,70 @@
+package com.walmartlabs.concord.cli;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public abstract class AbstractTest {
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+    @BeforeEach
+    public void setUpStreams() {
+        out.reset();
+        err.reset();
+        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(err));
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    protected void assertLog(String pattern) {
+        String outStr = out.toString();
+        if (grep(outStr, pattern) != 1) {
+            fail("Expected a single log entry: '" + pattern + "', got: \n" + outStr);
+        }
+    }
+
+    private static int grep(String str, String pattern) {
+        int cnt = 0;
+
+        String[] lines = str.split("\\r?\\n");
+        for (String line : lines) {
+            if (line.matches(pattern)) {
+                cnt++;
+            }
+        }
+
+        return cnt;
+    }
+}

--- a/cli/src/test/java/com/walmartlabs/concord/cli/LintTest.java
+++ b/cli/src/test/java/com/walmartlabs/concord/cli/LintTest.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.cli;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2022 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,30 +29,28 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class RunTest extends AbstractTest {
+class LintTest extends AbstractTest {
 
     @Test
-    void runTest() throws Exception {
-        int exitCode = run("simple", Collections.singletonMap("name", "Concord"));
+    void lintV1Test() throws Exception {
+        int exitCode = lint("lintV1");
         assertEquals(0, exitCode);
-        assertLog(".*Hello, Concord.*");
+        assertLog(".*flows: 2.*");
     }
 
     @Test
-    void testResourceTask() throws Exception {
-        int exitCode = run("resourceTask", Collections.emptyMap());
+    void lintV2Test() throws Exception {
+        int exitCode = lint("lintV2");
         assertEquals(0, exitCode);
-        assertLog(".*\"k\" : \"v\".*");
+        assertLog(".*flows: 2.*");
     }
 
-    private static int run(String payload, Map<String, Object> extraVars) throws Exception {
-        URI uri = RunTest.class.getResource(payload).toURI();
+    private static int lint(String payload) throws Exception {
+        URI uri = LintTest.class.getResource(payload).toURI();
         Path source = Paths.get(uri);
 
         try (TemporaryPath dst = IOUtils.tempDir("cli-tests")) {
@@ -62,12 +60,12 @@ class RunTest extends AbstractTest {
             CommandLine cmd = new CommandLine(app);
 
             List<String> args = new ArrayList<>();
-            args.add("run");
-            for (Map.Entry<String, Object> e : extraVars.entrySet()) {
-                args.add("-e");
-                args.add(e.getKey() + "=" + e.getValue());
-            }
-            args.add(dst.path().toString());
+            args.add("lint");
+
+            Path pwd = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+            Path relative = pwd.relativize(dst.path());
+
+            args.add(relative.toString());
 
             return cmd.execute(args.toArray(new String[0]));
         }

--- a/cli/src/test/resources/com/walmartlabs/concord/cli/lintV1/concord.yml
+++ b/cli/src/test/resources/com/walmartlabs/concord/cli/lintV1/concord.yml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - log: "Hello, world!"

--- a/cli/src/test/resources/com/walmartlabs/concord/cli/lintV1/concord/extra.concord.yml
+++ b/cli/src/test/resources/com/walmartlabs/concord/cli/lintV1/concord/extra.concord.yml
@@ -1,0 +1,3 @@
+flows:
+  extraFlow:
+    - log: "extra"

--- a/cli/src/test/resources/com/walmartlabs/concord/cli/lintV2/concord.yml
+++ b/cli/src/test/resources/com/walmartlabs/concord/cli/lintV2/concord.yml
@@ -1,0 +1,6 @@
+configuration:
+  runtime: concord-v2
+
+flows:
+  default:
+    - log: "Hello, world!"

--- a/cli/src/test/resources/com/walmartlabs/concord/cli/lintV2/concord/extra.concord.yml
+++ b/cli/src/test/resources/com/walmartlabs/concord/cli/lintV2/concord/extra.concord.yml
@@ -1,0 +1,3 @@
+flows:
+  extraFlow:
+    - log: "extra"


### PR DESCRIPTION
Concord's project loader normalizes the resource glob with an absolute path.

https://github.com/walmartlabs/concord/blob/66fc4e40af7daf4ce61fd004906eba183d7c42d1/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ProjectLoaderV2.java#L209

However, the CLI linter currently treats the command-line supplied `targetDir` as-is which breaks the resource filtering inside the project loader.