### PR TITLE
runtime-v2: allow access to the current argument when that argument is evaluated

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/UpdateLocalsCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/UpdateLocalsCommand.java
@@ -68,6 +68,14 @@ public class UpdateLocalsCommand implements Command {
             threads = Collections.singletonList(threadId);
         }
 
+        // allow access to arguments from arguments:
+        /* e.g.
+           configuration:
+             arguments:
+               args:
+                 k1: v1
+                 k2: ${context.variables().get('args.k1')}
+         */
         for (ThreadId tid : threads) {
             Frame root = VMUtils.assertNearestRoot(state, tid);
             VMUtils.putLocals(root, input);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/UpdateLocalsCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/UpdateLocalsCommand.java
@@ -63,13 +63,18 @@ public class UpdateLocalsCommand implements Command {
         ContextFactory contextFactory = runtime.getService(ContextFactory.class);
         Context ctx = contextFactory.create(runtime, state, threadId, null);
 
-        ExpressionEvaluator ee = runtime.getService(ExpressionEvaluator.class);
-        Map<String, Object> m = ee.evalAsMap(EvalContextFactory.scope(ctx), input);
-
         Collection<ThreadId> threads = threadIds;
         if (threads.isEmpty()) {
             threads = Collections.singletonList(threadId);
         }
+
+        for (ThreadId tid : threads) {
+            Frame root = VMUtils.assertNearestRoot(state, tid);
+            VMUtils.putLocals(root, input);
+        }
+
+        ExpressionEvaluator ee = runtime.getService(ExpressionEvaluator.class);
+        Map<String, Object> m = ee.evalAsMap(EvalContextFactory.scope(ctx), input);
 
         for (ThreadId tid : threads) {
             Frame root = VMUtils.assertNearestRoot(state, tid);

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -27,6 +27,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
+import com.walmartlabs.concord.common.ConfigurationUtils;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.forms.Form;
 import com.walmartlabs.concord.runtime.common.FormService;
@@ -1148,6 +1149,22 @@ public class MainTest {
         assertLog(log, ".*isDebug: true.*");
     }
 
+    @Test
+    public void argsFromArgs() throws Exception {
+        deploy("argsFromArgs");
+
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("k1", "v1");
+        args.put("k2", "${resultTask.get('args.k1')}");
+
+        save(ProcessConfiguration.builder()
+                .putArguments("args", args)
+                .build());
+
+        byte[] log = run();
+        assertLog(log, ".*Hello, " + Pattern.quote("{k1=v1, k2=v1}") + ".*");
+    }
+
     private void deploy(String resource) throws URISyntaxException, IOException {
         Path src = Paths.get(MainTest.class.getResource(resource).toURI());
         IOUtils.copy(src, workDir);
@@ -1334,12 +1351,26 @@ public class MainTest {
 
     @Named("resultTask")
     @SuppressWarnings("unused")
-    static class ResultTask implements Task {
+    public static class ResultTask implements Task {
+
+        private final Context context;
+
+        @Inject
+        public ResultTask(Context context) {
+            this.context = context;
+        }
 
         @Override
         public TaskResult execute(Variables input) {
             return TaskResult.success()
                     .value("result", input.get("result"));
+        }
+
+        public Object get(String path) {
+            String[] p = path.split("\\.");
+            Map<String, Object> m = context.variables().getMap(p[0], Collections.emptyMap());
+            p = Arrays.copyOfRange(p, 1, p.length);
+            return ConfigurationUtils.get(m, p);
         }
     }
 

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/argsFromArgs/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/argsFromArgs/concord.yml
@@ -1,0 +1,3 @@
+flows:
+  default:
+    - log: "Hello, ${args}"


### PR DESCRIPTION
```
configuration:
  arguments:
    args:
      k1: v1
      k2: ${context.variables().get('args.k1')}   # in runtime-v1: k2 = v1, in runtime-v2: k2 = null
```