### PR TITLE
runtime-v2: session state files

### DIFF
--- a/console2/src/components/organisms/ProcessAttachmentsActivity/index.tsx
+++ b/console2/src/components/organisms/ProcessAttachmentsActivity/index.tsx
@@ -28,6 +28,7 @@ import RequestErrorActivity from '../RequestErrorActivity';
 import { useCallback } from 'react';
 import { usePolling } from '../../../api/usePolling';
 import { ConcordId } from '../../../api/common';
+import {attempt} from "lodash";
 
 interface ExternalProps {
     instanceId: ConcordId;
@@ -63,7 +64,9 @@ const ProcessAttachmentsActivity = ({
 };
 
 const makeAttachmentsList = (data: string[]): string[] => {
-    return data.filter((attachment) => attachment.indexOf('_state') < 0);
+    return data
+        .filter((attachment) => attachment.indexOf('_state') < 0)
+        .filter((attachment) => attachment.indexOf('_session_files') < 0);
 };
 
 export default ProcessAttachmentsActivity;

--- a/console2/src/components/organisms/ProcessAttachmentsActivity/index.tsx
+++ b/console2/src/components/organisms/ProcessAttachmentsActivity/index.tsx
@@ -28,7 +28,6 @@ import RequestErrorActivity from '../RequestErrorActivity';
 import { useCallback } from 'react';
 import { usePolling } from '../../../api/usePolling';
 import { ConcordId } from '../../../api/common';
-import {attempt} from "lodash";
 
 interface ExternalProps {
     instanceId: ConcordId;

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -75,6 +75,20 @@ public final class ConcordConfiguration {
         return concord;
     }
 
+    // TODO: move to testcontainers
+    public static String getServerUrlForAgent(ConcordRule concord) {
+        switch (concord.mode()) {
+            case LOCAL:
+                return "http://localhost:8001";
+            case REMOTE:
+                return System.getProperty("it.remote.baseUrl");
+            case DOCKER:
+                return "http://server:8001";
+            default:
+                throw new IllegalArgumentException("Unknown mode: " + concord.mode());
+        }
+    }
+
     private ConcordConfiguration() {
     }
 }

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SessionStateFilesIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SessionStateFilesIT.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import static com.walmartlabs.concord.it.common.ITUtils.randomString;
+import static com.walmartlabs.concord.it.runtime.v2.ConcordConfiguration.getServerUrlForAgent;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SessionStateFilesIT extends AbstractTest {
@@ -64,7 +65,7 @@ public class SessionStateFilesIT extends AbstractTest {
         // ---
         Payload payload = new Payload()
                 .archive(resource("sessionFileAccess"))
-                .arg("baseUrl", concord.apiBaseUrl());
+                .arg("baseUrl", getServerUrlForAgent(concord));
 
         ApiClient client = concord.apiClient().setApiKey(cakr.getKey());
         ConcordProcess proc = new Processes(client)

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SessionStateFilesIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SessionStateFilesIT.java
@@ -1,0 +1,127 @@
+package com.walmartlabs.concord.it.runtime.v2;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.Payload;
+import ca.ibodrov.concord.testcontainers.Processes;
+import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.walmartlabs.concord.ApiClient;
+import com.walmartlabs.concord.ApiException;
+import com.walmartlabs.concord.client.*;
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.sdk.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.UUID;
+
+import static com.walmartlabs.concord.it.common.ITUtils.randomString;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SessionStateFilesIT extends AbstractTest {
+
+    @RegisterExtension
+    public static final ConcordRule concord = ConcordConfiguration.configure();
+
+    @Test
+    public void testSessionFileAccess() throws Exception {
+        String username = "user_" + randomString();
+
+        UsersApi usersApi = new UsersApi(concord.apiClient());
+        CreateUserResponse user = usersApi.createOrUpdate(new CreateUserRequest()
+                .setUsername(username)
+                .setType(CreateUserRequest.TypeEnum.LOCAL));
+
+        ApiKeysApi apiKeysApi = new ApiKeysApi(concord.apiClient());
+        CreateApiKeyResponse cakr = apiKeysApi.create(new CreateApiKeyRequest()
+                        .setUserId(user.getId()));
+
+        // ---
+        Payload payload = new Payload()
+                .archive(resource("sessionFileAccess"))
+                .arg("baseUrl", concord.apiBaseUrl());
+
+        ApiClient client = concord.apiClient().setApiKey(cakr.getKey());
+        ConcordProcess proc = new Processes(client)
+                .start(payload);
+
+        // ---
+        expectStatus(proc, ProcessEntry.StatusEnum.SUSPENDED);
+
+        // ---
+        Assertions.assertEquals(username, proc.getEntry().getInitiator());
+
+        ProcessApi processApiAdmin = new ProcessApi(concord.apiClient());
+        ProcessApi processApiInitiator = new ProcessApi(client);
+
+        String file = "sensitive_data.txt";
+
+        // ---
+        assertCantDownloadFile(processApiAdmin, proc.instanceId(), file);
+
+        // ---
+        assertCantDownloadFile(processApiInitiator, proc.instanceId(), file);
+
+        FormSubmitResponse fsr = proc.submitForm("myForm", Collections.emptyMap());
+        assertNull(fsr.getErrors());
+        expectStatus(proc, ProcessEntry.StatusEnum.FINISHED);
+
+        // ---
+        proc.assertLog(".*Secret: top-secret-value.*");
+    }
+
+    private static void assertCantDownloadFile(ProcessApi processApi, UUID instanceId, String file) throws Exception {
+        try {
+            processApi.downloadAttachment(instanceId, Constants.Files.JOB_SESSION_FILES_DIR_NAME + "/" + file);
+            fail("exception expected");
+        } catch (ApiException e) {
+            assertEquals(403, e.getCode());
+        }
+
+        String fullFileName = Constants.Files.JOB_ATTACHMENTS_DIR_NAME + "/" + Constants.Files.JOB_SESSION_FILES_DIR_NAME + "/" + file;
+
+        // ---
+        File state = processApi.downloadState(instanceId);
+        assertNoFileInState(fullFileName, state);
+
+        // ---
+        try {
+            processApi.downloadStateFile(instanceId, fullFileName);
+            fail("exception expected");
+        } catch (ApiException e) {
+            assertEquals(403, e.getCode());
+        }
+    }
+
+    private static void assertNoFileInState(String file, File state) throws IOException  {
+        Path target = Files.createTempDirectory("state-unzip");
+        IOUtils.unzip(state.toPath(), target, false, (sourceFile, dstFile) -> {
+            assertNotEquals(file, target.relativize(dstFile).toString());
+        });
+    }
+}

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/sessionFileAccess/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/sessionFileAccess/concord.yml
@@ -1,0 +1,53 @@
+configuration:
+  runtime: concord-v2
+
+flows:
+  default:
+    - script: js
+      body: |
+        var persistenceServiceType = Java.type('com.walmartlabs.concord.runtime.v2.runner.PersistenceService');
+
+        var w  = new persistenceServiceType.Writer() {
+          write: function(out) {
+            out.write('top-secret-value'.getBytes());
+          }
+        };
+
+        var persistenceService = context.execution().runtime().getService(persistenceServiceType)
+        persistenceService.persistSessionFile('sensitive_data.txt', w);
+
+    - form: myForm
+      fields:
+        - firstName: { type: "string?" }
+
+    - task: http
+      in:
+        method: GET
+        url: ${baseUrl}/api/v1/process/${txId}/state/snapshot/_attachments/_session_files/sensitive_data.txt
+        headers:
+          X-Concord-SessionToken: ${processInfo.sessionToken}
+      out: result
+
+    - if: ${result.statusCode != 200}
+      then:
+        - throw: "Can't load file from snapshot: ${result}"
+
+    - script: js
+      body: |
+        var persistenceServiceType = Java.type('com.walmartlabs.concord.runtime.v2.runner.PersistenceService');
+
+        var r  = new persistenceServiceType.Converter() {
+          apply: function() {
+            var String = Java.type('java.lang.String');
+            var IOUtils = Java.type('com.walmartlabs.concord.common.IOUtils');
+            var bytes = IOUtils.toByteArray(arguments[0]);
+            var result = new String(bytes);
+            return result;
+          }
+        };
+
+        var persistenceService = context.execution().runtime().getService(persistenceServiceType)
+        var topSecretValue = persistenceService.loadPersistedSessionFile('sensitive_data.txt', r);
+        context.variables().set('topSecret', topSecretValue);
+
+    - log: "Secret: ${topSecret}"

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/StateManager.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/StateManager.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -71,6 +70,10 @@ public final class StateManager {
                 .resolve(Constants.Files.JOB_STATE_DIR_NAME);
 
         IOUtils.deleteRecursively(stateDir);
+
+        Path sessionFilesDir = baseDir.resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
+                .resolve(Constants.Files.JOB_SESSION_FILES_DIR_NAME);
+        IOUtils.deleteRecursively(sessionFilesDir);
     }
 
     public static void saveResumeEvent(Path baseDir, String eventName) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultPersistenceService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultPersistenceService.java
@@ -57,6 +57,19 @@ public class DefaultPersistenceService implements PersistenceService {
         Path storeDir = workingDirectory.getValue()
                 .resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME);
 
+        persistFile(storeDir, name, writer);
+    }
+
+    @Override
+    public void persistSessionFile(String name, Writer writer) {
+        Path storeDir = workingDirectory.getValue()
+                .resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
+                .resolve(Constants.Files.JOB_SESSION_FILES_DIR_NAME);
+
+        persistFile(storeDir, name, writer);
+    }
+
+    private void persistFile(Path storeDir, String name, Writer writer) {
         try {
             if (!Files.exists(storeDir)) {
                 Files.createDirectories(storeDir);
@@ -77,6 +90,20 @@ public class DefaultPersistenceService implements PersistenceService {
                 .resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
                 .resolve(name);
 
+        return loadPersistedFile(file, name, converter);
+    }
+
+    @Override
+    public <T> T loadPersistedSessionFile(String name, Converter<InputStream, T> converter) {
+        Path file = workingDirectory.getValue()
+                .resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME)
+                .resolve(Constants.Files.JOB_SESSION_FILES_DIR_NAME)
+                .resolve(name);
+
+        return loadPersistedFile(file, name, converter);
+    }
+
+    private <T> T loadPersistedFile(Path file, String name, Converter<InputStream, T> converter) {
         try {
             if (!Files.exists(file)) {
                 return null;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PersistenceService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PersistenceService.java
@@ -33,7 +33,11 @@ public interface PersistenceService {
 
     void persistFile(String name, Writer writer);
 
+    void persistSessionFile(String name, Writer writer);
+
     <T> T loadPersistedFile (String name, Converter<InputStream, T> converter);
+
+    <T> T loadPersistedSessionFile(String name, Converter<InputStream, T> converter);
 
     interface Writer {
 

--- a/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
+++ b/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
@@ -395,6 +395,11 @@ public class Constants {
         public static final String JOB_CHECKPOINTS_DIR_NAME = "_checkpoints";
 
         /**
+         * Directory which contains job "attachments": reports, stats, etc.
+         */
+        public static final String JOB_SESSION_FILES_DIR_NAME = "_session_files";
+
+        /**
          * Directory which contains process' state.
          */
         public static final String JOB_STATE_DIR_NAME = "_state";

--- a/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
+++ b/sdk/src/main/java/com/walmartlabs/concord/sdk/Constants.java
@@ -395,7 +395,8 @@ public class Constants {
         public static final String JOB_CHECKPOINTS_DIR_NAME = "_checkpoints";
 
         /**
-         * Directory which contains job "attachments": reports, stats, etc.
+         * Directory which contains job "session files":
+         *  files that can be downloaded only with session key.
          */
         public static final String JOB_SESSION_FILES_DIR_NAME = "_session_files";
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -61,6 +61,7 @@ import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import com.walmartlabs.concord.server.security.Roles;
 import com.walmartlabs.concord.server.security.UserPrincipal;
+import com.walmartlabs.concord.server.security.sessionkey.SessionKeyPrincipal;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -662,6 +663,8 @@ public class ProcessResource implements Resource {
         }
 
         String resource = path(Constants.Files.JOB_ATTACHMENTS_DIR_NAME, attachmentName);
+        assertResourceAccess(processEntry, resource);
+
         Optional<Path> o = stateManager.get(processKey, resource, src -> {
             try {
                 Path tmp = IOUtils.createTempFile("attachment", ".bin");
@@ -860,11 +863,16 @@ public class ProcessResource implements Resource {
         ProcessEntry entry = assertProcess(PartialProcessKey.from(instanceId));
         ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
 
-        assertProcessAccess(entry, "attachments");
+        assertProcessAccess(entry, "state");
 
         StreamingOutput out = output -> {
             try (ZipArchiveOutputStream dst = new ZipArchiveOutputStream(output)) {
-                stateManager.export(processKey, zipTo(dst));
+                stateManager.export(processKey, new ProcessStateManager.FilteringConsumer(zipTo(dst), s -> {
+                    if (!isSessionResource(s)) {
+                        return true;
+                    }
+                    return isSessionKeyAccess(instanceId);
+                }));
             }
         };
 
@@ -888,6 +896,7 @@ public class ProcessResource implements Resource {
         ProcessKey processKey = new ProcessKey(p.instanceId(), p.createdAt());
 
         assertProcessAccess(p, "state");
+        assertResourceAccess(p, fileName);
 
         StreamingOutput out = output -> {
             Path tmp = stateManager.get(processKey, fileName, ProcessResource::copyToTmp)
@@ -1076,6 +1085,27 @@ public class ProcessResource implements Resource {
 
         throw new UnauthorizedException("The current user (" + principal.getUsername() + ") doesn't have " +
                 "the necessary permissions to the download " + downloadEntity + " : " + pe.instanceId());
+    }
+
+    private void assertResourceAccess(ProcessEntry pe, String resource) {
+        if (!isSessionResource(resource)) {
+            return;
+        }
+
+        if (isSessionKeyAccess(pe.instanceId())) {
+            return;
+        }
+
+        throw new UnauthorizedException("Resource accessible with session process key only");
+    }
+
+    private boolean isSessionResource(String resource) {
+        return resource.startsWith(path(Constants.Files.JOB_ATTACHMENTS_DIR_NAME, Constants.Files.JOB_SESSION_FILES_DIR_NAME));
+    }
+
+    private boolean isSessionKeyAccess(UUID instanceId) {
+        SessionKeyPrincipal principal = SessionKeyPrincipal.getCurrent();
+        return principal != null && principal.getProcessKey().getInstanceId().equals(instanceId);
     }
 
     private ProcessEntry assertProcess(PartialProcessKey processKey) {


### PR DESCRIPTION
we can save files in the process state that are only accessible with a session token.
The resource can be accessed only by using the process' session key. for example for https://github.com/walmartlabs/concord/pull/719