### PR TITLE
runtime-v2: hide stacktrace for peropertyNotFound exception, better error message

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/LazyExpressionEvaluator.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/LazyExpressionEvaluator.java
@@ -148,7 +148,7 @@ public class LazyExpressionEvaluator implements ExpressionEvaluator {
 
             String propName = propertyNameFromException(e);
             if (propName != null) {
-                errorMessage = String.format("Can't find variable %s in '%s'. " +
+                errorMessage = String.format("Can't find a variable %s used in '%s'. " +
                         "Check if it is defined in the current scope. Details: %s", propName, expr, e.getMessage());
             } else {
                 errorMessage = String.format("Can't find the specified variable in '%s'. " +

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluatorTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluatorTest.java
@@ -73,7 +73,7 @@ public class ExpressionEvaluatorTest {
             ee.eval(ctx, "Hello ${name}", String.class);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable 'name' in 'Hello ${name}'"));
+            assertThat(e.getMessage(), containsString("variable 'name' used in 'Hello ${name}'"));
         }
 
         // undef as null
@@ -155,7 +155,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' used in '${y}'"));
         }
 
         // undef -> x = null, z = null, y ...y3 = null
@@ -183,7 +183,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' used in '${y}'"));
         }
 
         // scope
@@ -192,7 +192,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(scope(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable 'x' in '${x}'"));
+            assertThat(e.getMessage(), containsString("variable 'x' used in '${x}'"));
         }
     }
 
@@ -229,7 +229,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' used in '${y}'"));
         }
 
         verify(task, times(0)).foo(anyString());
@@ -298,7 +298,7 @@ public class ExpressionEvaluatorTest {
         try {
             ee.evalAsMap(scope(vars), input);
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable 'y1' in '${y1}'"));
+            assertThat(e.getMessage(), containsString("variable 'y1' used in '${y1}'"));
         }
     }
 

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluatorTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/ExpressionEvaluatorTest.java
@@ -73,7 +73,7 @@ public class ExpressionEvaluatorTest {
             ee.eval(ctx, "Hello ${name}", String.class);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable in 'Hello ${name}'"));
+            assertThat(e.getMessage(), containsString("variable 'name' in 'Hello ${name}'"));
         }
 
         // undef as null
@@ -155,7 +155,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
         }
 
         // undef -> x = null, z = null, y ...y3 = null
@@ -183,7 +183,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
         }
 
         // scope
@@ -192,7 +192,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(scope(vars), input);
             fail("exception expected");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("variable in '${x}'"));
+            assertThat(e.getMessage(), containsString("variable 'x' in '${x}'"));
         }
     }
 
@@ -229,7 +229,7 @@ public class ExpressionEvaluatorTest {
             ee.evalAsMap(global(vars), input);
             fail("exception expected");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("variable in '${y}'"));
+            assertThat(e.getMessage(), containsString("variable 'y' in '${y}'"));
         }
 
         verify(task, times(0)).foo(anyString());
@@ -298,7 +298,7 @@ public class ExpressionEvaluatorTest {
         try {
             ee.evalAsMap(scope(vars), input);
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("Can't find the specified variable in '${y1}'"));
+            assertThat(e.getMessage(), containsString("variable 'y1' in '${y1}'"));
         }
     }
 


### PR DESCRIPTION
before:
```
Can't find the specified variable in 'BOOM ${abc}'. Check if it is defined in the current scope. Details: ELResolver cannot handle a null base Object with identifier 'abc'
```
after:
```
Can't find variable 'abc' in 'BOOM ${abc}'. Check if it is defined in the current scope. Details: ELResolver cannot handle a null base Object with identifier 'abc'
```