### PR TITLE
runtime-v2, cli: hide stack trace for user defined exception from parallel block

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +101,20 @@ public class Main {
             main.execute();
 
             System.exit(0);
-        } catch (MultiException | UserDefinedException e) {
+        } catch (UserDefinedException e) {
             log.error(e.getMessage());
+            System.exit(1);
+        } catch (MultiException e) {
+            StringBuilder msg = new StringBuilder();
+            for (Exception c : e.getCauses()) {
+                if (c instanceof UserDefinedException) {
+                    msg.append(c.getMessage());
+                } else {
+                    msg.append(MultiException.stacktraceToString(c));
+                }
+                msg.append("\n");
+            }
+            log.error("Errors: {}", msg);
             System.exit(1);
         } catch (Throwable t) {
             log.error("", t);

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ import com.walmartlabs.concord.runtime.v2.runner.logging.LoggerProvider;
 import com.walmartlabs.concord.runtime.v2.runner.logging.LoggingClient;
 import com.walmartlabs.concord.runtime.v2.runner.logging.LoggingConfigurator;
 import com.walmartlabs.concord.runtime.v2.runner.logging.RunnerLogger;
-import com.walmartlabs.concord.runtime.v2.runner.remote.EventRecordingExecutionListener;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallListener;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallPolicyChecker;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskResultListener;

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/MultiException.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/MultiException.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.svm;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class MultiException extends RuntimeException {
                 .collect(Collectors.joining("\n"));
     }
 
-    private static String stacktraceToString(Exception e) {
+    public static String stacktraceToString(Exception e) {
         StringWriter sw = new StringWriter();
         e.printStackTrace(new PrintWriter(sw));
         return sw.toString();


### PR DESCRIPTION
stacktraces for UserDefinedException is useless:)