### PR TITLE
runtime-v2: handle NPE in expressions

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/LazyExpressionEvaluator.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/el/LazyExpressionEvaluator.java
@@ -162,6 +162,8 @@ public class LazyExpressionEvaluator implements ExpressionEvaluator {
                     .findAny()
                     .map(i -> (RuntimeException)i)
                     .orElse(e);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while evaluating expression '" + expr + "'", e);
         }
     }
 


### PR DESCRIPTION
before:
```
02:32:13.865 [main] (concord.yml): Error @ line: 11, col: 7. Cannot invoke "Object.toString()" because the return value of "com.sun.el.parser.Node.getValue(com.sun.el.lang.EvaluationContext)" is null
```

after:
```
02:47:31.861 [main] (concord.yml): Error @ line: 11, col: 7. Error while evaluating expression '${'a' += arg.undefined}'
```