### PR TITLE
concord-agent: make more delays configurable

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ServerConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/ServerConfiguration.java
@@ -47,6 +47,8 @@ public class ServerConfiguration {
     private final long readTimeout;
     private final String userAgent;
     private final long maxNoHeartbeatInterval;
+    private final long processRequestDelay;
+    private final long reconnectDelay;
 
     @Inject
     public ServerConfiguration(Config cfg, AgentConfiguration agentCfg) {
@@ -71,6 +73,9 @@ public class ServerConfiguration {
         this.userAgent = getStringOrDefault(cfg, "server.userAgent", () -> "Concord-Agent: id=" + agentCfg.getAgentId());
 
         this.maxNoHeartbeatInterval = cfg.getDuration("server.maxNoHeartbeatInterval", TimeUnit.MILLISECONDS);
+
+        this.processRequestDelay = cfg.getDuration("server.processRequestDelay", TimeUnit.MILLISECONDS);
+        this.reconnectDelay = cfg.getDuration("server.reconnectDelay", TimeUnit.MILLISECONDS);
     }
 
     public String getApiBaseUrl() {
@@ -111,6 +116,14 @@ public class ServerConfiguration {
 
     public long getMaxNoHeartbeatInterval() {
         return maxNoHeartbeatInterval;
+    }
+
+    public long getProcessRequestDelay() {
+        return processRequestDelay;
+    }
+
+    public long getReconnectDelay() {
+        return reconnectDelay;
     }
 
     private static String[] getWebsocketUrls(Config cfg) {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/remote/QueueClientProvider.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/remote/QueueClientProvider.java
@@ -54,6 +54,8 @@ public class QueueClientProvider implements Provider<QueueClient> {
                     .connectTimeout(serverCfg.getConnectTimeout())
                     .pingInterval(serverCfg.getPingInterval())
                     .maxNoActivityPeriod(serverCfg.getMaxNoActivityPeriod())
+                    .processRequestDelay(serverCfg.getProcessRequestDelay())
+                    .reconnectDelay(serverCfg.getReconnectDelay())
                     .build());
 
             queueClient.start();

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -127,6 +127,12 @@ concord-agent {
 
         # maximum time interval without a heartbeat before the process fails
         maxNoHeartbeatInterval = "5 minutes"
+
+        # delay between successful polling attempts
+        processRequestDelay = "1 seconds"
+
+        # delay between re-connection attempts if the server is unreachable or unhealthy
+        reconnectDelay = "5 seconds"
     }
 
     docker {

--- a/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/QueueClient.java
+++ b/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/QueueClient.java
@@ -115,9 +115,6 @@ public class QueueClient {
             DISCONNECTING
         }
 
-        private static final long PROCESS_REQUEST_DELAY = 1000;
-        private static final long RECONNECT_DELAY = 10000;
-
         private final AtomicLong requestIdGenerator = new AtomicLong();
 
         private final String agentId;
@@ -129,6 +126,9 @@ public class QueueClient {
         private final long pingInterval;
         private final long maxNoActivityPeriod;
         private final long connectTimeout;
+
+        private final long processRequestDelay;
+        private final long reconnectDelay;
 
         private WebSocketClient client;
         private long lastRequestTimestamp;
@@ -147,6 +147,9 @@ public class QueueClient {
             this.pingInterval = cfg.getPingInterval();
             this.maxNoActivityPeriod = cfg.getMaxNoActivityPeriod();
             this.connectTimeout = cfg.getConnectTimeout();
+
+            this.processRequestDelay = cfg.getProcessRequestDelay();
+            this.reconnectDelay = cfg.getReconnectDelay();
 
             this.state = new AtomicReference<>(State.CONNECTING);
         }
@@ -169,14 +172,14 @@ public class QueueClient {
                         case CONNECTED: {
                             processRequests(session);
                             processPing(session);
-                            sleep(PROCESS_REQUEST_DELAY);
+                            sleep(processRequestDelay);
                             break;
                         }
                         case DISCONNECTING: {
                             close(session);
                             session = null;
                             state.set(State.CONNECTING);
-                            sleep(RECONNECT_DELAY);
+                            sleep(reconnectDelay);
                             break;
                         }
                     }

--- a/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/QueueClientConfiguration.java
+++ b/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/QueueClientConfiguration.java
@@ -34,6 +34,9 @@ public class QueueClientConfiguration implements Serializable {
     private final long pingInterval;
     private final long maxNoActivityPeriod;
 
+    private final long processRequestDelay;
+    private final long reconnectDelay;
+
     private QueueClientConfiguration(Builder b) {
         this.addresses = b.addresses;
         this.agentId = b.agentId;
@@ -42,6 +45,8 @@ public class QueueClientConfiguration implements Serializable {
         this.connectTimeout = b.connectTimeout;
         this.pingInterval = b.pingInterval;
         this.maxNoActivityPeriod = b.maxNoActivityPeriod;
+        this.processRequestDelay = b.processRequestDelay;
+        this.reconnectDelay = b.reconnectDelay;
     }
 
     public String[] getAddresses() {
@@ -72,6 +77,14 @@ public class QueueClientConfiguration implements Serializable {
         return maxNoActivityPeriod;
     }
 
+    public long getProcessRequestDelay() {
+        return processRequestDelay;
+    }
+
+    public long getReconnectDelay() {
+        return reconnectDelay;
+    }
+
     public static class Builder {
 
         private final String[] addresses;
@@ -82,6 +95,8 @@ public class QueueClientConfiguration implements Serializable {
         private long connectTimeout = 30000;
         private long pingInterval = 10000;
         private long maxNoActivityPeriod = 30000;
+        private long processRequestDelay = 1000;
+        private long reconnectDelay = 10000;
 
         public Builder(String[] addresses) {
             this.addresses = addresses;
@@ -114,6 +129,16 @@ public class QueueClientConfiguration implements Serializable {
 
         public Builder maxNoActivityPeriod(long maxNoActivityPeriod) {
             this.maxNoActivityPeriod = maxNoActivityPeriod;
+            return this;
+        }
+
+        public Builder processRequestDelay(long processRequestDelay) {
+            this.processRequestDelay = processRequestDelay;
+            return this;
+        }
+
+        public Builder reconnectDelay(long reconnectDelay) {
+            this.reconnectDelay = reconnectDelay;
             return this;
         }
 


### PR DESCRIPTION
Configurable delays for successful and unsuccessful (connection errors) polling attempts.