### PR TITLE
runtime-v2: allow expression for form call values and runAs

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
@@ -148,30 +148,7 @@ public class FormIT extends AbstractTest {
 
         // ---
 
-        ConcordProcess proc = concord.processes().start(payload);
-        ProcessEntry pe = expectStatus(proc, ProcessEntry.StatusEnum.SUSPENDED);
-
-        // ---
-
-        List<FormListEntry> forms = proc.forms();
-        assertEquals(1, forms.size());
-
-        // ---
-        String formName = forms.get(0).getName();
-        assertEquals("myForm", formName);
-
-        // start session
-        startCustomFormSession(concord, pe.getInstanceId(), formName);
-
-        // get data.js
-        Map<String, Object> dataJs = getDataJs(concord, pe.getInstanceId(), formName);
-        Map<String, Object> values = MapUtils.get(dataJs, "values", Collections.emptyMap());
-
-        assertEquals(4, values.size());
-        assertEquals("Moo", values.get("firstName"));
-        assertEquals("Xaa", values.get("lastName"));
-        assertEquals(3, values.get("sum"));
-        assertEquals(ImmutableMap.of("city", "Toronto", "province", "Ontario"), values.get("address"));
+        assertFormValues(payload);
     }
 
     @Test
@@ -182,6 +159,10 @@ public class FormIT extends AbstractTest {
 
         // ---
 
+        assertFormValues(payload);
+    }
+
+    private void assertFormValues(Payload payload) throws Exception {
         ConcordProcess proc = concord.processes().start(payload);
         ProcessEntry pe = expectStatus(proc, ProcessEntry.StatusEnum.SUSPENDED);
 

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/customFormValues/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/customFormValues/concord.yml
@@ -1,5 +1,15 @@
 configuration:
   runtime: "concord-v2"
+  arguments:
+    formValues:
+      firstName: "Moo"
+      lastName: "Xaa"
+      sum: "${1 + 2}"
+      address:
+        city: Toronto
+        province: Ontario
+    formRunAs:
+      username: 'admin'
 
 flows:
   default:
@@ -12,6 +22,12 @@ flows:
         address:
           city: Toronto
           province: Ontario
+
+  callExpressions:
+    - form: myForm
+      # form calls can override form values or provide additional data
+      values: "${formValues}"
+      runAs: "${formRunAs}"
 
 forms:
   myForm:

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/customFormValues/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/customFormValues/concord.yml
@@ -1,6 +1,7 @@
 configuration:
   runtime: "concord-v2"
   arguments:
+    runAsUser: 'admin'
     formValues:
       firstName: "Moo"
       lastName: "Xaa"
@@ -9,7 +10,7 @@ configuration:
         city: Toronto
         province: Ontario
     formRunAs:
-      username: 'admin'
+      username: "${runAsUser}"
 
 flows:
   default:
@@ -22,6 +23,8 @@ flows:
         address:
           city: Toronto
           province: Ontario
+      runAs:
+        username: "${runAsUser}"
 
   callExpressions:
     - form: myForm

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/FormCallOptions.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/FormCallOptions.java
@@ -69,6 +69,18 @@ public interface FormCallOptions extends StepOptions {
     @Nullable
     String fieldsExpression();
 
+    /**
+     * Support for expressions in {@code values}.
+     */
+    @Nullable
+    String valuesExpression();
+
+    /**
+     * Support for expressions in {@code runAs}.
+     */
+    @Nullable
+    String runAsExpression();
+
     static ImmutableFormCallOptions.Builder builder() {
         return ImmutableFormCallOptions.builder();
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FormsGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/FormsGrammar.java
@@ -75,13 +75,21 @@ public final class FormsGrammar {
         return orError(or(formFieldsArray.map(o::fields), maybeExpression.map(o::fieldsExpression)), YamlValueType.FORM_CALL_FIELDS);
     }
 
+    private static Parser<Atom, ImmutableFormCallOptions.Builder> formCallValuesOption(ImmutableFormCallOptions.Builder o) {
+        return orError(or(maybeMap.map(o::values), maybeExpression.map(o::valuesExpression)), YamlValueType.FORM_CALL_VALUES);
+    }
+
+    private static Parser<Atom, ImmutableFormCallOptions.Builder> formCallRunAsOption(ImmutableFormCallOptions.Builder o) {
+        return orError(or(maybeMap.map(o::runAs), maybeExpression.map(o::runAsExpression)), YamlValueType.FORM_CALL_RUN_AS);
+    }
+
     private static final Parser<Atom, FormCallOptions> formCallOptions =
             with(FormCallOptions::builder,
                     o -> options(
                             optional("yield", booleanVal.map(o::yield)),
                             optional("saveSubmittedBy", booleanVal.map(o::saveSubmittedBy)),
-                            optional("runAs", mapVal.map(o::runAs)),
-                            optional("values", mapVal.map(o::values)),
+                            optional("runAs", formCallRunAsOption(o)),
+                            optional("values", formCallValuesOption(o)),
                             optional("fields", formCallFieldsOption(o))
                     ))
                     .map(ImmutableFormCallOptions.Builder::build);

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/YamlValueType.java
@@ -70,6 +70,8 @@ public final class YamlValueType<T> {
     public static final YamlValueType<List<FormField>> ARRAY_OF_FORM_FIELD = array("ARRAY_OF_FORM_FIELD", FORM_FIELD);
     public static final YamlValueType<FormCall> FORM_CALL = type("FORM_CALL");
     public static final YamlValueType<ImmutableFormCallOptions.Builder> FORM_CALL_FIELDS = type("ARRAY_OF_FORM_FIELD or EXPRESSION");
+    public static final YamlValueType<ImmutableFormCallOptions.Builder> FORM_CALL_RUN_AS = type("OBJECT or EXPRESSION");
+    public static final YamlValueType<ImmutableFormCallOptions.Builder> FORM_CALL_VALUES = type("OBJECT or EXPRESSION");
     public static final YamlValueType<ImmutableRetry.Builder> RETRY_TIMES = type("INT or EXPRESSION");
     public static final YamlValueType<ImmutableRetry.Builder> RETRY_DELAY = type("INT or EXPRESSION");
     public static final YamlValueType<Imports> IMPORTS = type("IMPORTS");

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FormCallStepSerializer.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FormCallStepSerializer.java
@@ -57,13 +57,11 @@ public class FormCallStepSerializer extends StdSerializer<FormCall> {
 
         gen.writeObjectField("yield", options.yield());
         gen.writeObjectField("saveSubmittedBy", options.saveSubmittedBy());
-        writeNotEmptyObjectField("runAs", options.runAs(), gen);
-        writeNotEmptyObjectField("values", options.values(), gen);
 
-        if (!options.fields().isEmpty()) {
-            writeNotEmptyObjectField("fields", options.fields(), gen);
-        } else if (options.fieldsExpression() != null) {
-            gen.writeObjectField("fields", options.fieldsExpression());
+        if (!options.runAs().isEmpty()) {
+            writeNotEmptyObjectField("runAs", options.runAs(), gen);
+        } else {
+            gen.writeObjectField("runAs", options.runAsExpression());
         }
 
         if (!options.values().isEmpty()) {
@@ -72,10 +70,10 @@ public class FormCallStepSerializer extends StdSerializer<FormCall> {
             gen.writeObjectField("values", options.valuesExpression());
         }
 
-        if (!options.runAs().isEmpty()) {
-            writeNotEmptyObjectField("runAs", options.runAs(), gen);
-        } else {
-            gen.writeObjectField("runAs", options.runAsExpression());
+        if (!options.fields().isEmpty()) {
+            writeNotEmptyObjectField("fields", options.fields(), gen);
+        } else if (options.fieldsExpression() != null) {
+            gen.writeObjectField("fields", options.fieldsExpression());
         }
     }
 }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FormCallStepSerializer.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/serializer/FormCallStepSerializer.java
@@ -65,5 +65,17 @@ public class FormCallStepSerializer extends StdSerializer<FormCall> {
         } else if (options.fieldsExpression() != null) {
             gen.writeObjectField("fields", options.fieldsExpression());
         }
+
+        if (!options.values().isEmpty()) {
+            writeNotEmptyObjectField("values", options.values(), gen);
+        } else if (options.valuesExpression() != null) {
+            gen.writeObjectField("values", options.valuesExpression());
+        }
+
+        if (!options.runAs().isEmpty()) {
+            writeNotEmptyObjectField("runAs", options.runAs(), gen);
+        } else {
+            gen.writeObjectField("runAs", options.runAsExpression());
+        }
     }
 }

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1706,7 +1706,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1005() throws Exception {
         String msg =
-                "(005.yml): Error @ line: 6, col: 14. Invalid value type, expected: OBJECT, got: STRING\n" +
+                "(005.yml): Error @ line: 6, col: 14. Invalid value type, expected: OBJECT or EXPRESSION, got: ARRAY\n" +
                         "\twhile processing steps:\n" +
                         "\t'runAs' @ line: 6, col: 7\n" +
                         "\t\t'form' @ line: 3, col: 7\n" +
@@ -1719,7 +1719,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1006() throws Exception {
         String msg =
-                "(006.yml): Error @ line: 10, col: 15. Invalid value type, expected: OBJECT, got: STRING\n" +
+                "(006.yml): Error @ line: 10, col: 15. Invalid value type, expected: OBJECT or EXPRESSION, got: ARRAY\n" +
                         "\twhile processing steps:\n" +
                         "\t'values' @ line: 10, col: 7\n" +
                         "\t\t'form' @ line: 3, col: 7\n" +

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -268,7 +268,7 @@ public class YamlOkParserTest extends AbstractParserTest {
 
         List<Step> main = pd.flows().get("main");
 
-        assertEquals(1, main.size());
+        assertEquals(2, main.size());
 
         assertTrue(main.get(0) instanceof FormCall);
         FormCall t = (FormCall) main.get(0);
@@ -276,6 +276,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertNotNull(t.getName());
         assertNotNull(t.getLocation());
         assertEquals("myForm", t.getName());
+        assertNotNull(t.getOptions());
         assertTrue(t.getOptions().yield());
         assertTrue(t.getOptions().saveSubmittedBy());
         assertEquals(Collections.singletonMap("username", Arrays.asList("userA", "userB")), t.getOptions().runAs());
@@ -287,6 +288,18 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertEquals(Cardinality.ONE_AND_ONLY_ONE, field.cardinality());
         assertEquals(0, field.options().size());
         assertNotNull(field.location());
+
+
+        assertTrue(main.get(1) instanceof FormCall);
+        FormCall t2 = (FormCall) main.get(1);
+
+        assertNotNull(t2.getOptions());
+        assertNotNull(t2.getOptions().valuesExpression());
+        assertFalse(t2.getOptions().yield());
+        assertFalse(t2.getOptions().saveSubmittedBy());
+        assertEquals("${{ 'fieldA': 'valueA' }}", t2.getOptions().valuesExpression());
+        assertEquals("${{ 'username': [ 'userA', 'userB' ] }}", t2.getOptions().runAsExpression());
+
 
         assertNotNull(pd.forms());
         assertEquals(1, pd.forms().size());

--- a/runtime/v2/model/src/test/resources/006.yml
+++ b/runtime/v2/model/src/test/resources/006.yml
@@ -13,6 +13,13 @@ flows:
       values:
         myField: "a different value"
 
+    - form: myForm
+      fields:
+        - firstName: {type: "string"}
+        - lastName: {type: "string"}
+      runAs: "${{ 'username': [ 'userA', 'userB' ] }}"
+      values: "${{ 'fieldA': 'valueA' }}"
+
 forms:
   myForm:
     - fullName: { label: "Name", type: "string", pattern: ".* .*", readonly: true, placeholder: "Place name here" }

--- a/runtime/v2/model/src/test/resources/errors/formCall/005.yml
+++ b/runtime/v2/model/src/test/resources/errors/formCall/005.yml
@@ -3,4 +3,4 @@ flows:
     - form: "boo"
       yield: true
       saveSubmittedBy: true
-      runAs: "one"
+      runAs: [ "one" ]

--- a/runtime/v2/model/src/test/resources/errors/formCall/006.yml
+++ b/runtime/v2/model/src/test/resources/errors/formCall/006.yml
@@ -7,4 +7,4 @@ flows:
         username:
           - "userA"
           - "userB"
-      values: "boo"
+      values: [ "one" ]

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FormCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FormCallCommand.java
@@ -92,7 +92,10 @@ public class FormCallCommand extends StepCommand<FormCall> {
                 .build();
     }
 
-    private static List<com.walmartlabs.concord.forms.FormField> buildFormFields(ExpressionEvaluator expressionEvaluator, EvalContext ctx, List<com.walmartlabs.concord.runtime.v2.model.FormField> fields, Map<String, Serializable> values) {
+    private static List<com.walmartlabs.concord.forms.FormField> buildFormFields(ExpressionEvaluator expressionEvaluator,
+                                                                                 EvalContext ctx,
+                                                                                 List<com.walmartlabs.concord.runtime.v2.model.FormField> fields,
+                                                                                 Map<String, Serializable> values) {
         List<com.walmartlabs.concord.forms.FormField> result = new ArrayList<>();
 
         fields.forEach(f -> {
@@ -163,7 +166,7 @@ public class FormCallCommand extends StepCommand<FormCall> {
                                                            FormCall formCall) {
         FormCallOptions options = Objects.requireNonNull(formCall.getOptions());
         if (!options.values().isEmpty()) {
-            return options.values();
+            return expressionEvaluator.evalAsMap(ctx, options.values());
         }
 
         Map<String, Serializable> rawValues = expressionEvaluator.evalAsMap(ctx, options.valuesExpression());
@@ -179,7 +182,7 @@ public class FormCallCommand extends StepCommand<FormCall> {
                                                           FormCall formCall) {
         FormCallOptions options = Objects.requireNonNull(formCall.getOptions());
         if (!options.runAs().isEmpty()) {
-            return options.runAs();
+            return expressionEvaluator.evalAsMap(ctx, options.runAs());
         }
 
         Map<String, Serializable> rawRunAs = expressionEvaluator.evalAsMap(ctx, options.runAsExpression());


### PR DESCRIPTION
Enables support for expressions in `- form:` calls for `values` and `runAs` options.

```yaml
- set:
    extraValues:
      hello: world
    customRunAs: { }

- set:
    customRunAs.username:
      - 'admin'

- form: myForm
  fields: # ...
  values: "${extraValues}"
  runAs: "${customRunAs}"
```