### PR TITLE
runtime-v2: fix fork args

### DIFF
--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/forkAfterForm/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/forkAfterForm/concord.yml
@@ -1,0 +1,20 @@
+configuration:
+  runtime: concord-v2
+
+forms:
+  myForm:
+    - name: { type: "string" }
+
+flows:
+  default:
+    - form: myForm
+
+    - task: concord
+      in:
+        action: fork
+        entryPoint: newProcess
+
+  newProcess:
+    - log: |
+        parentInstanceId: ${parentInstanceId}
+        txId: ${txId}:

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -134,7 +134,6 @@ public class Main {
         }
 
         Path workDir = this.workDir.getValue();
-        Map<String, Object> processArgs = prepareProcessArgs(processCfg);
 
         // three modes:
         //  - regular start "from scratch" (or running a "handler" process)
@@ -147,15 +146,19 @@ public class Main {
         Action action = currentAction(events);
         switch (action) {
             case START: {
+                Map<String, Object> processArgs = new LinkedHashMap<>();
                 if (snapshot != null) {
                     // grab top-level variables from the snapshot and use them as process arguments
                     processArgs.putAll(getTopLevelVariables(snapshot));
                 }
+                processArgs.putAll(prepareProcessArgs(processCfg));
 
                 snapshot = start(runner, processCfg, workDir, processArgs);
                 break;
             }
             case RESUME: {
+                Map<String, Object> processArgs = prepareProcessArgs(processCfg);
+
                 snapshot = resume(runner, processCfg, snapshot, processArgs, events);
                 break;
             }


### PR DESCRIPTION
state of the parent process overwrites the fork variables (e.g. fork after form).

now fork arguments overrides parent process variables (state).