### PR TITLE
runtime-v2: "throw" with a string value shouldn't produce a stacktrace

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -36,6 +36,7 @@ import com.walmartlabs.concord.runtime.v2.runner.guice.ObjectMapperProvider;
 import com.walmartlabs.concord.runtime.v2.runner.logging.LoggingConfigurator;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskProviders;
 import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
+import com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException;
 import com.walmartlabs.concord.runtime.v2.sdk.WorkingDirectory;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.svm.Frame;
@@ -100,7 +101,7 @@ public class Main {
             main.execute();
 
             System.exit(0);
-        } catch (MultiException e) {
+        } catch (MultiException | UserDefinedException e) {
             log.error(e.getMessage());
             System.exit(1);
         } catch (Throwable t) {


### PR DESCRIPTION
same as runtime v1.

```
01:02:42 [ERROR] The variable 'boom' must be set. Exiting.
01:02:43 [ERROR] Process exit code: 1
01:02:43 [INFO ] Process status: FAILED
```