### PR TITLE
concord-cli: add no-default-cfg option

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -122,6 +122,9 @@ public class Run implements Callable<Integer> {
     @Option(names = {"--default-import-version"}, description = "default import version or repo branch")
     String defaultVersion = "main";
 
+    @Option(names = {"--no-default-cfg"}, description = "Do not load default configuration (including standard dependencies)")
+    boolean noDefaultCfg = false;
+
     @Parameters(arity = "0..1", description = "Directory with Concord files or a path to a single Concord YAML file.")
     Path sourceDir = Paths.get(System.getProperty("user.dir"));
 
@@ -154,7 +157,9 @@ public class Run implements Callable<Integer> {
             throw new IllegalArgumentException("Not a directory or single Concord YAML file: " + sourceDir);
         }
 
-        copyDefaultCfg(targetDir, defaultCfg, verbosity.verbose());
+        if (!noDefaultCfg) {
+            copyDefaultCfg(targetDir, defaultCfg, verbosity.verbose());
+        }
 
         DependencyManager dependencyManager = initDependencyManager();
         ImportManager importManager = new ImportManagerFactory(dependencyManager,

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -86,7 +86,7 @@ public class Main {
     public static void main(String[] args) throws Exception {
         RunnerConfiguration runnerCfg = readRunnerConfiguration(args);
 
-        // create the inject with all dependencies and services available before
+        // create the injector with all dependencies and services available before
         // the actual process' working directory is ready. It allows us to load
         // all dependencies and have them available in "pre-fork" situations
         Injector injector = InjectorFactory.createDefault(runnerCfg);


### PR DESCRIPTION
```
concord run --no-default-cfg
```

Skips the defaultCfg.yml (i.e. the default `dependencies`).