### PR TITLE
runtime-v2: do not create log segment for expression by default

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ExpressionCommand.java
@@ -69,9 +69,4 @@ public class ExpressionCommand extends StepCommand<Expression> {
             ctx.variables().set(opts.out(), result);
         }
     }
-
-    @Override
-    protected String getDefaultSegmentName() {
-        return "expression";
-    }
 }


### PR DESCRIPTION
if the user needs a log segment then he can add `name` attribute to the expression step.

logs look clearer without this segment :)