### PR TITLE
runtime-v2: better loop items serialization

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/script/VariablesSanitizer.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/script/VariablesSanitizer.java
@@ -20,10 +20,7 @@ package com.walmartlabs.concord.runtime.v2.runner.script;
  * =====
  */
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public final class VariablesSanitizer {
@@ -42,7 +39,7 @@ public final class VariablesSanitizer {
                     .collect(Collectors.toList());
         } else if (scriptObj instanceof Map) {
             Map<Object, Object> m = (Map<Object, Object>) scriptObj;
-            Map<Object, Object> result = new HashMap<>();
+            Map<Object, Object> result = new LinkedHashMap<>();
             m.forEach((key, value) -> result.put(sanitize(key), sanitize(value)));
             return result;
         } else {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/LoopItemSanitizer.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/LoopItemSanitizer.java
@@ -1,0 +1,105 @@
+package com.walmartlabs.concord.runtime.v2.runner.vm;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class LoopItemSanitizer {
+
+    public static ArrayList<Serializable> sanitize(Object items) {
+        if (items == null) {
+            return null;
+        }
+
+        ArrayList<Serializable> result = toArray(items);
+        if (result == null) {
+            return null;
+        }
+
+        result.forEach(LoopItemSanitizer::assertItem);
+
+        return result;
+    }
+
+    public static ArrayList<Serializable> toArray(Object items) {
+        if (items instanceof Collection) {
+            Collection<?> collection = (Collection<?>) items;
+            if (collection.isEmpty()) {
+                return null;
+            }
+            return collection.stream()
+                    .map(LoopItemSanitizer::sanitizeItem)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } else if (items instanceof Map) {
+            Map<?, ?> m = (Map<?, ?>) items;
+            items = m.entrySet().stream()
+                    .map(e -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue()))
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } else if (items.getClass().isArray()) {
+            return Arrays.stream((Object[])items)
+                    .map(LoopItemSanitizer::sanitizeItem)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        throw new IllegalArgumentException("'loop' accepts only Lists of items, Java Maps or arrays of values. Got: " + items.getClass());
+    }
+
+    private static Serializable sanitizeItem(Object item) {
+        if (item == null) {
+            return null;
+        }
+
+        if (item instanceof Serializable) {
+            return (Serializable) item;
+        }
+
+        if (item instanceof Map.Entry) {
+            Map.Entry<?, ?> e = (Map.Entry<?, ?>) item;
+            return new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue());
+        } else if (item instanceof Map) {
+            return new HashMap<>((Map<?, ?>)item);
+        } else if (item instanceof Collection) {
+            return new ArrayList<>((Collection<?>) item);
+        }
+
+        throw new IllegalArgumentException("Can't use non-serializable values in 'loop': " + item + " (" + item.getClass() + ")");
+    }
+
+    static void assertItem(Object item) {
+        if (item == null) {
+            return;
+        }
+
+        try (ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream())) {
+            oos.writeObject(item);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Can't use non-serializable values in 'loop': " + item + " (" + item.getClass() + ")");
+        }
+    }
+
+    private LoopItemSanitizer() {
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/LoopItemSanitizer.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/LoopItemSanitizer.java
@@ -55,7 +55,7 @@ public final class LoopItemSanitizer {
                     .collect(Collectors.toCollection(ArrayList::new));
         } else if (items instanceof Map) {
             Map<?, ?> m = (Map<?, ?>) items;
-            items = m.entrySet().stream()
+            return m.entrySet().stream()
                     .map(e -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue()))
                     .collect(Collectors.toCollection(ArrayList::new));
         } else if (items.getClass().isArray()) {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -1189,6 +1189,17 @@ public class MainTest {
         assertLog(log, ".*Hello, " + Pattern.quote("{k1=v1, k2=v1}") + ".*");
     }
 
+    @Test
+    public void loopItemSerialization() throws Exception {
+        deploy("loopSerializationError");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        byte[] log = run();
+        assertLog(log, ".*name=one.*");
+    }
+
     private void deploy(String resource) throws URISyntaxException, IOException {
         Path src = Paths.get(MainTest.class.getResource(resource).toURI());
         IOUtils.copy(src, workDir);

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/loopSerializationError/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/loopSerializationError/concord.yml
@@ -1,0 +1,14 @@
+flows:
+  default:
+    - set:
+        items:
+          - name: one
+          - name: two
+        filteredItems: ${items.stream().filter(i -> i.name.equals('one')).toList()}
+
+    - call: test
+      loop:
+        items: ${filteredItems}
+
+  test:
+    - log: ${item}


### PR DESCRIPTION
class cast exception before this PR:

```
flows:
  default:
    - set:
        items:
          - name: one
          - name: two
        filteredItems: ${items.stream().filter(i -> i.name.equals('one')).toList()}

    - call: test
      loop:
        items: ${filteredItems}

  test:
    - log: ${item}
```