### PR TITLE
runtime-v2: log call stack on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## [1.102.0] - Unreleased
+## [1.102.0] - 2023-05-22
 
 ### Added
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
@@ -1,0 +1,79 @@
+package com.walmartlabs.concord.runtime.v2.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.model.FlowCall;
+import com.walmartlabs.concord.runtime.v2.model.Location;
+import com.walmartlabs.concord.runtime.v2.runner.vm.FlowCallCommand;
+import com.walmartlabs.concord.svm.Runtime;
+import com.walmartlabs.concord.svm.*;
+
+public class StackTraceCollector implements ExecutionListener {
+
+    @Override
+    public Result afterCommand(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
+        if (cmd instanceof FlowCallCommand) {
+            FlowCallCommand fcc = (FlowCallCommand)cmd;
+            FlowCall step = fcc.getStep();
+            String flowName = fcc.getFlowName();
+            if (flowName == null) {
+                flowName = step.getFlowName();
+            }
+            Location location = step.getLocation();
+            FrameId frameId = state.peekFrame(threadId).id();
+            state.pushStackTraceItem(threadId, new StackTraceItem(frameId, threadId, location.fileName(), flowName, location.lineNum(), location.column()));
+            return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
+        }
+
+        Frame frame = state.peekFrame(threadId);
+        if (frame == null) {
+            state.clearStackTrace(threadId);
+            return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
+        }
+
+        if (frame.peek() == null) {
+            state.getStackTrace(threadId).stream()
+                    .filter(i -> i.getFrameId() != null)
+                    .filter(i -> i.getFrameId().equals(frame.id()))
+                    .reduce((first, second) -> second)
+                    .ifPresent(item -> popStackTraceTill(state, threadId, item));
+        }
+
+        return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
+    }
+
+    private void popStackTraceTill(State state, ThreadId threadId, StackTraceItem marker) {
+        while (true) {
+            StackTraceItem item = state.popStackTraceItem(threadId);
+            if (item == null) {
+                return;
+            }
+            if (item == marker) {
+                return;
+            }
+        }
+    }
+
+//    @Override
+//    public Result onCommandError(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
+        // clean stacktrace till exception handler (marker in before command for errorWrapper command);
+//    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
@@ -31,7 +31,7 @@ public class StackTraceCollector implements ExecutionListener {
     @Override
     public Result afterCommand(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
         if (cmd instanceof FlowCallCommand) {
-            FlowCallCommand fcc = (FlowCallCommand)cmd;
+            FlowCallCommand fcc = (FlowCallCommand) cmd;
             FlowCall step = fcc.getStep();
             String flowName = fcc.getFlowName();
             if (flowName == null) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
@@ -50,26 +50,6 @@ public class StackTraceCollector implements ExecutionListener {
             return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
         }
 
-        if (frame.peek() == null) {
-            state.getStackTrace(threadId).stream()
-                    .filter(i -> i.getFrameId() != null)
-                    .filter(i -> i.getFrameId().equals(frame.id()))
-                    .reduce((first, second) -> second)
-                    .ifPresent(item -> popStackTraceTill(state, threadId, item));
-        }
-
         return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
-    }
-
-    private void popStackTraceTill(State state, ThreadId threadId, StackTraceItem marker) {
-        while (true) {
-            StackTraceItem item = state.popStackTraceItem(threadId);
-            if (item == null) {
-                return;
-            }
-            if (item == marker) {
-                return;
-            }
-        }
     }
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
@@ -71,9 +71,4 @@ public class StackTraceCollector implements ExecutionListener {
             }
         }
     }
-
-//    @Override
-//    public Result onCommandError(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
-        // clean stacktrace till exception handler (marker in before command for errorWrapper command);
-//    }
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/StackTraceCollector.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.runtime.v2.runner;
 import com.walmartlabs.concord.runtime.v2.model.FlowCall;
 import com.walmartlabs.concord.runtime.v2.model.Location;
 import com.walmartlabs.concord.runtime.v2.runner.vm.FlowCallCommand;
+import com.walmartlabs.concord.runtime.v2.runner.vm.VMUtils;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.*;
 
@@ -33,7 +34,7 @@ public class StackTraceCollector implements ExecutionListener {
         if (cmd instanceof FlowCallCommand) {
             FlowCallCommand fcc = (FlowCallCommand) cmd;
             FlowCall step = fcc.getStep();
-            String flowName = fcc.getFlowName();
+            String flowName = VMUtils.getLocal(state, threadId, "flowName");
             if (flowName == null) {
                 flowName = step.getFlowName();
             }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.runner.guice;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
@@ -75,5 +75,6 @@ public class DefaultRunnerModule extends AbstractModule {
         executionListeners.addBinding().to(MetadataProcessor.class);
         executionListeners.addBinding().to(OutVariablesProcessor.class);
         executionListeners.addBinding().to(SensitiveDataPersistenceService.class);
+        executionListeners.addBinding().to(StackTraceCollector.class);
     }
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
@@ -43,6 +43,8 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
 
     private static final long serialVersionUID = 1L;
 
+    private String flowName;
+
     public FlowCallCommand(FlowCall step) {
         super(step);
     }
@@ -60,7 +62,7 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         FlowCall call = getStep();
 
         // the called flow's name
-        String flowName = ee.eval(evalCtx, call.getFlowName(), String.class);
+        flowName = ee.eval(evalCtx, call.getFlowName(), String.class);
 
         // the called flow's steps
         Compiler compiler = runtime.getService(Compiler.class);
@@ -93,6 +95,10 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         // push the out handler first so it executes after the called flow's frame is done
         state.peekFrame(threadId).push(processOutVars);
         state.pushFrame(threadId, innerFrame);
+    }
+
+    public String getFlowName() {
+        return flowName;
     }
 
     private static class EvalVariablesCommand implements Command {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FlowCallCommand.java
@@ -43,8 +43,6 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
 
     private static final long serialVersionUID = 1L;
 
-    private String flowName;
-
     public FlowCallCommand(FlowCall step) {
         super(step);
     }
@@ -62,7 +60,7 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         FlowCall call = getStep();
 
         // the called flow's name
-        flowName = ee.eval(evalCtx, call.getFlowName(), String.class);
+        String flowName = ee.eval(evalCtx, call.getFlowName(), String.class);
 
         // the called flow's steps
         Compiler compiler = runtime.getService(Compiler.class);
@@ -95,10 +93,7 @@ public class FlowCallCommand extends StepCommand<FlowCall> {
         // push the out handler first so it executes after the called flow's frame is done
         state.peekFrame(threadId).push(processOutVars);
         state.pushFrame(threadId, innerFrame);
-    }
-
-    public String getFlowName() {
-        return flowName;
+        VMUtils.putLocal(innerFrame, "flowName", flowName);
     }
 
     private static class EvalVariablesCommand implements Command {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
@@ -31,14 +31,14 @@ import com.walmartlabs.concord.runtime.v2.runner.logging.RunnerLogger;
 import com.walmartlabs.concord.runtime.v2.runner.logging.SegmentedLogger;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.ContextProvider;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
-import com.walmartlabs.concord.svm.Command;
+import com.walmartlabs.concord.svm.*;
 import com.walmartlabs.concord.svm.Runtime;
-import com.walmartlabs.concord.svm.State;
-import com.walmartlabs.concord.svm.ThreadId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Base class for commands that were created from a flow {@link Step}.
@@ -107,6 +107,10 @@ public abstract class StepCommand<T extends Step> implements Command {
                 }
 
                 log.error("{} {}", Location.toErrorPrefix(step.getLocation()), e.getMessage());
+                List<StackTraceItem> stackTrace = state.getStackTrace(threadId);
+                if (!stackTrace.isEmpty()) {
+                    log.error("Call stack:\n{}", stackTrace.stream().map(StackTraceItem::toString).collect(Collectors.joining("\n")));
+                }
                 throw e;
             }
         });

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.runner.vm;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -250,8 +250,13 @@ public class MainTest {
             // ignore
         }
         assertLog(lastLog, ".*" + Pattern.quote("in flowA") + ".*");
-        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 13, col: 7, thread: 2, flow: flowB") + ".*");
-        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 3, col: 7, thread: 2, flow: flowA") + ".*");
+
+        String expected = "Call stack:\n" +
+                "(concord.yml) @ line: 13, col: 7, thread: 2, flow: flowB\n" +
+                "(concord.yml) @ line: 3, col: 7, thread: 2, flow: flowA";
+
+        String logString = new String(lastLog);
+        assertTrue(logString.contains(expected), "expected log contains: " + expected + ", actual: " + logString);
     }
 
     @Test
@@ -268,16 +273,75 @@ public class MainTest {
             // ignore
         }
 
-        String expected = "(concord.yml) @ line: 8, col: 7, thread: 0, flow: flowB\n" +
+        String expected = "Call stack:\n" +
+                "(concord.yml) @ line: 8, col: 7, thread: 0, flow: flowB\n" +
                 "(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA";
 
-        String expected1 = "(concord.yml) @ line: 16, col: 11, thread: 0, flow: flowThrow\n" +
+        String expected1 = "Call stack:\n" +
+                "(concord.yml) @ line: 16, col: 11, thread: 0, flow: flowThrow\n" +
                 "(concord.yml) @ line: 8, col: 7, thread: 0, flow: flowB\n" +
                 "(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA";
 
         String logString = new String(lastLog);
         assertTrue(logString.contains(expected), "expected log contains: " + expected + ", actual: " + logString);
         assertTrue(logString.contains(expected1), "expected log contains: " + expected1 + ", actual: " + logString);
+    }
+
+    @Test
+    public void testStackTrace5() throws Exception {
+        deploy("stackTrace5");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+
+        String expected = "Call stack:\n" +
+                "(concord.yml) @ line: 21, col: 7, thread: 4, flow: flowC\n" +
+                "(concord.yml) @ line: 11, col: 11, thread: 2, flow: flowB\n" +
+                "(concord.yml) @ line: 6, col: 7, thread: 0, flow: flowA\n" +
+                "(concord.yml) @ line: 3, col: 7, thread: 0, flow: flow0";
+
+        String logString = new String(lastLog);
+        assertTrue(logString.contains(expected), "expected log contains: " + expected + ", actual: " + logString);
+    }
+
+    @Test
+    public void testStackTrace6() throws Exception {
+        deploy("stackTrace6");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+
+        assertNoLog(lastLog, ".*" + Pattern.quote("[ERROR] Call stack:") + ".*");
+    }
+
+    @Test
+    public void testStackTrace7() throws Exception {
+        deploy("stackTrace7");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+        assertNoLog(lastLog, ".*" + Pattern.quote("[ERROR] Call stack:") + ".*");
     }
 
     @Test

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -227,6 +227,32 @@ public class MainTest {
     }
 
     @Test
+    public void testStackTrace4() throws Exception {
+        deploy("stackTrace4");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+
+        String expected = "(concord.yml) @ line: 8, col: 7, thread: 0, flow: flowB\n" +
+                "(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA";
+
+        String expected1 = "(concord.yml) @ line: 16, col: 11, thread: 0, flow: flowThrow\n" +
+                "(concord.yml) @ line: 8, col: 7, thread: 0, flow: flowB\n" +
+                "(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA";
+
+        String logString = new String(lastLog);
+        assertTrue(logString.contains(expected), "expected log contains: " + expected + ", actual: " + logString);
+        assertTrue(logString.contains(expected1), "expected log contains: " + expected1 + ", actual: " + logString);
+    }
+
+    @Test
     public void testForm() throws Exception {
         deploy("form");
 

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -50,7 +50,6 @@ import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallPolicyChecker;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskResultListener;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskV2Provider;
 import com.walmartlabs.concord.runtime.v2.runner.vm.BlockCommand;
-import com.walmartlabs.concord.runtime.v2.runner.vm.ForkCommand;
 import com.walmartlabs.concord.runtime.v2.runner.vm.ParallelCommand;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.sdk.Constants;
@@ -1821,7 +1820,7 @@ public class MainTest {
 
     @Named("injectorTestTask")
     static class InjectorTestTask implements Task {
-f
+
         private final Map<String, InjectorTestBean> testBeans;
 
         @Inject

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -141,6 +141,7 @@ public class MainTest {
                         SensitiveDataHolder.getInstance().get().clear();
                     }
                 });
+                executionListeners.addBinding().to(StackTraceCollector.class);
             }
         };
 
@@ -170,6 +171,59 @@ public class MainTest {
         assertLog(log, ".*" + Pattern.quote("defaultsMap:{a=a-value}") + ".*");
 
         verify(processStatusCallback, times(1)).onRunning(instanceId);
+    }
+
+    @Test
+    public void testStackTrace() throws Exception {
+        deploy("stackTrace");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 9, col: 7, thread: 0, flow: flowB") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA") + ".*");
+    }
+
+    @Test
+    public void testStackTrace2() throws Exception {
+        deploy("stackTrace2");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 10, col: 7, thread: 1, flow: flowB") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 4, col: 11, thread: 1, flow: flowA") + ".*");
+
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 5, col: 11, thread: 2, flow: flowB") + ".*");
+    }
+
+    @Test
+    public void testStackTrace3() throws Exception {
+        deploy("stackTrace3");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        try {
+            run();
+            fail("must fail");
+        } catch (Exception e) {
+            // ignore
+        }
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 12, col: 7, thread: 0, flow: flowB") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA") + ".*");
     }
 
     @Test

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -249,8 +249,9 @@ public class MainTest {
         } catch (Exception e) {
             // ignore
         }
-        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 12, col: 7, thread: 0, flow: flowB") + ".*");
-        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 3, col: 7, thread: 0, flow: flowA") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("in flowA") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 13, col: 7, thread: 2, flow: flowB") + ".*");
+        assertLog(lastLog, ".*" + Pattern.quote("(concord.yml) @ line: 3, col: 7, thread: 2, flow: flowA") + ".*");
     }
 
     @Test

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
@@ -152,11 +152,6 @@ public class SingleFrameContext extends DummyContext {
                     }
 
                     @Override
-                    public StackTraceItem popStackTraceItem(ThreadId threadId) {
-                        throw new IllegalStateException("Not implemented");
-                    }
-
-                    @Override
                     public void pushStackTraceItem(ThreadId threadId, StackTraceItem item) {
                         throw new IllegalStateException("Not implemented");
                     }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
@@ -147,6 +147,26 @@ public class SingleFrameContext extends DummyContext {
                     }
 
                     @Override
+                    public List<StackTraceItem> getStackTrace(ThreadId threadId) {
+                        throw new IllegalStateException("Not implemented");
+                    }
+
+                    @Override
+                    public StackTraceItem popStackTraceItem(ThreadId threadId) {
+                        throw new IllegalStateException("Not implemented");
+                    }
+
+                    @Override
+                    public void pushStackTraceItem(ThreadId threadId, StackTraceItem item) {
+                        throw new IllegalStateException("Not implemented");
+                    }
+
+                    @Override
+                    public void clearStackTrace(ThreadId threadId) {
+                        throw new IllegalStateException("Not implemented");
+                    }
+
+                    @Override
                     public void gc() {
                         throw new IllegalStateException("Not implemented");
                     }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/el/SingleFrameContext.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.runner.el;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace/concord.yml
@@ -1,0 +1,18 @@
+flows:
+  default:
+    - call: flowA
+    - log: "end"
+
+  flowA:
+    - log: "in flowA"
+
+    - call: "flowB"
+
+  flowB:
+    - log: "in flowB"
+    - call: flowC
+    - throw: "boom"
+    - log: "end flow C"
+
+  flowC:
+    - log: "in flowC"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace2/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace2/concord.yml
@@ -1,0 +1,19 @@
+flows:
+  default:
+    - parallel:
+        - call: "flowA"
+        - call: "flowB"
+
+  flowA:
+    - log: "in flowA"
+
+    - call: "flowB"
+
+  flowB:
+    - log: "in flowB"
+    - call: flowC
+    - throw: "boom"
+    - log: "end flow C"
+
+  flowC:
+    - log: "in flowC"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace3/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace3/concord.yml
@@ -5,6 +5,7 @@ flows:
         items:
           - "flowC"
           - "flowA"
+        mode: parallel
 
   flowA:
     - log: "in flowA"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace3/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace3/concord.yml
@@ -1,0 +1,21 @@
+flows:
+  default:
+    - call: "${item}"
+      loop:
+        items:
+          - "flowC"
+          - "flowA"
+
+  flowA:
+    - log: "in flowA"
+
+    - call: "flowB"
+
+  flowB:
+    - log: "in flowB"
+    - call: flowC
+    - throw: "boom"
+    - log: "end flow C"
+
+  flowC:
+    - log: "in flowC"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace4/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace4/concord.yml
@@ -1,0 +1,24 @@
+flows:
+  default:
+    - call: flowA
+
+  flowA:
+    - log: "in flowA"
+
+    - call: "flowB"
+
+  flowB:
+    - log: "in flowB"
+    - call: flowC
+    - try:
+      - throw: "boom"
+      error:
+        - call: flowThrow
+        - log: "error"
+    - log: "end flow B"
+
+  flowC:
+    - log: "in flowC"
+
+  flowThrow:
+    - throw: "boom"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace5/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace5/concord.yml
@@ -1,0 +1,35 @@
+flows:
+  default:
+    - call: flow0
+
+  flow0:
+    - call: flowA
+
+  flowA:
+    - log: "in A"
+    - try:
+        - call: flowB
+          in:
+            flowBInput: ${item}
+      loop:
+        items:
+          - first
+          - second
+        mode: parallel
+
+  flowB:
+    - call: flowC
+      in:
+        sa: ${flowBInput}-${item}
+      loop:
+        items:
+          - first
+          - second
+        mode: parallel
+
+  flowC:
+    - log: "in C"
+    - log: ${item}
+    - if: ${sa == 'second-second'}
+      then:
+        - throw: "BOOM"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace6/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace6/concord.yml
@@ -1,0 +1,10 @@
+flows:
+  default:
+    - call: "flowA"
+    - throw: "qweq"
+
+  flowA:
+    - try:
+      - log: "flowA"
+      error:
+        - log: "ignore"

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace7/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/stackTrace7/concord.yml
@@ -1,0 +1,7 @@
+flows:
+  default:
+    - call: "flowA"
+    - throw: "qweq"
+
+  flowA:
+    - return

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.svm;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/Frame.java
@@ -40,6 +40,7 @@ public class Frame implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private final FrameId id;
     private final FrameType type;
     private final List<Command> commandStack;
     private final Map<String, Serializable> locals;
@@ -47,6 +48,7 @@ public class Frame implements Serializable {
     private Command exceptionHandler;
 
     private Frame(Builder b) {
+        this.id = new FrameId(UUID.randomUUID());
         this.type = b.type;
 
         this.commandStack = new LinkedList<>();
@@ -59,6 +61,10 @@ public class Frame implements Serializable {
         this.locals = Collections.synchronizedMap(new LinkedHashMap<>(b.locals != null ? b.locals : Collections.emptyMap()));
 
         this.exceptionHandler = b.exceptionHandler;
+    }
+
+    public FrameId id() {
+        return id;
     }
 
     public Command peek() {

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/FrameId.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/FrameId.java
@@ -1,0 +1,54 @@
+package com.walmartlabs.concord.svm;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+public class FrameId implements Serializable, Comparable<FrameId> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final UUID id;
+
+    public FrameId(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FrameId frameId = (FrameId) o;
+        return Objects.equals(id, frameId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public int compareTo(FrameId o) {
+        return id.compareTo(o.id);
+    }
+}

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.svm;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/StackTraceItem.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/StackTraceItem.java
@@ -1,0 +1,87 @@
+package com.walmartlabs.concord.svm;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.Serializable;
+
+public class StackTraceItem implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final FrameId frameId;
+
+    private final ThreadId threadId;
+
+    private final String fileName;
+
+    private final String flowName;
+
+    private final int lineNumber;
+
+    private final int columnNumber;
+
+    public StackTraceItem(FrameId frameId, ThreadId threadId, String fileName, String flowName, int lineNumber, int columnNumber) {
+        this.frameId = frameId;
+        this.threadId = threadId;
+        this.fileName = fileName;
+        this.flowName = flowName;
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
+    public FrameId getFrameId() {
+        return frameId;
+    }
+
+    public ThreadId getThreadId() {
+        return threadId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getFlowName() {
+        return flowName;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(%s) @ line: %d, col: %d, thread: %s, flow: %s",
+                nullToNa(fileName), lineNumber, columnNumber, threadId.id(), flowName);
+    }
+
+    private static String nullToNa(String value) {
+        if (value == null) {
+            return "n/a";
+        }
+        return value;
+    }
+
+}

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
@@ -121,11 +121,6 @@ public interface State extends Serializable {
     List<StackTraceItem> getStackTrace(ThreadId threadId);
 
     /**
-     * Removes the current stack trace element of the specified thread.
-     */
-    StackTraceItem popStackTraceItem(ThreadId threadId);
-
-    /**
      * Adds a stack trace item to the specified thread.
      */
     void pushStackTraceItem(ThreadId threadId, StackTraceItem item);

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.svm;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2023 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/State.java
@@ -116,6 +116,26 @@ public interface State extends Serializable {
     Exception clearThreadError(ThreadId threadId);
 
     /**
+     * Returns call stack trace for thread id.
+     */
+    List<StackTraceItem> getStackTrace(ThreadId threadId);
+
+    /**
+     * Removes the current stack trace element of the specified thread.
+     */
+    StackTraceItem popStackTraceItem(ThreadId threadId);
+
+    /**
+     * Adds a stack trace item to the specified thread.
+     */
+    void pushStackTraceItem(ThreadId threadId, StackTraceItem item);
+
+    /**
+     * Clears stack trace for the specific thread.
+     */
+    void clearStackTrace(ThreadId threadId);
+
+    /**
      * Performs state maintenance and cleanup.
      */
     void gc();


### PR DESCRIPTION
example logs:
```
14:38:08 [ERROR] (concord.yml): Error @ line: 20, col: 7. boom
14:38:08 [ERROR] Call stack:
(concord.yml) @ line: 15, col: 7, thread: 0, flow: flowB
(concord.yml) @ line: 6, col: 7, thread: 0, flow: flowA
```

I think we can remove column number from error messages, it's a bit useless. wdyt?