### PR TITLE
server: use clean directory for each refresh listener

### DIFF
--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/externalImportSymlink/concord.txt
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/externalImportSymlink/concord.txt
@@ -1,0 +1,7 @@
+imports:
+  - git:
+      url: "{{gitUrl}}"
+
+triggers:
+  - test:
+      entryPoint: "flowFromTemplate"

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/ProcessDefinitionRefreshListener.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/ProcessDefinitionRefreshListener.java
@@ -20,12 +20,9 @@ package com.walmartlabs.concord.server.repository.listeners;
  * =====
  */
 
-import com.walmartlabs.concord.imports.ImportsListener;
-import com.walmartlabs.concord.process.loader.ProjectLoader;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.server.org.project.RepositoryDao;
 import com.walmartlabs.concord.server.org.project.RepositoryEntry;
-import com.walmartlabs.concord.server.process.ImportsNormalizerFactory;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,24 +39,14 @@ public class ProcessDefinitionRefreshListener implements RepositoryRefreshListen
     private static final Logger log = LoggerFactory.getLogger(ProcessDefinitionRefreshListener.class);
 
     private final RepositoryDao repositoryDao;
-    private final ProjectLoader projectLoader;
-    private final ImportsNormalizerFactory importsNormalizer;
 
     @Inject
-    public ProcessDefinitionRefreshListener(RepositoryDao repositoryDao,
-                                            ProjectLoader projectLoader,
-                                            ImportsNormalizerFactory importsNormalizer) {
-
+    public ProcessDefinitionRefreshListener(RepositoryDao repositoryDao) {
         this.repositoryDao = repositoryDao;
-        this.projectLoader = projectLoader;
-        this.importsNormalizer = importsNormalizer;
     }
 
     @Override
-    public void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath) throws Exception {
-        ProcessDefinition pd = projectLoader.loadProject(repoPath, importsNormalizer.forProject(repo.getProjectId()), ImportsListener.NOP_LISTENER)
-                .projectDefinition();
-
+    public void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath, ProcessDefinition pd) {
         Set<String> pf = pd.publicFlows();
         if (pf == null || pf.isEmpty()) {
             // all flows are public when no public flows defined

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/RepositoryRefreshListener.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/RepositoryRefreshListener.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.server.repository.listeners;
  * =====
  */
 
+import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.server.org.project.RepositoryEntry;
 import org.jooq.DSLContext;
 
@@ -27,5 +28,5 @@ import java.nio.file.Path;
 
 public interface RepositoryRefreshListener {
 
-    void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath) throws Exception;
+    void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath, ProcessDefinition pd);
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/TriggerRefreshListener.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/listeners/TriggerRefreshListener.java
@@ -20,13 +20,10 @@ package com.walmartlabs.concord.server.repository.listeners;
  * =====
  */
 
-import com.walmartlabs.concord.imports.ImportsListener;
-import com.walmartlabs.concord.process.loader.ProjectLoader;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.server.org.project.ProjectValidator;
 import com.walmartlabs.concord.server.org.project.RepositoryEntry;
 import com.walmartlabs.concord.server.org.triggers.TriggerManager;
-import com.walmartlabs.concord.server.process.ImportsNormalizerFactory;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,21 +39,14 @@ public class TriggerRefreshListener implements RepositoryRefreshListener {
     private static final Logger log = LoggerFactory.getLogger(TriggerRefreshListener.class);
 
     private final TriggerManager triggerManager;
-    private final ProjectLoader projectLoader;
-    private final ImportsNormalizerFactory importsNormalizer;
 
     @Inject
-    public TriggerRefreshListener(TriggerManager triggerManager,
-                                  ProjectLoader projectLoader,
-                                  ImportsNormalizerFactory importsNormalizer) {
-
+    public TriggerRefreshListener(TriggerManager triggerManager) {
         this.triggerManager = triggerManager;
-        this.projectLoader = projectLoader;
-        this.importsNormalizer = importsNormalizer;
     }
 
     @Override
-    public void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath) throws Exception {
+    public void onRefresh(DSLContext ctx, RepositoryEntry repo, Path repoPath, ProcessDefinition pd) {
         if (repo.isTriggersDisabled()) {
             triggerManager.clearTriggers(repo.getProjectId(), repo.getId());
             return;
@@ -64,9 +54,6 @@ public class TriggerRefreshListener implements RepositoryRefreshListener {
 
         log.info("refresh ['{}'] -> triggers", repo.getId());
 
-        ProjectLoader.Result result = projectLoader.loadProject(repoPath, importsNormalizer.forProject(repo.getProjectId()), ImportsListener.NOP_LISTENER);
-
-        ProcessDefinition pd = result.projectDefinition();
         ProjectValidator.Result validationResult = ProjectValidator.validate(pd);
         if (!validationResult.isValid()) {
             throw new ValidationErrorsException(String.join("\n", validationResult.getErrors()));


### PR DESCRIPTION
When a `RepositoryRefreshListener` processes the repo directory, it typically will process `imports` which adds files to the directory. If any of the files are symlinks, then multiple listeners re-processing the same directory will try to recreate existing symlinks causing an exception.

This change gives each listener a fresh copy of the base exported repo directory so the listener can do whatever it wants without assumptions.

Alternatively, we could refactor one of two things:
1.  Change [`IOUtils.copy(...)`](https://github.com/walmartlabs/concord/blob/53db9edaa44b0a028af57046dc7f57cfd87d801c/common/src/main/java/com/walmartlabs/concord/common/IOUtils.java#L253-L268) to delete and re-create any existing symlinks it encounters. That _may_ have some side effects.
2. Refactor the repository export process to not re-process imports after they've already been handled once.