### PR TITLE
console2: displaying the running process duration on the process toolbar

### DIFF
--- a/console2/src/components/organisms/ProcessActivity/Toolbar.tsx
+++ b/console2/src/components/organisms/ProcessActivity/Toolbar.tsx
@@ -45,6 +45,7 @@ import { CancelProcessPopup, DisableProcessPopup } from '../../organisms';
 import { ConcordId } from '../../../api/common';
 
 import './styles.css';
+import { formatDuration } from '../../../utils';
 
 interface ExternalProps {
     stickyRef: any;
@@ -143,9 +144,16 @@ const renderProcessStatus = (process?: ProcessEntry) => {
         return;
     }
 
+    let duration;
+    if (process.status === ProcessStatus.RUNNING) {
+        duration = formatDuration(new Date().getTime() - parseDate(process.createdAt).getTime());
+    }
     return (
         <>
-            <Label color={getStatusColor(process.status)}>{process.status}</Label>
+            <Label color={getStatusColor(process.status)}>
+                {process.status}
+                {duration && <Label.Detail>{duration}</Label.Detail>}
+            </Label>
             {process.status === ProcessStatus.FAILED && (
                 <>
                     &nbsp;


### PR DESCRIPTION
<img width="1295" alt="Screenshot 2023-07-03 at 23 56 27" src="https://github.com/walmartlabs/concord/assets/980726/b4ca663a-9012-4f08-ab9b-14ce5f875c47">
