### PR TITLE
cli: log step info with --verbose

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -87,6 +87,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -30,6 +30,7 @@ import com.walmartlabs.concord.runtime.v2.runner.checkpoints.CheckpointService;
 import com.walmartlabs.concord.runtime.v2.runner.guice.BaseRunnerModule;
 import com.walmartlabs.concord.runtime.v2.runner.logging.RunnerLogger;
 import com.walmartlabs.concord.runtime.v2.runner.logging.SimpleLogger;
+import com.walmartlabs.concord.runtime.v2.runner.remote.EventRecordingExecutionListener;
 import com.walmartlabs.concord.runtime.v2.sdk.DockerService;
 import com.walmartlabs.concord.runtime.v2.sdk.LockService;
 import com.walmartlabs.concord.runtime.v2.sdk.SecretService;
@@ -44,16 +45,19 @@ public class CliServicesModule extends AbstractModule {
     private final Path workDir;
     private final VaultProvider vaultProvider;
     private final DependencyManager dependencyManager;
+    private final boolean verbose;
 
     public CliServicesModule(Path secretStoreDir,
                              Path workDir,
                              VaultProvider vaultProvider,
-                             DependencyManager dependencyManager) {
+                             DependencyManager dependencyManager,
+                             boolean verbose) {
 
         this.secretStoreDir = secretStoreDir;
         this.workDir = workDir;
         this.vaultProvider = vaultProvider;
         this.dependencyManager = dependencyManager;
+        this.verbose = verbose;
     }
 
     @Override
@@ -76,7 +80,10 @@ public class CliServicesModule extends AbstractModule {
         bind(DependencyManager.class).toInstance(dependencyManager);
         bind(com.walmartlabs.concord.runtime.v2.sdk.DependencyManager.class).to(DefaultDependencyManager.class).in(Singleton.class);
 
-        Multibinder.newSetBinder(binder(), ExecutionListener.class);
+        Multibinder<ExecutionListener> executionListeners = Multibinder.newSetBinder(binder(), ExecutionListener.class);
+        if (verbose) {
+            executionListeners.addBinding().to(EventLoggerExecutionListener.class);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/EventLoggerExecutionListener.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/EventLoggerExecutionListener.java
@@ -1,0 +1,77 @@
+package com.walmartlabs.concord.cli.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.model.*;
+import com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand;
+import com.walmartlabs.concord.svm.Runtime;
+import com.walmartlabs.concord.svm.*;
+
+public class EventLoggerExecutionListener implements ExecutionListener {
+
+    @Override
+    public Result beforeCommand(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
+        if (!(cmd instanceof StepCommand)) {
+            return Result.CONTINUE;
+        }
+
+        StepCommand<?> s = (StepCommand<?>) cmd;
+
+        Location loc = s.getStep().getLocation();
+
+        System.out.println(">>> '" + getDescription(s.getStep()) + "' at " + loc.fileName() + ":" + loc.lineNum());
+
+        return Result.CONTINUE;
+    }
+
+    private static String getDescription(Step step) {
+        // TODO: add 'description' into step? so we will not miss description for new steps...
+        if (step instanceof FlowCall) {
+            return "Flow call: " + ((FlowCall) step).getFlowName();
+        } else if (step instanceof Expression) {
+            return "Expression: " + ((Expression) step).getExpr();
+        } else if (step instanceof ScriptCall) {
+            return "Script: " + ((ScriptCall) step).getLanguageOrRef();
+        } else if (step instanceof IfStep) {
+            return "Check: " + ((IfStep) step).getExpression();
+        } else if (step instanceof SwitchStep) {
+            return "Switch: " + ((SwitchStep) step).getExpression();
+        } else if (step instanceof SetVariablesStep) {
+            return "Set variables";
+        } else if (step instanceof Checkpoint) {
+            return "Checkpoint: " + ((Checkpoint) step).getName();
+        } else if (step instanceof FormCall) {
+            return "Form call: " + ((FormCall) step).getName();
+        } else if (step instanceof GroupOfSteps) {
+            return "Group of steps";
+        } else if (step instanceof ParallelBlock) {
+            return "Parallel block";
+        } else if (step instanceof ExitStep) {
+            return "Exit";
+        } else if (step instanceof ReturnStep) {
+            return "Return";
+        } else if (step instanceof TaskCall) {
+            return "Task: " + ((TaskCall) step).getName();
+        }
+
+        return step.getClass().getName();
+    }
+}


### PR DESCRIPTION
```
Starting...
>>> 'Task: log' at concord.yml:30
15:48:03.504 [main] All variables: {myVar=world, newVar= Hello earth, url=https://rubygems.org, txId=f29ebf5c-ed3d-4ba1-98d1-1a49b14f4a23, workDir=/Users/brig/prj/github/concord/examples/runtime-v2/demo-flow/target}
>>> 'Check: ${hasVariable('projectInfo.orgName')}' at concord.yml:32
>>> 'Task: log' at concord.yml:36
15:48:03.507 [main] Nope, we do not have 'orgName' variable
>>> 'Flow call: externalFlow' at concord.yml:38
>>> 'Task: log' at concord/test.concord.yml:6
...
```