### PR TITLE
concord-console: fix rendering of multiple string values in process form

### DIFF
--- a/console2/src/components/molecules/DropdownWithAddition/index.tsx
+++ b/console2/src/components/molecules/DropdownWithAddition/index.tsx
@@ -18,7 +18,7 @@
  * =====
  */
 import * as React from 'react';
-import { Dropdown, DropdownProps } from 'semantic-ui-react';
+import { Dropdown, DropdownItemProps, DropdownProps } from 'semantic-ui-react';
 
 interface State {
     stateOptions: any[];
@@ -28,7 +28,7 @@ interface Props {
     name: string;
     required: boolean;
     value?: any;
-    options: any[];
+    options: DropdownItemProps[];
     multiple: boolean;
     allowAdditions: boolean;
     submitting?: boolean;
@@ -36,14 +36,14 @@ interface Props {
     onChange: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void;
 }
 
-const toState = (options: any[]): State => {
+const toState = (value: any[], options: DropdownItemProps[]): State => {
     return { stateOptions: options };
 };
 
 class DropdownWithAddition extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
-        this.state = toState(this.props.options);
+        this.state = toState(props.value, this.props.options);
 
         this.handleAddition = this.handleAddition.bind(this);
     }

--- a/console2/src/components/molecules/ProcessForm/index.tsx
+++ b/console2/src/components/molecules/ProcessForm/index.tsx
@@ -25,7 +25,7 @@ import { DateInput, DateTimeInput } from 'semantic-ui-calendar-react';
 import {
     Button,
     Checkbox,
-    CheckboxProps,
+    CheckboxProps, DropdownItemProps,
     DropdownProps,
     Form,
     Header,
@@ -196,18 +196,12 @@ class ProcessForm extends React.Component<Props, State> {
     renderDropdown(
         name: string,
         cardinality: Cardinality,
-        value: DropdownValue,
+        value: DropdownValue | DropdownValue[],
         allowedValue: DropdownAllowedValue,
         multiple: boolean,
         opts?: {}
     ) {
         const { submitting, completed } = this.props;
-
-        const options = allowedValue ? allowedValue.map((v) => ({ text: v, value: v })) : [];
-        const required =
-            cardinality === Cardinality.AT_LEAST_ONE ||
-            cardinality === Cardinality.ONE_AND_ONLY_ONE;
-        const allowAdditions = options.length === 0;
 
         if (value === null) {
             value = undefined;
@@ -216,6 +210,13 @@ class ProcessForm extends React.Component<Props, State> {
         if (multiple && value === undefined) {
             value = [];
         }
+
+        const allowedOptions: DropdownItemProps[] = this.toOpts(allowedValue);
+        const options: DropdownItemProps[] = allowedOptions.length > 0 ? allowedOptions : this.toOpts(value);
+        const required =
+            cardinality === Cardinality.AT_LEAST_ONE ||
+            cardinality === Cardinality.ONE_AND_ONLY_ONE;
+        const allowAdditions = allowedOptions.length === 0;
 
         return (
             <DropdownWithAddition
@@ -231,6 +232,18 @@ class ProcessForm extends React.Component<Props, State> {
                 {...opts}
             />
         );
+    }
+
+    toOpts(val: DropdownValue | DropdownValue[]) : DropdownItemProps[]  {
+        if (val === undefined) {
+            return [];
+        }
+
+        if (Array.isArray(val)) {
+            return val.map((v: DropdownValue) => ({text: v, value: v} as DropdownItemProps));
+        }
+
+        return [ { text: val, value: val } ]
     }
 
     renderStringField(

--- a/it/console/src/test/java/com/walmartlabs/concord/it/console/FormsIT.java
+++ b/it/console/src/test/java/com/walmartlabs/concord/it/console/FormsIT.java
@@ -20,15 +20,17 @@ package com.walmartlabs.concord.it.console;
  * =====
  */
 
-import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.ProcessEntry;
 import com.walmartlabs.concord.client.StartProcessResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,10 +39,10 @@ import java.util.concurrent.TimeUnit;
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.*;
 import static com.walmartlabs.concord.it.console.Utils.DEFAULT_TEST_TIMEOUT;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Timeout(value = DEFAULT_TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
-public class FormsIT {
+class FormsIT {
 
     @RegisterExtension
     public static ConcordServerRule serverRule = new ConcordServerRule();
@@ -48,21 +50,16 @@ public class FormsIT {
     @RegisterExtension
     public static ConcordConsoleRule consoleRule = new ConcordConsoleRule();
 
+    private ProcessApi processApi;
+
+    @BeforeEach
+    void setup() {
+        processApi = new ProcessApi(serverRule.getClient());
+    }
+
     @Test
-    public void testDateTimeField() throws Exception {
-        ApiClient apiClient = serverRule.getClient();
-
-        // ---
-
-        byte[] payload = archive(FormsIT.class.getResource("dateTimeField").toURI());
-        Map<String, Object> input = new HashMap<>();
-        input.put("archive", payload);
-
-        ProcessApi processApi = new ProcessApi(apiClient);
-        StartProcessResponse spr = serverRule.start(input);
-        assertNotNull(spr.getInstanceId());
-
-        ProcessEntry pir = waitForStatus(processApi, spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
+    void testDateTimeField() throws Exception {
+        ProcessEntry pir = startConsoleProcess("dateTimeField");
 
         // ---
 
@@ -95,5 +92,83 @@ public class FormsIT {
         byte[] ab = serverRule.getLog(pir.getLogFileName());
         assertLog(".*dateField=2019-09-04.*", ab);
         assertLog(".*dateTimeField=2019-09-04T05:05:00.000Z.*", ab);
+    }
+
+    @Test
+    void testStringValues() throws Exception {
+        ProcessEntry pir = startConsoleProcess("stringValues");
+
+        // ---
+
+        consoleRule.login(Concord.ADMIN_API_KEY);
+
+        String url = "/#/process/" + pir.getInstanceId();
+        consoleRule.navigateToRelative(url);
+
+        WebElement wizardButton = consoleRule.waitFor(By.id("formWizardButton"));
+        wizardButton.click();
+
+        consoleRule.waitFor(By.name("field0")).click();
+        new Actions(consoleRule.getDriver()) // first option is selected on open
+                .sendKeys(Keys.DOWN)
+                .sendKeys(Keys.ENTER) // select "second" value
+                .sendKeys(Keys.ENTER) // select "third" value
+                .sendKeys(Keys.ESCAPE)
+                .perform();
+
+        consoleRule.waitFor(By.name("field1")).click();
+        new Actions(consoleRule.getDriver())
+                .sendKeys(Keys.ENTER) // select "third" value
+                .sendKeys(Keys.ESCAPE)
+                .perform();
+
+        consoleRule.waitFor(By.name("field2")).click();
+        new Actions(consoleRule.getDriver())
+                .sendKeys(Keys.BACK_SPACE) // remove "second" value
+                .sendKeys("third")         // add "third" value
+                .sendKeys(Keys.ENTER)
+                .sendKeys("fourth")        // add "fourth" value
+                .sendKeys(Keys.ENTER)
+                .sendKeys(Keys.ESCAPE)
+                .perform();
+
+        consoleRule.waitFor(By.name("field3")).click();
+        new Actions(consoleRule.getDriver())
+                .sendKeys("hello")    // add two strings
+                .sendKeys(Keys.ENTER)
+                .sendKeys("world")
+                .sendKeys(Keys.ENTER)
+                .sendKeys(Keys.ESCAPE)
+                .perform();
+
+        consoleRule.waitFor(By.name("field4")).click();
+        new Actions(consoleRule.getDriver())
+                .sendKeys("single string")
+                .perform();
+
+        WebElement submitButton = consoleRule.waitFor(By.id("formSubmitButton"));
+        submitButton.click();
+
+        // ---
+
+        pir = waitForCompletion(processApi, pir.getInstanceId());
+
+        byte[] ab = serverRule.getLog(pir.getLogFileName());
+        assertLog(".*\"field0\" : \\[ \"second\", \"third\" ].*", ab);
+        assertLog(".*\"field1\" : \\[ \"first\", \"second\", \"third\" ].*", ab);
+        assertLog(".*\"field2\" : \\[ \"first\", \"third\", \"fourth\" ].*", ab);
+        assertLog(".*\"field3\" : \\[ \"hello\", \"world\" ].*", ab);
+        assertLog(".*\"field4\" : \"single string\".*", ab);
+    }
+
+    private ProcessEntry startConsoleProcess(String res) throws Exception {
+        byte[] payload = archive(FormsIT.class.getResource(res).toURI());
+        Map<String, Object> input = new HashMap<>();
+        input.put("archive", payload);
+
+        StartProcessResponse spr = serverRule.start(input);
+        assertNotNull(spr.getInstanceId());
+
+        return waitForStatus(processApi, spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
     }
 }

--- a/it/console/src/test/resources/com/walmartlabs/concord/it/console/stringValues/concord.yml
+++ b/it/console/src/test/resources/com/walmartlabs/concord/it/console/stringValues/concord.yml
@@ -1,0 +1,13 @@
+flows:
+  default:
+    - set:
+        defaults: [ "first", "second" ]
+
+    - form: myForm
+      fields:
+        - field0: { label: "field0", type: "string*", allow: ["first", "second", "third"] }
+        - field1: { label: "field1", type: "string*", value: "${defaults}", allow: ["first", "second", "third"] }
+        - field2: { label: "field2", type: "string+", value: "${defaults}" }
+        - field3: { label: "field3", type: "string*" }
+        - field4: { label: "field4", type: "string" }
+    - log: "${resource.prettyPrintJson(myForm)}"


### PR DESCRIPTION
Currently, if a form field is defined with a list of values, they are not displayed. However, they _are_ submitted which is pretty confusing. e.g. a form defined as
```yaml
- form: myForm
  fields:
  - aField: { label: "the-label", type: "string+", value: [ "first", "second" ] }
```
will not show `first` and `second` when loaded. If the user adds another option and submits the form, the submitted value is actually `[ "first", "second", "third" ]`
