### PR TITLE
concord-server: @Inject refactoring (part 1)

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerCommandBuilder.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerCommandBuilder.java
@@ -104,8 +104,10 @@ public class RunnerCommandBuilder {
 
         // speeds up the start, we don't care much about all potential optimizations done by HotSpot
         l.add("-client");
-        // don't do bytecode verification
-        l.add("-noverify");
+        if (majorJavaVersion < 13) {
+            // don't do bytecode verification
+            l.add("-noverify");
+        }
         // enable support for calling vararg methods in JUEL
         l.add("-Djavax.el.varArgs=true");
         // avoid blocking on crypto

--- a/server/dist/src/main/java/com/walmartlabs/concord/server/dist/Main.java
+++ b/server/dist/src/main/java/com/walmartlabs/concord/server/dist/Main.java
@@ -37,7 +37,10 @@ public class Main {
         log.info("Starting Concord Server ({}, {}, {})...", v.getVersion(), v.getCommitId(), v.getEnv());
 
         long t1 = System.currentTimeMillis();
-        ConcordServer.start();
+
+        ConcordServer.withAutoWiring()
+                .start();
+
         long t2 = System.currentTimeMillis();
         log.info("main -> started in {}ms", (t2 - t1));
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
@@ -22,16 +22,21 @@ package com.walmartlabs.concord.server;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 import com.walmartlabs.concord.server.boot.BackgroundTasks;
 import com.walmartlabs.concord.server.boot.HttpServer;
 import org.eclipse.sisu.space.BeanScanning;
 import org.eclipse.sisu.space.SpaceModule;
 import org.eclipse.sisu.space.URLClassSpace;
 import org.eclipse.sisu.wire.WireModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
 public final class ConcordServer {
+
+    private static final Logger log = LoggerFactory.getLogger(ConcordServer.class);
 
     @Inject
     private Injector injector;
@@ -42,17 +47,32 @@ public final class ConcordServer {
     @Inject
     private HttpServer server;
 
-    public static ConcordServer start() throws Exception {
+    /**
+     * Start ConcordServer by scanning the local class path for the implementations of
+     * {@link HttpServer} or {@link BackgroundTasks}.
+     */
+    public static ConcordServer withAutoWiring() throws Exception {
         ClassLoader cl = ConcordServer.class.getClassLoader();
-        Injector injector = Guice.createInjector(new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
+        return withModules(new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
+    }
+
+    /**
+     * Start ConcordServer using the provided modules.
+     */
+    public static ConcordServer withModules(Module... modules) throws Exception {
+        Injector injector = Guice.createInjector(modules);
 
         ConcordServer instance = new ConcordServer();
         injector.injectMembers(instance);
 
-        instance.tasks.start();
-        instance.server.start();
-
+        log.info("start -> starting {} task(s)", instance.tasks.count());
         return instance;
+    }
+
+    public synchronized ConcordServer start() throws Exception {
+        tasks.start();
+        server.start();
+        return this;
     }
 
     public synchronized void stop() throws Exception {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/Listeners.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/Listeners.java
@@ -34,8 +34,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.*;
 
 @Named
@@ -48,18 +48,18 @@ public class Listeners {
 
     private static final Duration MAX_LISTENER_TIME = Duration.ofSeconds(3);
 
-    private final Collection<ProcessEventListener> eventListeners;
-    private final Collection<ProcessLogListener> logListeners;
-    private final Collection<AuditLogListener> auditLogListeners;
+    private final Set<ProcessEventListener> eventListeners;
+    private final Set<ProcessLogListener> logListeners;
+    private final Set<AuditLogListener> auditLogListeners;
 
     private final ForkJoinPool eventListenerPool;
     private final ForkJoinPool logListenerPool;
     private final ForkJoinPool auditLogListenerPool;
 
     @Inject
-    public Listeners(Collection<ProcessEventListener> eventListeners,
-                     Collection<ProcessLogListener> logListeners,
-                     Collection<AuditLogListener> auditLogListeners) {
+    public Listeners(Set<ProcessEventListener> eventListeners,
+                     Set<ProcessLogListener> logListeners,
+                     Set<AuditLogListener> auditLogListeners) {
 
         this.eventListeners = eventListeners;
         eventListeners.forEach(l -> log.info("Using process event listener: {}", l));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/agent/AgentCommandWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/agent/AgentCommandWatchdog.java
@@ -36,7 +36,7 @@ import java.time.OffsetDateTime;
 
 import static com.walmartlabs.concord.server.jooq.tables.AgentCommands.AGENT_COMMANDS;
 
-@Named("agent-command-watchdog")
+@Named
 @Singleton
 public class AgentCommandWatchdog implements ScheduledTask {
 
@@ -48,6 +48,11 @@ public class AgentCommandWatchdog implements ScheduledTask {
     public AgentCommandWatchdog(AgentConfiguration cfg, WatchdogDao watchdogDao) {
         this.cfg = cfg;
         this.watchdogDao = watchdogDao;
+    }
+
+    @Override
+    public String getId() {
+        return "agent-command-watchdog";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogCleaner.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/audit/AuditLogCleaner.java
@@ -38,7 +38,7 @@ import java.time.OffsetDateTime;
 
 import static com.walmartlabs.concord.server.jooq.tables.AuditLog.AUDIT_LOG;
 
-@Named("audit-log-cleaner")
+@Named
 @Singleton
 public class AuditLogCleaner implements ScheduledTask {
 
@@ -51,6 +51,11 @@ public class AuditLogCleaner implements ScheduledTask {
     public AuditLogCleaner(AuditConfiguration cfg, CleanerDao cleanerDao) {
         this.cfg = cfg;
         this.cleanerDao = cleanerDao;
+    }
+
+    @Override
+    public String getId() {
+        return "audit-log-cleaner";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/BackgroundTasks.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/BackgroundTasks.java
@@ -45,4 +45,8 @@ public class BackgroundTasks {
     public synchronized void stop() {
         tasks.forEach(BackgroundTask::stop);
     }
+
+    public int count() {
+        return tasks.size();
+    }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggerScheduler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggerScheduler.java
@@ -53,7 +53,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-@Named("trigger-scheduler")
+@Named
 @Singleton
 public class TriggerScheduler implements ScheduledTask {
 
@@ -97,6 +97,11 @@ public class TriggerScheduler implements ScheduledTask {
         this.processManager = processManager;
         this.processSecurityContext = processSecurityContext;
         this.triggerCfg = triggerCfg;
+    }
+
+    @Override
+    public String getId() {
+        return "trigger-scheduler";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessCleaner.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessCleaner.java
@@ -42,7 +42,7 @@ import static com.walmartlabs.concord.server.jooq.tables.ProcessEvents.PROCESS_E
 import static com.walmartlabs.concord.server.jooq.tables.ProcessQueue.PROCESS_QUEUE;
 import static com.walmartlabs.concord.server.jooq.tables.ProcessState.PROCESS_STATE;
 
-@Named("process-cleaner")
+@Named
 @Singleton
 public class ProcessCleaner implements ScheduledTask {
 
@@ -61,6 +61,11 @@ public class ProcessCleaner implements ScheduledTask {
     public ProcessCleaner(ProcessConfiguration cfg, CleanerDao cleanerDao) {
         this.cfg = cfg;
         this.cleanerDao = cleanerDao;
+    }
+
+    @Override
+    public String getId() {
+        return "process-cleaner";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/locks/ProcessLocksWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/locks/ProcessLocksWatchdog.java
@@ -45,8 +45,7 @@ import static com.walmartlabs.concord.server.jooq.tables.ProcessQueue.PROCESS_QU
  * Takes care of processes dead process locks.
  * E.g. removes locks for finished processes.
  */
-@Named("process-locks-watchdog")
-@Singleton
+@Named
 public class ProcessLocksWatchdog implements ScheduledTask {
 
     private static final Logger log = LoggerFactory.getLogger(ProcessLocksWatchdog.class);
@@ -56,6 +55,11 @@ public class ProcessLocksWatchdog implements ScheduledTask {
     @Inject
     public ProcessLocksWatchdog(WatchdogDao dao) {
         this.dao = dao;
+    }
+
+    @Override
+    public String getId() {
+        return "process-locks-watchdog";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
@@ -55,7 +55,7 @@ import static com.walmartlabs.concord.db.PgUtils.interval;
 import static com.walmartlabs.concord.server.jooq.tables.ProcessQueue.PROCESS_QUEUE;
 import static org.jooq.impl.DSL.*;
 
-@Named("process-queue-watchdog")
+@Named
 @Singleton
 public class ProcessQueueWatchdog implements ScheduledTask {
 
@@ -139,6 +139,11 @@ public class ProcessQueueWatchdog implements ScheduledTask {
         this.processManager = processManager;
         this.queueManager = queueManager;
         this.processSecurityContext = processSecurityContext;
+    }
+
+    @Override
+    public String getId() {
+        return "process-queue-watchdog";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
@@ -55,7 +55,7 @@ import static com.walmartlabs.concord.server.jooq.Tables.PROCESS_WAIT_CONDITIONS
  * Takes care of processes with wait conditions.
  * E.g. waiting for other processes to finish, locking, etc.
  */
-@Named("process-wait-watchdog")
+@Named
 @Singleton
 public class ProcessWaitWatchdog implements ScheduledTask {
 
@@ -88,6 +88,11 @@ public class ProcessWaitWatchdog implements ScheduledTask {
 
         handlers.forEach(h -> this.processWaitHandlers.put(h.getType(), h));
         this.waitItemsHistogram = metricRegistry.histogram("process-wait-watchdog-items");
+    }
+
+    @Override
+    public String getId() {
+        return "process-wait-watchdog";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyCleaner.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyCleaner.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import static com.walmartlabs.concord.server.jooq.Tables.API_KEYS;
 import static org.jooq.impl.DSL.currentOffsetDateTime;
 
-@Named("api-key-cleanup")
+@Named
 @Singleton
 public class ApiKeyCleaner implements ScheduledTask {
 
@@ -51,6 +51,11 @@ public class ApiKeyCleaner implements ScheduledTask {
     public ApiKeyCleaner(ApiKeyConfiguration cfg, CleanerDao cleanerDao) {
         this.enabled = cfg.isExpirationEnabled();
         this.cleanerDao = cleanerDao;
+    }
+
+    @Override
+    public String getId() {
+        return "api-key-cleanup";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyExpirationNotifier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyExpirationNotifier.java
@@ -49,7 +49,7 @@ import static com.walmartlabs.concord.server.jooq.Tables.API_KEYS;
 import static org.jooq.impl.DSL.currentOffsetDateTime;
 import static org.jooq.impl.DSL.trunc;
 
-@Named("api-key-expiration-notifier")
+@Named
 @Singleton
 public class ApiKeyExpirationNotifier implements ScheduledTask {
 
@@ -74,6 +74,11 @@ public class ApiKeyExpirationNotifier implements ScheduledTask {
         this.dao = dao;
         this.userDao = userDao;
         this.notifier = notifier;
+    }
+
+    @Override
+    public String getId() {
+        return "api-key-expiration-notifier";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/UserLdapGroupSynchronizer.java
@@ -49,7 +49,7 @@ import static com.walmartlabs.concord.server.jooq.Tables.USERS;
  * Responsible for AD/LDAP group synchronization and enabling/disabling users
  * based on whether they have active groups or not.
  */
-@Named("user-ldap-group-sync")
+@Named
 @Singleton
 public class UserLdapGroupSynchronizer implements ScheduledTask {
 
@@ -72,6 +72,11 @@ public class UserLdapGroupSynchronizer implements ScheduledTask {
         this.ldapManager = ldapManager;
         this.userManager = userManager;
         this.ldapGroupsDao = ldapGroupsDao;
+    }
+
+    @Override
+    public String getId() {
+        return "user-ldap-group-sync";
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/task/SchedulerDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/task/SchedulerDao.java
@@ -36,8 +36,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -109,17 +109,17 @@ public final class SchedulerDao extends AbstractDao {
         taskFinished(tx, taskId, TaskStatusType.STALLED, null);
     }
 
-    public void updateTaskIntervals(Map<String, ScheduledTask> tasks) {
+    public void updateTaskIntervals(Collection<ScheduledTask> tasks) {
         tx(tx -> {
-            for (Map.Entry<String, ScheduledTask> e : tasks.entrySet()) {
-                ScheduledTask task = e.getValue();
+            for (ScheduledTask task : tasks) {
+                String taskId = task.getId();
 
                 if (task.getIntervalInSec() <= 0) {
-                    log.warn("{} has period <= 0, the task will be disabled", e.getKey());
+                    log.warn("{} has period <= 0, the task will be disabled", taskId);
                 }
 
                 tx.insertInto(TASKS, TASKS.TASK_ID, TASKS.TASK_INTERVAL)
-                        .values(e.getKey(), task.getIntervalInSec())
+                        .values(taskId, task.getIntervalInSec())
                         .onDuplicateKeyUpdate().set(TASKS.TASK_INTERVAL, task.getIntervalInSec())
                         .execute();
             }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/task/TaskScheduler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/task/TaskScheduler.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static com.walmartlabs.concord.db.PgUtils.interval;
+import static java.util.stream.Collectors.toMap;
 import static org.jooq.impl.DSL.currentOffsetDateTime;
 
 @Named
@@ -59,12 +60,12 @@ public class TaskScheduler extends PeriodicTask {
     private long lasStalledCheckDate;
 
     @Inject
-    public TaskScheduler(Map<String, ScheduledTask> tasks, SchedulerDao dao) {
+    public TaskScheduler(Set<ScheduledTask> tasks, SchedulerDao dao) {
         super(POLL_INTERVAL, ERROR_DELAY);
 
         this.executor = Executors.newCachedThreadPool();
         this.dao = dao;
-        this.tasks = tasks;
+        this.tasks = tasks.stream().collect(toMap(ScheduledTask::getId, t -> t));
 
         this.dao.updateTaskIntervals(tasks);
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserManager.java
@@ -49,7 +49,7 @@ public class UserManager {
     private static final String SSO_REALM_NAME = "sso";
 
     @Inject
-    public UserManager(UserDao userDao, TeamDao teamDao, AuditLog auditLog, List<UserInfoProvider> providers) {
+    public UserManager(UserDao userDao, TeamDao teamDao, AuditLog auditLog, Set<UserInfoProvider> providers) {
         this.userDao = userDao;
         this.teamDao = teamDao;
         this.auditLog = auditLog;
@@ -97,7 +97,7 @@ public class UserManager {
                 return result;
             }
         }
-        
+
         return Optional.of(create(username, userDomain, displayName, email, type, roles));
     }
 
@@ -225,26 +225,26 @@ public class UserManager {
         }
         return p;
     }
-    
-    private UserType assertUserType(String username, String domain, UserType type){
+
+    private UserType assertUserType(String username, String domain, UserType type) {
         /* Override LDAP to SSO type if current user loggedIn via SSO */
         /*
         1. LoggedIn via internal user realm -> domain = null
         2. LoggedIn via ldap realm -> realm != SSO_REALM_NAME
         3. LoggedIn via SSO -> @return UserType.SSO
          */
-        if (username != null && domain != null){
+        if (username != null && domain != null) {
             UserPrincipal u = UserPrincipal.getCurrent();
-            if (u != null && u.getUsername().equalsIgnoreCase(username) && u.getDomain().equalsIgnoreCase(domain)){
-              return assertSsoUserType(u, type);
+            if (u != null && u.getUsername().equalsIgnoreCase(username) && u.getDomain().equalsIgnoreCase(domain)) {
+                return assertSsoUserType(u, type);
             }
         }
         return type;
     }
 
-    private UserType assertSsoUserType(UserPrincipal u, UserType type){
-        if (u.getRealm().equals(SSO_REALM_NAME)){
-            if (userInfoProviders.get(UserType.SSO) != null){
+    private UserType assertSsoUserType(UserPrincipal u, UserType type) {
+        if (u.getRealm().equals(SSO_REALM_NAME)) {
+            if (userInfoProviders.get(UserType.SSO) != null) {
                 return UserType.SSO;
             }
         }

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/ListenersTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/ListenersTest.java
@@ -35,13 +35,13 @@ public class ListenersTest {
     @Test
     public void test() {
         List<ProcessEvent> receivedEvents = new ArrayList<>();
-        Collection<ProcessEventListener> processEventListeners = Collections.singletonList(events -> {
+        Set<ProcessEventListener> processEventListeners = Collections.singleton(events -> {
             synchronized (receivedEvents) {
                 receivedEvents.addAll(events);
             }
         });
 
-        Listeners listeners = new Listeners(processEventListeners, Collections.emptyList(), Collections.emptyList());
+        Listeners listeners = new Listeners(processEventListeners, Collections.emptySet(), Collections.emptySet());
         listeners.onProcessEvent(Collections.singletonList(ProcessEvent.builder()
                 .processKey(new ProcessKey(UUID.randomUUID(), OffsetDateTime.now()))
                 .eventSeq(0)

--- a/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/EventFetcher.java
+++ b/server/plugins/ansible/impl/src/main/java/com/walmartlabs/concord/server/plugins/ansible/EventFetcher.java
@@ -36,7 +36,7 @@ import java.util.*;
 import static com.walmartlabs.concord.server.jooq.Tables.PROCESS_EVENTS;
 import static org.jooq.impl.DSL.*;
 
-@Named("ansible-event-processor")
+@Named
 @Singleton
 public class EventFetcher extends AbstractEventProcessor<EventProcessor.Event> {
 
@@ -55,6 +55,11 @@ public class EventFetcher extends AbstractEventProcessor<EventProcessor.Event> {
         this.cfg = cfg;
         this.dao = dao;
         this.processors = processors;
+    }
+
+    @Override
+    public String getId() {
+        return "ansible-event-processor";
     }
 
     @Override
@@ -102,14 +107,14 @@ public class EventFetcher extends AbstractEventProcessor<EventProcessor.Event> {
             ProcessEvents pe = PROCESS_EVENTS.as("pe");
 
             SelectConditionStep<Record6<UUID, OffsetDateTime, Long, OffsetDateTime, String, JSONB>> q = tx.select(
-                    pe.INSTANCE_ID,
-                    pe.INSTANCE_CREATED_AT,
-                    pe.EVENT_SEQ,
-                    pe.EVENT_DATE,
-                    pe.EVENT_TYPE,
-                    when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_EVENT_TYPE), payloadField(tx, "host", "hostGroup", "status", "duration", "ignore_errors", "currentRetryCount", "hostStatus", "playId", "playbookId", "parentCorrelationId", "action", "isHandler", "taskId", "task"))
-                            .when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_PLAYBOOK_INFO), payloadField(tx, "plays", "playbookId", "playbook", "uniqueHosts", "totalWork", "parentCorrelationId", "currentRetryCount"))
-                            .when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_PLAYBOOK_RESULT), payloadField(tx, "playbookId", "status", "parentCorrelationId")))
+                            pe.INSTANCE_ID,
+                            pe.INSTANCE_CREATED_AT,
+                            pe.EVENT_SEQ,
+                            pe.EVENT_DATE,
+                            pe.EVENT_TYPE,
+                            when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_EVENT_TYPE), payloadField(tx, "host", "hostGroup", "status", "duration", "ignore_errors", "currentRetryCount", "hostStatus", "playId", "playbookId", "parentCorrelationId", "action", "isHandler", "taskId", "task"))
+                                    .when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_PLAYBOOK_INFO), payloadField(tx, "plays", "playbookId", "playbook", "uniqueHosts", "totalWork", "parentCorrelationId", "currentRetryCount"))
+                                    .when(pe.EVENT_TYPE.eq(Constants.ANSIBLE_PLAYBOOK_RESULT), payloadField(tx, "playbookId", "status", "parentCorrelationId")))
                     .from(pe)
                     .where(pe.EVENT_TYPE.in(Constants.ANSIBLE_EVENT_TYPE, Constants.ANSIBLE_PLAYBOOK_INFO, Constants.ANSIBLE_PLAYBOOK_RESULT)
                             .and(pe.EVENT_SEQ.greaterThan(marker.eventSeq())));

--- a/server/plugins/noderoster/impl/src/main/java/com/walmartlabs/concord/server/plugins/noderoster/processor/AnsibleEventsProcessor.java
+++ b/server/plugins/noderoster/impl/src/main/java/com/walmartlabs/concord/server/plugins/noderoster/processor/AnsibleEventsProcessor.java
@@ -45,7 +45,7 @@ import static org.jooq.impl.DSL.function;
  * Scans the process_events table for new Ansible events and hands
  * the data off to individual processors.
  */
-@Named("noderoster/ansible-events-processor")
+@Named
 public class AnsibleEventsProcessor extends AbstractEventProcessor<AnsibleEvent> {
 
     private static final String NAME = "noderoster/ansible-events-processor";
@@ -71,6 +71,11 @@ public class AnsibleEventsProcessor extends AbstractEventProcessor<AnsibleEvent>
 
         Instant startTimestamp = eventsCfg.getStartTimestamp();
         this.startTimestamp = startTimestamp != null ? OffsetDateTime.ofInstant(startTimestamp, ZoneId.systemDefault()) : null;
+    }
+
+    @Override
+    public String getId() {
+        return "noderoster/ansible-events-processor";
     }
 
     @Override

--- a/server/sdk/src/main/java/com/walmartlabs/concord/server/sdk/ScheduledTask.java
+++ b/server/sdk/src/main/java/com/walmartlabs/concord/server/sdk/ScheduledTask.java
@@ -22,6 +22,8 @@ package com.walmartlabs.concord.server.sdk;
 
 public interface ScheduledTask {
 
+    String getId();
+
     long getIntervalInSec();
 
     void performTask() throws Exception;


### PR DESCRIPTION
I'm gradually replacing the usage of `@Named` autowiring with explicit bindings using `Module`.

The idea is that the top-level modules (e.g. `ConcordServer`) and server plugins are autowired by Sisu while all internal modules are wired explicitly using Guice `Module`s. This should provide better re-usability of pieces of concord-server -- e.g., for testing and creating Concord-based tools.
