### PR TITLE
concord-server: termintate process wait watchdog loop on batches less than fetch limit

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
@@ -35,7 +35,10 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.ScheduledTask;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import org.immutables.value.Value;
-import org.jooq.*;
+import org.jooq.Configuration;
+import org.jooq.JSONB;
+import org.jooq.Record5;
+import org.jooq.SelectConditionStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +84,7 @@ public class ProcessWaitWatchdog implements ScheduledTask {
         this.processWaitManager = processWaitManager;
         this.processManager = processManager;
         this.payloadManager = payloadManager;
-        this.processWaitHandlers = new HashMap<>();
+        this.processWaitHandlers = new EnumMap<>(WaitType.class);
 
         handlers.forEach(h -> this.processWaitHandlers.put(h.getType(), h));
         this.waitItemsHistogram = metricRegistry.histogram("process-wait-watchdog-items");
@@ -107,6 +110,10 @@ public class ProcessWaitWatchdog implements ScheduledTask {
             for (WaitingProcess p : processes) {
                 processWaits(p);
                 lastId = p.id();
+            }
+
+            if (processes.size() < cfg.getPollLimit()) {
+                return;
             }
         }
     }


### PR DESCRIPTION
In a busy environment, it's possible for wait conditions to come in faster than they can be dispatched in a loop. This keeps the loop going with a small (maybe just one) element in each loop. Then that keeps processes (checked in an earlier iteration) that have been ready to resume for a while to be ignored until the `processWaits()` method gets lucky and returns nothing.