### PR TITLE
docker-images: fix build for debian 12 based images

### DIFF
--- a/docker-images/ansible/oss/debian/Dockerfile
+++ b/docker-images/ansible/oss/debian/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH=/usr/local/bin/concord_venv/bin:${PATH}
 ENV VIRTUAL_ENV=/usr/local/bin/concord_venv
 
 RUN umask 0022 && \
-    pip3 install --no-cache-dir --upgrade --ignore-installed \
+    pip3 install --no-cache-dir --upgrade --break-system-packages --ignore-installed \
     "cryptography<=3.3.1" \
     "ansible>=2.8.0,<2.9.0" \
     "Appium-Python-Client<1.0" \

--- a/docker-images/base/oss/debian/Dockerfile
+++ b/docker-images/base/oss/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get -y install python3 python3-pip coreutils locales locales-all curl && \
     apt-get clean && \
     ln -f -s /usr/bin/python3 /usr/bin/python && \
-    pip3 install --no-cache-dir dumb-init virtualenv
+    pip3 install --no-cache-dir --break-system-packages dumb-init virtualenv
     
 
 ADD --chmod=755 ./get_jdk_url.sh /tmp/


### PR DESCRIPTION
Fix for

```
#6 158.4 error: externally-managed-environment
#6 158.4 
#6 158.4 × This environment is externally managed
#6 158.4 ╰─> To install Python packages system-wide, try apt install
#6 158.4     python3-xyz, where xyz is the package you are trying to
#6 158.4     install.
#6 158.4     
#6 158.4     If you wish to install a non-Debian-packaged Python package,
#6 158.4     create a virtual environment using python3 -m venv path/to/venv.
#6 158.4     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#6 158.4     sure you have python3-full installed.
#6 158.4     
#6 158.4     If you wish to install a non-Debian packaged Python application,
#6 158.4     it may be easiest to use pipx install xyz, which will manage a
#6 158.4     virtual environment for you. Make sure you have pipx installed.
#6 158.4     
#6 158.4     See /usr/share/doc/python3.11/README.venv for more information.
#6 158.4 
#6 158.4 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#6 158.4 hint: See PEP 668 for the detailed specification.
#6 ERROR: executor failed running [/bin/sh -c apt-get update &&     apt-get -y upgrade &&     apt-get -y install openssh-client libltdl-dev wget unzip diffutils strace git gdebi-core &&     apt-get -y install python3 python3-pip coreutils locales locales-all curl &&     apt-get clean &&     ln -f -s /usr/bin/python3 /usr/bin/python &&     pip3 install --no-cache-dir dumb-init virtualenv]: exit code: 1
```