### PR TITLE
feat: init easy script Variables instantiation

### DIFF
--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Variables.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/Variables.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.sdk;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,13 @@ import java.util.UUID;
 public interface Variables {
 
     Object get(String key);
+
+    default Variables withMap(Map<String, Object> map) {
+      for(Map.Entry<String, Object> entry: map.entrySet()) {
+        set(entry.getKey(), entry.getValue());
+      }
+      return this;
+    }
 
     void set(String key, Object value);
 


### PR DESCRIPTION
# Problem

- `Variables` is cumbersome to work with from a scripting context

example:

```js
const task = tasks.get("slack");
const slackInputs = { foo: ...., bar: ...};
for (var key in slackInputs) {
  context.variables().set(key, slackInputs[key]);
}
task.execute(context.variables());
```

# Solution

Make working with variables more ergonomic/~~pure~~/declaritive/whatever by means of a fluent/chained `.withMap(...)` method


```js
```js
const task = tasks.get("slack");
task.execute(context.variables().withMap({ foo: ...., bar: ...}));
```

# Screenshot

(errr GH is having cert issues ATM with its static asset service :( )