### PR TITLE
resource-task: add printJson() method

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ResourceTaskIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ResourceTaskIT.java
@@ -23,46 +23,71 @@ package com.walmartlabs.concord.it.runtime.v2;
 import ca.ibodrov.concord.testcontainers.ConcordProcess;
 import ca.ibodrov.concord.testcontainers.Payload;
 import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.walmartlabs.concord.ApiException;
 import com.walmartlabs.concord.client.ProcessEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ResourceTaskIT extends AbstractTest {
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourceTaskIT extends AbstractTest {
 
     @RegisterExtension
     public static final ConcordRule concord = ConcordConfiguration.configure();
 
     @Test
-    public void testReadAsJson() throws Exception {
-        test("resourceReadAsJson");
+    void testReadAsJson() throws Exception {
+        basicAssert(test("resourceReadAsJson"));
     }
 
     @Test
-    public void testFromJsonString() throws Exception {
-        test("resourceReadFromJsonString");
+    void testFromJsonString() throws Exception {
+        basicAssert(test("resourceReadFromJsonString"));
     }
 
     @Test
-    public void testReadAsString() throws Exception {
-        test("resourceReadAsString");
+    void testReadAsString() throws Exception {
+        basicAssert(test("resourceReadAsString"));
     }
 
     @Test
-    public void testWriteAsJson() throws Exception {
-        test("resourceWriteAsJson");
+    void testWriteAsJson() throws Exception {
+        basicAssert(test("resourceWriteAsJson"));
     }
 
     @Test
-    public void testWriteAsString() throws Exception {
-        test("resourceWriteAsString");
+    void testWriteAsString() throws Exception {
+        basicAssert(test("resourceWriteAsString"));
     }
 
     @Test
-    public void testWriteAsYaml() throws Exception {
-        test("resourceWriteAsYaml");
+    void testWriteAsYaml() throws Exception {
+        basicAssert(test("resourceWriteAsYaml"));
     }
 
-    private void test(String resource) throws Exception {
+    @Test
+    void testPrintJson() throws Exception {
+        ConcordProcess proc = test("resourcePrintJson");
+
+        // ---
+
+        Map<String, Object> out = proc.getOutVariables();
+
+        String condensedResult = (String) out.get("condensedResult");
+        assertFalse(condensedResult.contains("\n"));
+        assertTrue(condensedResult.contains("\"x\":123"));
+        assertTrue(condensedResult.contains("\"y\":\"hello"));
+
+        String prettyResult = (String) out.get("prettyResult");
+        assertTrue(prettyResult.contains("\n"));
+        assertTrue(prettyResult.contains("\"x\" : 123"));
+        assertTrue(prettyResult.contains("\"y\" : \"hello\""));
+    }
+
+    private ConcordProcess test(String resource) throws Exception {
         Payload payload = new Payload()
                 .archive(resource(resource));
 
@@ -70,8 +95,10 @@ public class ResourceTaskIT extends AbstractTest {
 
         expectStatus(proc, ProcessEntry.StatusEnum.FINISHED);
 
-        // ---
+        return proc;
+    }
 
+    private void basicAssert(ConcordProcess proc) throws ApiException {
         proc.assertLog(".*Runtime: concord-v2.*");
         proc.assertLog(".*Hello Concord!.*");
     }

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/resourcePrintJson/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/resourcePrintJson/concord.yml
@@ -1,0 +1,15 @@
+configuration:
+  runtime: concord-v2
+  out:
+    - condensedResult
+    - prettyResult
+
+flows:
+  default:
+    - set:
+        m:
+          x: 123
+          y: "hello"
+    - set:
+        condensedResult: "${resource.printJson(m)}"
+        prettyResult: "${resource.prettyPrintJson(m)}"

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ResourceIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ResourceIT.java
@@ -23,48 +23,69 @@ package com.walmartlabs.concord.it.server;
 import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.ProcessEntry;
 import com.walmartlabs.concord.client.StartProcessResponse;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.Map;
 
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.assertLog;
 import static com.walmartlabs.concord.it.common.ServerClient.waitForCompletion;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ResourceIT extends AbstractServerIT {
 
     @Test
     public void testReadAsJson() throws Exception {
-        test("resourceReadAsJson", ".*Hello Concord!");
+        basicAssert(test("resourceReadAsJson"), ".*Hello Concord!");
     }
 
     @Test
     public void testFromJsonString() throws Exception {
-        test("resourceReadFromJsonString", ".*Hello Concord!");
+        basicAssert(test("resourceReadFromJsonString"), ".*Hello Concord!");
     }
 
     @Test
     public void testReadAsString() throws Exception {
-        test("resourceReadAsString", ".*Hello Concord!");
+        basicAssert(test("resourceReadAsString"), ".*Hello Concord!");
     }
 
     @Test
     public void testWriteAsJson() throws Exception {
-        test("resourceWriteAsJson", ".*Hello Concord!");
+        basicAssert(test("resourceWriteAsJson"), ".*Hello Concord!");
     }
 
     @Test
     public void testWriteAsString() throws Exception {
-        test("resourceWriteAsString", ".*Hello Concord!");
+        basicAssert(test("resourceWriteAsString"), ".*Hello Concord!");
     }
 
     @Test
     public void testWriteAsYaml() throws Exception {
-        test("resourceWriteAsYaml", ".*Hello Concord!");
+        basicAssert(test("resourceWriteAsYaml"), ".*Hello Concord!");
     }
 
-    private void test(String resource, String pattern) throws Exception {
+    @Test
+    void testPrintJson() throws Exception {
+        ProcessEntry pir = test("resourcePrintJson");
+
+        // ---
+
+        Map<String, Object> meta = pir.getMeta();
+
+        String condensedResult = (String) meta.get("condensedResult");
+        assertFalse(condensedResult.contains("\n"));
+        assertTrue(condensedResult.contains("\"x\":123"));
+        assertTrue(condensedResult.contains("\"y\":\"hello"));
+
+        String prettyResult = (String) meta.get("prettyResult");
+        assertTrue(prettyResult.contains("\n"));
+        assertTrue(prettyResult.contains("\"x\" : 123"));
+        assertTrue(prettyResult.contains("\"y\" : \"hello\""));
+    }
+
+    private ProcessEntry test(String resource) throws Exception {
         URI dir = ResourceIT.class.getResource(resource).toURI();
         byte[] payload = archive(dir);
 
@@ -74,6 +95,10 @@ public class ResourceIT extends AbstractServerIT {
         ProcessEntry pir = waitForCompletion(processApi, spr.getInstanceId());
         assertEquals(ProcessEntry.StatusEnum.FINISHED, pir.getStatus());
 
+        return pir;
+    }
+
+    private void basicAssert(ProcessEntry pir, @Language("RegExp") String pattern) throws Exception {
         byte[] ab = getLog(pir.getLogFileName());
         assertLog(pattern, ab);
     }

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/resourcePrintJson/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/resourcePrintJson/concord.yml
@@ -1,0 +1,14 @@
+configuration:
+  meta:
+    condensedResult: ''
+    prettyResult: ''
+
+flows:
+  default:
+    - set:
+        m:
+          x: 123
+          y: "hello"
+    - set:
+        condensedResult: "${resource.printJson(m)}"
+        prettyResult: "${resource.prettyPrintJson(m)}"

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTask.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTask.java
@@ -79,6 +79,10 @@ public class ResourceTask implements Task {
         return delegate(null).writeAsYaml(content);
     }
 
+    public String printJson(Object value) throws IOException {
+        return ResourceTaskCommon.printJson(value);
+    }
+
     public String prettyPrintJson(Object value) throws IOException {
         return ResourceTaskCommon.prettyPrintJson(value);
     }

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
@@ -153,6 +153,17 @@ public class ResourceTaskCommon {
         return workDir.relativize(tmpFile.toAbsolutePath()).toString();
     }
 
+    public static String printJson(Object value) throws IOException {
+        ObjectMapper mapper = createObjectMapper();
+
+        if (value instanceof String) {
+            // parse json string to object
+            value = mapper.readValue((String) value, Object.class);
+        }
+
+        return mapper.writeValueAsString(value);
+    }
+
     public static String prettyPrintJson(Object value) throws IOException {
         ObjectMapper mapper = createObjectMapper();
 

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/v2/ResourceTaskV2.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/v2/ResourceTaskV2.java
@@ -88,8 +88,12 @@ public class ResourceTaskV2 implements Task {
         return delegate.writeAsYaml(content);
     }
 
-    public String prettyPrintJson(Object json) throws IOException {
-        return ResourceTaskCommon.prettyPrintJson(json);
+    public String printJson(Object value) throws IOException {
+        return ResourceTaskCommon.printJson(value);
+    }
+
+    public String prettyPrintJson(Object value) throws IOException {
+        return ResourceTaskCommon.prettyPrintJson(value);
     }
 
     public String prettyPrintYaml(Object value) throws IOException {

--- a/plugins/tasks/resource/src/test/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommonTest.java
+++ b/plugins/tasks/resource/src/test/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommonTest.java
@@ -26,7 +26,6 @@ import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -37,10 +36,10 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ResourceTaskCommonTest {
+class ResourceTaskCommonTest {
 
     @Test
-    public void testPrettyPrintYaml() throws Exception {
+    void testPrettyPrintYaml() throws Exception {
         Map<String, Object> m = new HashMap<>();
         m.put("x", 123);
         m.put("y", Collections.singletonMap("a", false));
@@ -52,15 +51,34 @@ public class ResourceTaskCommonTest {
     }
 
     @Test
-    public void testPrettyPrintJson() {
+    void testPrintJson() throws IOException {
         Map<String, Object> m = new HashMap<>();
         m.put("x", 123);
-        m.put("y", OffsetDateTime.now());
+        m.put("y", "hello");
+
+        String result = ResourceTaskCommon.printJson(m);
+
+        assertFalse(result.contains("\n"));
+        assertTrue(result.contains("\"x\":123"));
+        assertTrue(result.contains("\"y\":\"hello"));
+    }
+
+    @Test
+    void testPrettyPrintJson() throws IOException {
+        Map<String, Object> m = new HashMap<>();
+        m.put("x", 123);
+        m.put("y", "hello");
+
+        String result = ResourceTaskCommon.prettyPrintJson(m);
+
+        assertTrue(result.contains("\n"));
+        assertTrue(result.contains("\"x\" : 123"));
+        assertTrue(result.contains("\"y\" : \"hello\""));
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testFromJsonString() throws Exception {
+    void testFromJsonString() throws Exception {
         String jsonString = "{ \"stringKey\": \"stringValue\", \"listKey\": [1,2,3]}";
         Path workDir = Paths.get(System.getProperty("user.dir"));
 
@@ -76,7 +94,7 @@ public class ResourceTaskCommonTest {
     }
 
     @Test
-    public void testAsProperties() throws Exception {
+    void testAsProperties() throws Exception {
         Path workDir = Paths.get(System.getProperty("user.dir"));
 
         ResourceTaskCommon rsc = new ResourceTaskCommon(workDir,


### PR DESCRIPTION
Adds a `printJson(obj)` method to serialize an object to a condensed JSON string.