### PR TITLE
runtime-v2: plugin to assert flow call input parameters

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -31,13 +31,11 @@ import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.dependencymanager.DependencyManagerConfiguration;
 import com.walmartlabs.concord.dependencymanager.DependencyManagerRepositories;
-import com.walmartlabs.concord.imports.ImportManager;
-import com.walmartlabs.concord.imports.ImportManagerFactory;
-import com.walmartlabs.concord.imports.ImportProcessingException;
-import com.walmartlabs.concord.imports.Imports;
+import com.walmartlabs.concord.imports.*;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinitionUtils;
 import com.walmartlabs.concord.process.loader.v2.ProcessDefinitionV2;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
+import com.walmartlabs.concord.runtime.v2.NoopImportsNormalizer;
 import com.walmartlabs.concord.runtime.v2.ProjectLoaderV2;
 import com.walmartlabs.concord.runtime.v2.ProjectSerializerV2;
 import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
@@ -45,6 +43,7 @@ import com.walmartlabs.concord.runtime.v2.model.ProcessDefinitionConfiguration;
 import com.walmartlabs.concord.runtime.v2.model.Profile;
 import com.walmartlabs.concord.runtime.v2.model.Step;
 import com.walmartlabs.concord.runtime.v2.runner.InjectorFactory;
+import com.walmartlabs.concord.runtime.v2.runner.ProjectLoadListeners;
 import com.walmartlabs.concord.runtime.v2.runner.Runner;
 import com.walmartlabs.concord.runtime.v2.runner.guice.ProcessDependenciesModule;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskProviders;
@@ -255,6 +254,11 @@ public class Run implements Callable<Integer> {
                 new ProcessDependenciesModule(targetDir, runnerCfg.dependencies(), cfg.debug()),
                 new CliServicesModule(secretStoreDir, targetDir, new VaultProvider(vaultDir, vaultId), dependencyManager, verbosity))
                 .create();
+
+        // Just to notify listeners
+        ProjectLoadListeners loadListeners = injector.getInstance(ProjectLoadListeners.class);
+        ProjectLoaderV2 loader = new ProjectLoaderV2(new NoopImportManager());
+        loader.load(targetDir, new NoopImportsNormalizer(), ImportsListener.NOP_LISTENER, loadListeners);
 
         Runner runner = injector.getInstance(Runner.class);
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -36,5 +36,6 @@
         <module>tasks/variables</module>
         <module>templates/ansible</module>
         <module>tasks/files</module>
+        <module>tasks/input-params-assert</module>
     </modules>
 </project>

--- a/plugins/tasks/input-params-assert/pom.xml
+++ b/plugins/tasks/input-params-assert/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.walmartlabs.concord.plugins.basic</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.102.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>input-params-assert</artifactId>
+    <packaging>takari-jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runtime-sdk-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runner-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runtime-vm-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runtime-model-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+        </dependency>
+
+        <!-- Immutables -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.takari.maven.plugins</groupId>
+                <artifactId>takari-lifecycle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <proc>proc</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/ConcordYamlProcessor.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/ConcordYamlProcessor.java
@@ -1,0 +1,70 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.plugins.input.parser.CommentParser;
+import com.walmartlabs.concord.plugins.input.parser.CommentsGrabber;
+import com.walmartlabs.concord.runtime.v2.ProjectLoadListener;
+import com.walmartlabs.concord.runtime.v2.runner.PersistenceService;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ConcordYamlProcessor implements ProjectLoadListener {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final PersistenceService persistenceService;
+
+    private static final FlowCallSchemaGenerator schemaGenerator = new FlowCallSchemaGenerator(new CommentsGrabber(), new CommentParser());
+
+    private final Map<String, Object> definitions = new LinkedHashMap<>();
+
+    @Inject
+    public ConcordYamlProcessor(PersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    @Override
+    public void afterFlowDefinitionLoaded(Path filename) {
+        if (schemaExists()) {
+            return;
+        }
+
+        definitions.putAll(schemaGenerator.generate(filename));
+    }
+
+    @Override
+    public void afterProjectLoaded() {
+        if (schemaExists()) {
+            return;
+        }
+
+        persistenceService.persistFile(InputParamsDefinitionProvider.DEFAULT_SCHEMA_FILENAME, out -> mapper.writeValue(out, definitions));
+    }
+
+    private boolean schemaExists() {
+        return persistenceService.loadPersistedFile(InputParamsDefinitionProvider.DEFAULT_SCHEMA_FILENAME, inputStream -> true) != null;
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallInputParamsAssert.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallInputParamsAssert.java
@@ -1,0 +1,75 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
+import com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+public class FlowCallInputParamsAssert {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowCallInputParamsAssert.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final InputParamsDefinitionProvider definitionProvider;
+
+    private final boolean debug;
+
+    @Inject
+    public FlowCallInputParamsAssert(InputParamsDefinitionProvider definitionProvider, ProcessConfiguration cfg) {
+        this.definitionProvider = definitionProvider;
+        this.debug = cfg.debug();
+    }
+
+    public void process(String flowName, Map<String, Object> input) {
+        JsonNode definition = definitionProvider.get(flowName);
+        if (definition == null) {
+            if (debug) {
+                log.info("Can't find input params definition for '{}' flow", flowName);
+            }
+            return;
+        }
+
+        if (debug) {
+            log.info("Validating input params for '{}' flow", flowName);
+        }
+
+        JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        JsonSchema schema = schemaFactory.getSchema(definition);
+
+        Set<ValidationMessage> validationResult = schema.validate(mapper.valueToTree(input));
+        if (!validationResult.isEmpty()) {
+            throw new UserDefinedException("Input params validation failed: " + validationResult);
+        }
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallListener.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallListener.java
@@ -1,0 +1,59 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.model.Location;
+import com.walmartlabs.concord.runtime.v2.runner.vm.FlowCallCommand;
+import com.walmartlabs.concord.runtime.v2.runner.vm.VMUtils;
+import com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException;
+import com.walmartlabs.concord.svm.*;
+import com.walmartlabs.concord.svm.Runtime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class FlowCallListener implements ExecutionListener {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowCallListener.class);
+
+    private final FlowCallInputParamsAssert inputParamsAssert;
+
+    @Inject
+    public FlowCallListener(FlowCallInputParamsAssert inputParamsAssert) {
+        this.inputParamsAssert = inputParamsAssert;
+    }
+
+    @Override
+    public Result afterCommand(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
+        if (cmd instanceof FlowCallCommand) {
+            String flowName = VMUtils.getLocal(state, threadId, "flowName");
+            try {
+                inputParamsAssert.process(flowName, VMUtils.getCombinedLocals(state, threadId));
+            } catch (UserDefinedException e) {
+                log.error("{} {}", Location.toErrorPrefix(((FlowCallCommand) cmd).getStep().getLocation()), e.getMessage());
+                throw e;
+            }
+        }
+
+        return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallSchemaGenerator.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/FlowCallSchemaGenerator.java
@@ -1,0 +1,112 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.input.parser.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.*;
+
+public class FlowCallSchemaGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowCallSchemaGenerator.class);
+
+    private final CommentsGrabber grabber;
+    private final CommentParser parser;
+
+    public FlowCallSchemaGenerator(CommentsGrabber commentsGrabber, CommentParser parser) {
+        this.grabber = commentsGrabber;
+        this.parser = parser;
+    }
+
+    public Map<String, Object> generate(Path concordYaml) {
+        Map<String, List<String>> comments = grabber.grab(concordYaml);
+
+        Map<String, Object> schema = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> e : comments.entrySet()) {
+            try {
+                FlowDefinition fd = parser.parse(e.getValue());
+
+                Map<String, Object> flowSchema = new LinkedHashMap<>();
+                if (fd.description() != null) {
+                    flowSchema.put("title", fd.description());
+                }
+
+                for (Map.Entry<String, ParamDefinition> in : fd.in().entrySet()) {
+                    set(flowSchema, in.getKey(), in.getValue());
+                }
+
+                schema.put(e.getKey(), flowSchema);
+            } catch (Exception err) {
+                log.warn("error parsing comment in '" + concordYaml + "' for flow '" + e.getKey() + "': " + err.getMessage());
+            }
+        }
+        return schema;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void set(Map<String, Object> result, String key, ParamDefinition value) {
+        Map<String, Object> current = result;
+        String[] path = key.split("\\.");
+        for (int i = 0, pathLength = path.length; i < pathLength - 1; i++) {
+            String p = path[i];
+
+            if (isArray(current)) {
+                current = (Map<String, Object>) current.computeIfAbsent("items", k -> new LinkedHashMap<>());
+            }
+            current.putIfAbsent("type", ParamType.OBJECT.name().toLowerCase());
+
+            Map<String, Object> properties = (Map<String, Object>) current.computeIfAbsent("properties", k -> new LinkedHashMap<>());
+            current = (Map<String, Object>) properties.computeIfAbsent(p, k -> new LinkedHashMap<>());
+        }
+
+        if (isArray(current)) {
+            current = (Map<String, Object>) current.computeIfAbsent("items", k -> new LinkedHashMap<>());
+        }
+        current.putIfAbsent("type", ParamType.OBJECT.name().toLowerCase());
+
+        Map<String, Object> object = new LinkedHashMap<>();
+        if (value.isSimpleArray()) {
+            object.put("type", ParamType.ARRAY.name().toLowerCase());
+            object.put("items", new LinkedHashMap<>(Collections.singletonMap("type", value.type().name().toLowerCase())));
+        } else {
+            object.put("type", value.type().name().toLowerCase());
+        }
+
+        if (value.description() != null) {
+            object.put("description", value.description());
+        }
+
+        if (!value.optional()) {
+            List<String> required = (List<String>) current.computeIfAbsent("required", k -> new ArrayList<>());
+            required.add(path[path.length - 1]);
+        }
+
+        Map<String, Object> properties = (Map<String, Object>) current.computeIfAbsent("properties", k -> new LinkedHashMap<>());
+        properties.put(path[path.length - 1], object);
+    }
+
+    private static boolean isArray(Map<String, Object> current) {
+        return ParamType.ARRAY.name().equalsIgnoreCase((String)current.get("type"));
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/InputParamsAssertModule.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/InputParamsAssertModule.java
@@ -1,0 +1,41 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+import com.walmartlabs.concord.runtime.v2.ProjectLoadListener;
+import com.walmartlabs.concord.svm.ExecutionListener;
+
+import javax.inject.Named;
+
+@Named
+public class InputParamsAssertModule implements com.google.inject.Module {
+
+    @Override
+    public void configure(Binder binder) {
+        Multibinder<ExecutionListener> taskProviders = Multibinder.newSetBinder(binder, ExecutionListener.class);
+        taskProviders.addBinding().to(FlowCallListener.class);
+
+        Multibinder<ProjectLoadListener> projectLoadListeners = Multibinder.newSetBinder(binder, ProjectLoadListener.class);
+        projectLoadListeners.addBinding().to(ConcordYamlProcessor.class);
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/InputParamsDefinitionProvider.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/InputParamsDefinitionProvider.java
@@ -1,0 +1,66 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.runtime.v2.runner.PersistenceService;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Map;
+
+@Singleton
+public class InputParamsDefinitionProvider {
+
+    public static final String DEFAULT_SCHEMA_FILENAME = "concord-flow-call-schema.json";
+
+    private static final TypeReference<Map<String, JsonNode>> MAP_TYPE = new TypeReference<Map<String, JsonNode>>() {
+    };
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private Map<String, JsonNode> definitions;
+
+    private final PersistenceService persistenceService;
+
+    @Inject
+    public InputParamsDefinitionProvider(PersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    public synchronized JsonNode get(String flowName) {
+        if (definitions == null) {
+            definitions = loadDefinitions();
+        }
+
+        return definitions.get(flowName);
+    }
+
+    private Map<String, JsonNode> loadDefinitions() {
+        Map<String, JsonNode> result = persistenceService.loadPersistedFile(DEFAULT_SCHEMA_FILENAME, inputStream -> mapper.readValue(inputStream, MAP_TYPE));
+        if (result == null) {
+            return Collections.emptyMap();
+        }
+        return result;
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/CommentParser.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/CommentParser.java
@@ -1,0 +1,124 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CommentParser {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+    };
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    private static final Set<String> keys = Set.of("in:", "out:");
+
+    @SuppressWarnings("unchecked")
+    public FlowDefinition parse(List<String> commentLines) {
+        Map<String, Object> fields = parseFields(commentLines);
+        return FlowDefinition.builder()
+                .description((String)(fields.get("description")))
+                .in(convert((Map<String, String>)fields.get("in")))
+                .out(convert((Map<String, String>)fields.get("out")))
+                .build();
+    }
+
+    private static boolean isHeader(String line) {
+        return line.trim().startsWith("##");
+    }
+
+    private static Map<String, ParamDefinition> convert(Map<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return ParamDefinitionParser.parse(params);
+    }
+
+    public Map<String, Object> parseFields(List<String> commentLines) {
+        if (commentLines.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        if (!isHeader(commentLines.get(0))) {
+            throw new RuntimeException("No header");
+        }
+
+        int keyIndex = findKey(commentLines, keys);
+        if (keyIndex == -1) {
+            throw new RuntimeException("No in/out defined");
+        }
+
+        StringBuilder description = new StringBuilder();
+        for (int i = 0; i < keyIndex; i++) {
+            String line = trimStartChar(commentLines.get(i).trim(), '#').trim();
+            if (!line.isEmpty()) {
+                description.append(line);
+            }
+        }
+
+        StringBuilder inOut =  new StringBuilder();
+        for (int i = keyIndex; i < commentLines.size(); i++) {
+            String line = trimStartChar(commentLines.get(i).trim(), '#');
+            inOut.append(line).append('\n');
+        }
+
+        Map<String, Object> fields = readMap(inOut.toString());
+        if (description.length() > 0) {
+            fields.put("description", description.toString());
+        }
+        return fields;
+    }
+
+    private static Map<String, Object> readMap(String content) {
+        try {
+            return mapper.readValue(content, MAP_TYPE);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reading '" + content + "': " + e.getMessage());
+        }
+    }
+
+    private static int findKey(List<String> commentLines, Set<String> keys) {
+        for (int i = 0; i< commentLines.size(); i++) {
+            String line = trimStartChar(commentLines.get(i).trim(), '#').trim();
+            if (keys.contains(line)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String trimStartChar(String str, char ch) {
+        int startIndex = 0;
+        int length = str.length();
+        while (startIndex < length && str.charAt(startIndex) == ch) {
+            startIndex++;
+        }
+        return str.substring(startIndex);
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/CommentsGrabber.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/CommentsGrabber.java
@@ -1,0 +1,92 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CommentsGrabber {
+
+    public Map<String, List<String>> grab(Path file) {
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        try (BufferedReader reader = Files.newBufferedReader(file)) {
+            int lineNum = findKey(reader, "flows:");
+            if (lineNum == -1) {
+                return result;
+            }
+
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (isNewYamlBlock(line)) {
+                    break;
+                } else if (line.trim().startsWith("#")) {
+                    lines.add(line);
+                } else if (isFlowName(line)) {
+                    if (!lines.isEmpty()) {
+                        line = line.trim();
+                        String flowName = line.substring(0, line.length() - 1);
+                        result.put(flowName, new ArrayList<>(lines));
+                        lines.clear();
+                    }
+                }
+            }
+
+            return result;
+        } catch (IOException e) {
+            throw new RuntimeException("Error while reading " + file + ": " + e.getMessage());
+        }
+    }
+
+    private static int findKey(BufferedReader reader, String key) throws IOException {
+        String line;
+        int lineNum = 0;
+        while ((line = reader.readLine()) != null) {
+            lineNum++;
+            if (key.equals(line.trim())) {
+                return lineNum;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isNewYamlBlock(String line) {
+        if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+            return false;
+        }
+
+        return !Character.isWhitespace(line.charAt(0));
+    }
+
+    private static boolean isFlowName(String line) {
+        if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+            return false;
+        }
+
+        return Character.isWhitespace(line.charAt(0));
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/FlowDefinition.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/FlowDefinition.java
@@ -1,0 +1,49 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+
+@Value.Immutable
+@Value.Style(jdkOnly = true)
+public interface FlowDefinition {
+
+    @Nullable
+    String description();
+
+    @Value.Default
+    default Map<String, ParamDefinition> in() {
+        return Collections.emptyMap();
+    }
+
+    @Value.Default
+    default Map<String, ParamDefinition> out() {
+        return Collections.emptyMap();
+    }
+
+    static ImmutableFlowDefinition.Builder builder() {
+        return ImmutableFlowDefinition.builder();
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinition.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinition.java
@@ -1,0 +1,49 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+@Value.Style(jdkOnly = true)
+public interface ParamDefinition {
+
+    @Value.Default
+    default boolean optional() {
+        return false;
+    }
+
+    @Nullable
+    String description();
+
+    ParamType type();
+
+    @Value.Default
+    default boolean isSimpleArray() {
+        return false;
+    }
+
+    static ImmutableParamDefinition.Builder builder() {
+        return ImmutableParamDefinition.builder();
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinitionParser.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinitionParser.java
@@ -1,0 +1,35 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ParamDefinitionParser {
+
+    public static Map<String, ParamDefinition> parse(Map<String, String> definition) {
+        Map<String, ParamDefinition> result = new LinkedHashMap<>();
+        for (Map.Entry<String, String> e : definition.entrySet()) {
+            result.put(e.getKey(), SimpleParamDefinitionParser.parse(e.getValue()));
+        }
+        return result;
+    }
+}

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamType.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/ParamType.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public enum ParamType {
+
+    STRING(),
+    NUMBER ("int", "integer"),
+    BOOLEAN(),
+    OBJECT(),
+    ARRAY(),
+    ANY();
+
+    private final Set<String> aliases;
+
+    ParamType(String... aliases) {
+        this.aliases = new HashSet<>(Arrays.asList(aliases));
+    }
+
+    public Set<String> getAliases() {
+        return aliases;
+    }
+}
+

--- a/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/SimpleParamDefinitionParser.java
+++ b/plugins/tasks/input-params-assert/src/main/java/com/walmartlabs/concord/plugins/input/parser/SimpleParamDefinitionParser.java
@@ -1,0 +1,85 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.util.Arrays;
+
+public class SimpleParamDefinitionParser {
+
+    public static ParamDefinition parse(String str) {
+        int pos = str.indexOf(",");
+        String paramTypeStr;
+        if (pos > 0) {
+            paramTypeStr = str.substring(0, pos);
+            str = str.substring(pos + 1);
+        } else {
+            paramTypeStr = str;
+            str = null;
+        }
+
+        ParamType paramType = toParamType(paramTypeStr);
+        boolean isArray = paramTypeStr.trim().endsWith("[]");
+
+        boolean optional = false;
+        if (str != null) {
+            pos = str.indexOf(",");
+            if (pos > 0) {
+                String optionalOrMandatory = str.substring(0, pos).trim();
+                if ("optional".equalsIgnoreCase(optionalOrMandatory)) {
+                    optional = true;
+                    str = str.substring(pos + 1);
+                } else if ("mandatory".equalsIgnoreCase(optionalOrMandatory)) {
+                    optional = false;
+                    str = str.substring(pos + 1);
+                }
+            }
+        }
+
+        String description = null;
+        if (str != null) {
+            description = str.trim();
+        }
+        return ParamDefinition.builder()
+                .optional(optional)
+                .description(description)
+                .type(paramType)
+                .isSimpleArray(isArray)
+                .build();
+    }
+
+    private static ParamType toParamType(String type) {
+        String normalized;
+        if (type.endsWith("[]")) {
+            normalized = type.substring(0, type.length() - 2).trim();
+        } else {
+            normalized = type.trim();
+        }
+
+        for (ParamType t : ParamType.values()) {
+            if (t.name().equalsIgnoreCase(normalized)) {
+                return t;
+            } else if (t.getAliases().stream().anyMatch(a -> a.equalsIgnoreCase(normalized))) {
+                return t;
+            }
+        }
+        throw new RuntimeException("Unknown param type: '" + type + "'. Available types: " + Arrays.toString(ParamType.values()));
+    }
+}

--- a/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/FlowCallInputParamsAssertTest.java
+++ b/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/FlowCallInputParamsAssertTest.java
@@ -1,0 +1,191 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.walmartlabs.concord.runtime.v2.runner.PersistenceService;
+import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
+import com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlowCallInputParamsAssertTest {
+
+    @Test
+    public void testTypeMismatch() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/001-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", false);
+
+        try {
+            assertion.process("default", input);
+            fail("exception expected");
+        } catch (UserDefinedException e) {
+            assertThat(e.getMessage()).contains("param1: boolean found, string expected");
+        }
+    }
+
+    @Test
+    public void testMissingMandatory() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/002-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+
+        try {
+            assertion.process("default", input);
+            fail("exception expected");
+        } catch (UserDefinedException e) {
+            assertThat(e.getMessage()).contains("param1: is missing but it is required");
+        }
+    }
+
+    @Test
+    public void testMissingMandatoryObject() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/003-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", Collections.singletonMap("key1", "value"));
+
+        try {
+            assertion.process("default", input);
+            fail("exception expected");
+        } catch (UserDefinedException e) {
+            assertThat(e.getMessage()).contains("param1.key2: is missing but it is required");
+        }
+    }
+
+    @Test
+    public void testArrayTypeMismatch() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/004-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", Collections.singletonList(1));
+
+        try {
+            assertion.process("default", input);
+            fail("exception expected");
+        } catch (UserDefinedException e) {
+            assertThat(e.getMessage()).contains("param1[0]: integer found, string expected");
+        }
+    }
+
+    @Test
+    public void testOkStringParam() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/001-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", "one");
+        input.put("param2", "additional");
+
+        assertion.process("default", input);
+    }
+
+    @Test
+    public void testOkStringMandatoryParam() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/002-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", "one");
+        input.put("param2", "additional");
+
+        assertion.process("default", input);
+    }
+
+    @Test
+    public void testOkObjectMandatoryParam() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/003-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> param1 = new HashMap<>();
+        param1.put("key1", "value1");
+        param1.put("key2", "value2");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", param1);
+        input.put("param2", "additional");
+
+        assertion.process("default", input);
+    }
+
+    @Test
+    public void testOkStringArray() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/004-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", Collections.singletonList("one"));
+        input.put("param2", "additional");
+
+        assertion.process("default", input);
+    }
+
+    @Test
+    public void testOkComplex() throws Exception {
+        FlowCallInputParamsAssert assertion = new FlowCallInputParamsAssert(provider("ok/005-json-schema.json"), ProcessConfiguration.builder().build());
+
+        Map<String, Object> input = fromYaml("ok/005-input.yaml");
+
+        assertion.process("default", input);
+    }
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+    };
+
+    private static Map<String, Object> fromYaml(String resource) {
+        URL url = FlowCallInputParamsAssertTest.class.getResource(resource);
+        if (url == null) {
+            throw new RuntimeException("Can't find resource: " + resource);
+        }
+
+        try {
+            return new ObjectMapper(new YAMLFactory()).readValue(url, MAP_TYPE);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final TypeReference<Map<String, JsonNode>> JSON_NODE_MAP_TYPE = new TypeReference<Map<String, JsonNode>>() {
+    };
+
+    private static InputParamsDefinitionProvider provider(String resource) throws Exception {
+        URL url = FlowCallInputParamsAssertTest.class.getResource(resource);
+        if (url == null) {
+            throw new RuntimeException("Can't find resource: " + resource);
+        }
+
+        PersistenceService persistenceService = mock(PersistenceService.class);
+        when(persistenceService.loadPersistedFile(any(), any())).thenReturn(new ObjectMapper().readValue(url, JSON_NODE_MAP_TYPE));
+
+        return new InputParamsDefinitionProvider(persistenceService);
+    }
+}

--- a/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/FlowCallSchemaGeneratorTest.java
+++ b/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/FlowCallSchemaGeneratorTest.java
@@ -1,0 +1,97 @@
+package com.walmartlabs.concord.plugins.input;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.plugins.input.parser.CommentParser;
+import com.walmartlabs.concord.plugins.input.parser.CommentsGrabber;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FlowCallSchemaGeneratorTest {
+
+    private final FlowCallSchemaGenerator generator = new FlowCallSchemaGenerator(new CommentsGrabber(), new CommentParser());
+
+    @Test
+    public void tests() throws Exception {
+        Map<String, Object> schema = generator.generate(readResource("ok/001-concord.yaml"));
+        assertSchema("ok/001-json-schema.json", schema);
+
+        schema = generator.generate(readResource("ok/002-concord.yaml"));
+        assertSchema("ok/002-json-schema.json", schema);
+
+        schema = generator.generate(readResource("ok/003-concord.yaml"));
+        assertSchema("ok/003-json-schema.json", schema);
+
+        schema = generator.generate(readResource("ok/004-concord.yaml"));
+        assertSchema("ok/004-json-schema.json", schema);
+
+        schema = generator.generate(readResource("ok/005-concord.yaml"));
+        assertSchema("ok/005-json-schema.json", schema);
+    }
+
+    private static void assertSchema(String fileName, Map<String, Object> schema) {
+        assertEquals(getResourceFileAsString(fileName), writeAsString(schema));
+    }
+
+    static String getResourceFileAsString(String fileName) {
+        try (InputStream is = FlowCallSchemaGeneratorTest.class.getResourceAsStream(fileName)) {
+            if (is == null) {
+                throw new RuntimeException("Resource '" + fileName + "' not found");
+            }
+            try (InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader reader = new BufferedReader(isr)) {
+                return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Path readResource(String name) throws Exception {
+        URL url = FlowCallSchemaGeneratorTest.class.getResource(name);
+        if (url == null) {
+            throw new RuntimeException("Resource '" + name + "' not found");
+        }
+
+        return Paths.get(url.toURI());
+    }
+
+    private static String writeAsString(Object value) {
+        try {
+            return new ObjectMapper().writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(value);
+        } catch (Exception e) {
+            throw new RuntimeException("Error writing value '" + value + "' to string: " + e.getMessage());
+        }
+    }
+}

--- a/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinitionParserTest.java
+++ b/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/parser/ParamDefinitionParserTest.java
@@ -1,0 +1,125 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ParamDefinitionParserTest {
+
+    @Test
+    public void testParse_withSingleSimpleParam() {
+        String input = "stringParam: STRING, optional, This is a string parameter";
+        ParamDefinition expected = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        Map<String, ParamDefinition> result = ParamDefinitionParser.parse(toMap(input));
+
+        assertEquals(Map.of("stringParam", expected), result);
+    }
+
+    @Test
+    public void testParse_withTwoSimpleParam() {
+        String input =
+                "stringParam: STRING, optional, This is a string parameter\n" +
+                "booleanParam: boolean, mandatory, This is boolean parameter";
+
+        ParamDefinition expectedString = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        ParamDefinition expectedBoolean = ParamDefinition.builder()
+                .optional(false)
+                .description("This is boolean parameter")
+                .type(ParamType.BOOLEAN)
+                .build();
+
+        Map<String, ParamDefinition> result = ParamDefinitionParser.parse(toMap(input));
+
+        assertEquals(Map.of("stringParam", expectedString, "booleanParam", expectedBoolean), result);
+    }
+
+    @Test
+    public void testParse_withComplexParam() {
+        String input =
+                "objectParam: object, optional, This is an object parameter\n" +
+                "objectParam.stringParam: STRING, optional, This is a string parameter";
+        ParamDefinition expected = ParamDefinition.builder()
+                .optional(true)
+                .description("This is an object parameter")
+                .type(ParamType.OBJECT)
+                .build();
+
+        ParamDefinition expectedValue = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        Map<String, ParamDefinition> result = ParamDefinitionParser.parse(toMap(input));
+
+        assertEquals(Map.of("objectParam", expected, "objectParam.stringParam", expectedValue), result);
+    }
+
+    @Test
+    public void testParse_withArrayType() {
+        String input =
+                "arrayParam: array, mandatory, This is array parameter\n" +
+                "arrayParam.stringParam: STRING, optional, This is a string parameter";
+
+        ParamDefinition expected = ParamDefinition.builder()
+                .optional(false)
+                .description("This is array parameter")
+                .type(ParamType.ARRAY)
+                .build();
+        ParamDefinition expectedValue = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        Map<String, ParamDefinition> result = ParamDefinitionParser.parse(toMap(input));
+
+        assertEquals(Map.of("arrayParam", expected, "arrayParam.stringParam", expectedValue), result);
+    }
+
+    private static final TypeReference<Map<String, String>> MAP_TYPE = new TypeReference<Map<String, String>>() {
+    };
+
+    private Map<String, String> toMap(String input) {
+        try {
+            return new ObjectMapper(new YAMLFactory()).readValue(input, MAP_TYPE);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/parser/SimpleParamDefinitionParserTest.java
+++ b/plugins/tasks/input-params-assert/src/test/java/com/walmartlabs/concord/plugins/input/parser/SimpleParamDefinitionParserTest.java
@@ -1,0 +1,118 @@
+package com.walmartlabs.concord.plugins.input.parser;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SimpleParamDefinitionParserTest {
+
+    @Test
+    public void testParse_withValidInput() {
+        String input = "STRING, optional, This is a string parameter";
+        ParamDefinition expectedOutput = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        ParamDefinition result = SimpleParamDefinitionParser.parse(input);
+
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testParse_withMandatory() {
+        String input = "INTEGER, mandatory, This is an integer parameter";
+        ParamDefinition expectedOutput = ParamDefinition.builder()
+                .optional(false)
+                .description("This is an integer parameter")
+                .type(ParamType.NUMBER)
+                .build();
+
+        ParamDefinition result = SimpleParamDefinitionParser.parse(input);
+
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testParse_withNoTypeAndOptional() {
+        String input = "This is a parameter without type and optional";
+
+        assertThrows(RuntimeException.class, () -> {
+            SimpleParamDefinitionParser.parse(input);
+        });
+    }
+
+    @Test
+    public void testParse_withNoOptional() {
+        String input = "STRING, This is a string parameter";
+        ParamDefinition expectedOutput = ParamDefinition.builder()
+                .optional(false)
+                .description("This is a string parameter")
+                .type(ParamType.STRING)
+                .build();
+
+        ParamDefinition result = SimpleParamDefinitionParser.parse(input);
+
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testParse_withNoOptionalAndNoDescription() {
+        String input = "STRING";
+        ParamDefinition expectedOutput = ParamDefinition.builder()
+                .optional(false)
+                .type(ParamType.STRING)
+                .build();
+
+        ParamDefinition result = SimpleParamDefinitionParser.parse(input);
+
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testParse_withUnknownType() {
+        String input = "UNKNOWN_TYPE, optional, This is an unknown type parameter";
+
+        assertThrows(RuntimeException.class, () -> {
+            SimpleParamDefinitionParser.parse(input);
+        });
+    }
+
+    @Test
+    public void testParse_withArray() {
+        String input = "string[], optional, This is a string array parameter";
+        ParamDefinition expectedOutput = ParamDefinition.builder()
+                .optional(true)
+                .description("This is a string array parameter")
+                .type(ParamType.STRING)
+                .isSimpleArray(true)
+                .build();
+
+        ParamDefinition result = SimpleParamDefinitionParser.parse(input);
+
+        assertEquals(expectedOutput, result);
+    }
+
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/flow-call-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/flow-call-schema.json
@@ -1,0 +1,23 @@
+{
+  "test" : {
+    "type" : "object",
+    "required" : [ "param1" ],
+    "properties" : {
+      "param1" : {
+        "type" : "object",
+        "description" : "param1 description",
+        "required" : [ "key1", "key2" ],
+        "properties" : {
+          "key1" : {
+            "type" : "string",
+            "description" : "key1 description"
+          },
+          "key2" : {
+            "type" : "string",
+            "description" : "key2 description"
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/001-concord.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/001-concord.yaml
@@ -1,0 +1,7 @@
+flows:
+  ##
+  #  in:
+  #    param1: string, optional, param1 description
+  ##
+  default:
+    - log: "default"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/001-json-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/001-json-schema.json
@@ -1,0 +1,11 @@
+{
+  "default" : {
+    "type" : "object",
+    "properties" : {
+      "param1" : {
+        "type" : "string",
+        "description" : "param1 description"
+      }
+    }
+  }
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/002-concord.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/002-concord.yaml
@@ -1,0 +1,7 @@
+flows:
+  ##
+  #  in:
+  #    param1: string, mandatory, param1 description
+  ##
+  default:
+    - log: "default"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/002-json-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/002-json-schema.json
@@ -1,0 +1,12 @@
+{
+  "default" : {
+    "type" : "object",
+    "required" : [ "param1" ],
+    "properties" : {
+      "param1" : {
+        "type" : "string",
+        "description" : "param1 description"
+      }
+    }
+  }
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/003-concord.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/003-concord.yaml
@@ -1,0 +1,9 @@
+flows:
+  ##
+  #  in:
+  #    param1: object, mandatory, param1 description
+  #    param1.key1: string, mandatory, key1 description
+  #    param1.key2: string, mandatory, key2 description
+  ##
+  default:
+    - log: "default"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/003-json-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/003-json-schema.json
@@ -1,0 +1,23 @@
+{
+  "default" : {
+    "type" : "object",
+    "required" : [ "param1" ],
+    "properties" : {
+      "param1" : {
+        "type" : "object",
+        "description" : "param1 description",
+        "required" : [ "key1", "key2" ],
+        "properties" : {
+          "key1" : {
+            "type" : "string",
+            "description" : "key1 description"
+          },
+          "key2" : {
+            "type" : "string",
+            "description" : "key2 description"
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/004-concord.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/004-concord.yaml
@@ -1,0 +1,7 @@
+flows:
+  ##
+  #  in:
+  #    param1: string[], mandatory, param1 description
+  ##
+  default:
+    - log: "default"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/004-json-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/004-json-schema.json
@@ -1,0 +1,15 @@
+{
+  "default" : {
+    "type" : "object",
+    "required" : [ "param1" ],
+    "properties" : {
+      "param1" : {
+        "type" : "array",
+        "items" : {
+          "type" : "string"
+        },
+        "description" : "param1 description"
+      }
+    }
+  }
+}

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-concord.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-concord.yaml
@@ -1,0 +1,18 @@
+flows:
+  ##
+  #  in:
+  #    param1: string, mandatory, param1 description
+  #    param2: object, mandatory, param2 description
+  #    param2.arr: array, mandatory, arr description
+  #    param2.arr.key: object, mandatory, object in arr description
+  #    param2.arr.key.key2: string, mandatory, object object in arr description
+  ##
+  default:
+    - log: "default"
+
+
+  param1: "param1-value"
+  param2:
+    arr:
+      - key:
+          key2: "value"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-input.yaml
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-input.yaml
@@ -1,0 +1,5 @@
+param1: "param1-value"
+param2:
+  arr:
+    - key:
+        key2: "value"

--- a/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-json-schema.json
+++ b/plugins/tasks/input-params-assert/src/test/resources/com/walmartlabs/concord/plugins/input/ok/005-json-schema.json
@@ -1,0 +1,40 @@
+{
+  "default" : {
+    "type" : "object",
+    "required" : [ "param1", "param2" ],
+    "properties" : {
+      "param1" : {
+        "type" : "string",
+        "description" : "param1 description"
+      },
+      "param2" : {
+        "type" : "object",
+        "description" : "param2 description",
+        "required" : [ "arr" ],
+        "properties" : {
+          "arr" : {
+            "type" : "array",
+            "description" : "arr description",
+            "items" : {
+              "type" : "object",
+              "required" : [ "key" ],
+              "properties" : {
+                "key" : {
+                  "type" : "object",
+                  "description" : "object in arr description",
+                  "required" : [ "key2" ],
+                  "properties" : {
+                    "key2" : {
+                      "type" : "string",
+                      "description" : "object object in arr description"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/NopProjectLoadListener.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/NopProjectLoadListener.java
@@ -1,0 +1,36 @@
+package com.walmartlabs.concord.runtime.v2;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.nio.file.Path;
+
+public class NopProjectLoadListener implements ProjectLoadListener{
+
+    @Override
+    public void afterFlowDefinitionLoaded(Path filename) {
+        // do nothing
+    }
+
+    @Override
+    public void afterProjectLoaded() {
+        // do nothing
+    }
+}

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ProjectLoadListener.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ProjectLoadListener.java
@@ -1,0 +1,30 @@
+package com.walmartlabs.concord.runtime.v2;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.nio.file.Path;
+
+public interface ProjectLoadListener {
+
+    void afterFlowDefinitionLoaded(Path filename);
+
+    void afterProjectLoaded();
+}

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ProjectLoaderV2.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/ProjectLoaderV2.java
@@ -45,11 +45,15 @@ public class ProjectLoaderV2 {
     }
 
     public Result load(Path baseDir, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception {
+        return load(baseDir, importsNormalizer, listener, new NopProjectLoadListener());
+    }
+
+    public Result load(Path baseDir, ImportsNormalizer importsNormalizer, ImportsListener listener, ProjectLoadListener loadListener) throws Exception {
         YamlParserV2 parser = new YamlParserV2();
 
         // load the initial ProcessDefinition from the root concord.yml file
         // it will be used to determine whether we need to load other resources (e.g. imports)
-        ProcessDefinition root = loadRoot(parser, baseDir);
+        ProcessDefinition root = loadRoot(parser, baseDir, loadListener);
 
         List<Snapshot> snapshots = Collections.emptyList();
         if (root != null) {
@@ -62,7 +66,9 @@ public class ProjectLoaderV2 {
 
         List<ProcessDefinition> definitions = new ArrayList<>();
         for (Path p : files) {
-            definitions.add(parser.parse(baseDir, p));
+            ProcessDefinition pd = parser.parse(baseDir, p);
+            loadListener.afterFlowDefinitionLoaded(p);
+            definitions.add(pd);
         }
 
         if (root != null) {
@@ -73,13 +79,15 @@ public class ProjectLoaderV2 {
             throw new IllegalStateException("Can't find any Concord process definition files in '" + baseDir + "'");
         }
 
+        loadListener.afterProjectLoaded();
+
         return new Result(snapshots, merge(definitions));
     }
 
     public void export(Path baseDir, Path destDir, ImportsNormalizer importsNormalizer, ImportsListener listener, CopyOption... options) throws Exception {
         YamlParserV2 parser = new YamlParserV2();
 
-        ProcessDefinition root = loadRoot(parser, baseDir);
+        ProcessDefinition root = loadRoot(parser, baseDir, new NopProjectLoadListener());
 
         Resources resources = root != null ? root.resources() : Resources.builder().build();
         boolean hasImports = root != null && root.imports() != null && !root.imports().isEmpty();
@@ -104,11 +112,13 @@ public class ProjectLoaderV2 {
         }
     }
 
-    private ProcessDefinition loadRoot(YamlParserV2 parser, Path baseDir) throws IOException {
+    private ProcessDefinition loadRoot(YamlParserV2 parser, Path baseDir, ProjectLoadListener loadListener) throws IOException {
         for (String fileName : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
             Path p = baseDir.resolve(fileName);
             if (Files.exists(p)) {
-                return parser.parse(baseDir, p);
+                ProcessDefinition result = parser.parse(baseDir, p);
+                loadListener.afterFlowDefinitionLoaded(p);
+                return result;
             }
         }
         return null;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -211,10 +211,10 @@ public class Main {
         }
     }
 
-    private static ProcessSnapshot start(Runner runner, ProcessConfiguration cfg, Path workDir, Map<String, Object> args, ProjectLoadListener loadSourceListener) throws Exception {
+    private static ProcessSnapshot start(Runner runner, ProcessConfiguration cfg, Path workDir, Map<String, Object> args, ProjectLoadListener projectLoadListener) throws Exception {
         // assume all imports were processed by the agent
         ProjectLoaderV2 loader = new ProjectLoaderV2(new NoopImportManager());
-        ProcessDefinition processDefinition = loader.load(workDir, new NoopImportsNormalizer(), ImportsListener.NOP_LISTENER, loadSourceListener).getProjectDefinition();
+        ProcessDefinition processDefinition = loader.load(workDir, new NoopImportsNormalizer(), ImportsListener.NOP_LISTENER, projectLoadListener).getProjectDefinition();
 
         Map<String, Object> initiator = cfg.initiator();
         if (initiator != null) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -30,6 +30,7 @@ import com.walmartlabs.concord.runtime.common.ProcessHeartbeat;
 import com.walmartlabs.concord.runtime.common.StateManager;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
 import com.walmartlabs.concord.runtime.v2.NoopImportsNormalizer;
+import com.walmartlabs.concord.runtime.v2.ProjectLoadListener;
 import com.walmartlabs.concord.runtime.v2.ProjectLoaderV2;
 import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
 import com.walmartlabs.concord.runtime.v2.runner.guice.ObjectMapperProvider;
@@ -66,6 +67,7 @@ public class Main {
     private final WorkingDirectory workDir;
     private final TaskProviders taskProviders;
     private final ClassLoader classLoader;
+    private final ProjectLoadListeners projectLoadListeners;
 
     @Inject
     public Main(Runner runner,
@@ -73,7 +75,8 @@ public class Main {
                 ProcessConfiguration processCfg,
                 WorkingDirectory workDir,
                 TaskProviders taskProviders,
-                @Named("runtime") ClassLoader classLoader) {
+                @Named("runtime") ClassLoader classLoader,
+                ProjectLoadListeners projectLoadListeners) {
 
         this.runner = runner;
         this.runnerCfg = runnerCfg;
@@ -81,6 +84,7 @@ public class Main {
         this.workDir = workDir;
         this.taskProviders = taskProviders;
         this.classLoader = classLoader;
+        this.projectLoadListeners = projectLoadListeners;
     }
 
     public static void main(String[] args) throws Exception {
@@ -156,7 +160,7 @@ public class Main {
                 }
                 processArgs.putAll(prepareProcessArgs(processCfg));
 
-                snapshot = start(runner, processCfg, workDir, processArgs);
+                snapshot = start(runner, processCfg, workDir, processArgs, projectLoadListeners);
                 break;
             }
             case RESUME: {
@@ -207,10 +211,10 @@ public class Main {
         }
     }
 
-    private static ProcessSnapshot start(Runner runner, ProcessConfiguration cfg, Path workDir, Map<String, Object> args) throws Exception {
+    private static ProcessSnapshot start(Runner runner, ProcessConfiguration cfg, Path workDir, Map<String, Object> args, ProjectLoadListener loadSourceListener) throws Exception {
         // assume all imports were processed by the agent
         ProjectLoaderV2 loader = new ProjectLoaderV2(new NoopImportManager());
-        ProcessDefinition processDefinition = loader.load(workDir, new NoopImportsNormalizer(), ImportsListener.NOP_LISTENER).getProjectDefinition();
+        ProcessDefinition processDefinition = loader.load(workDir, new NoopImportsNormalizer(), ImportsListener.NOP_LISTENER, loadSourceListener).getProjectDefinition();
 
         Map<String, Object> initiator = cfg.initiator();
         if (initiator != null) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PersistenceService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/PersistenceService.java
@@ -35,7 +35,7 @@ public interface PersistenceService {
 
     void persistSessionFile(String name, Writer writer);
 
-    <T> T loadPersistedFile (String name, Converter<InputStream, T> converter);
+    <T> T loadPersistedFile(String name, Converter<InputStream, T> converter);
 
     <T> T loadPersistedSessionFile(String name, Converter<InputStream, T> converter);
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProjectLoadListeners.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProjectLoadListeners.java
@@ -1,0 +1,48 @@
+package com.walmartlabs.concord.runtime.v2.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.ProjectLoadListener;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Set;
+
+public class ProjectLoadListeners implements ProjectLoadListener {
+
+    private final Collection<ProjectLoadListener> listeners;
+
+    @Inject
+    public ProjectLoadListeners(Set<ProjectLoadListener> listeners) {
+        this.listeners = listeners;
+    }
+
+    @Override
+    public void afterFlowDefinitionLoaded(Path filename) {
+        listeners.forEach(l -> l.afterFlowDefinitionLoaded(filename));
+    }
+
+    @Override
+    public void afterProjectLoaded() {
+        listeners.forEach(ProjectLoadListener::afterProjectLoaded);
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/BaseRunnerModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/BaseRunnerModule.java
@@ -25,6 +25,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.walmartlabs.concord.dependencymanager.DependencyManagerConfiguration;
 import com.walmartlabs.concord.policyengine.PolicyEngine;
 import com.walmartlabs.concord.runtime.common.FormService;
+import com.walmartlabs.concord.runtime.v2.ProjectLoadListener;
 import com.walmartlabs.concord.runtime.v2.runner.*;
 import com.walmartlabs.concord.runtime.v2.runner.compiler.DefaultCompiler;
 import com.walmartlabs.concord.runtime.v2.runner.context.ContextFactory;
@@ -65,5 +66,7 @@ public class BaseRunnerModule extends AbstractModule {
         Multibinder<TaskCallListener> taskCallListeners = Multibinder.newSetBinder(binder(), TaskCallListener.class);
         taskCallListeners.addBinding().to(TaskCallPolicyChecker.class);
         taskCallListeners.addBinding().to(TaskResultListener.class);
+
+        Multibinder.newSetBinder(binder(), ProjectLoadListener.class);
     }
 }


### PR DESCRIPTION
example:
```
configuration:
  runtime: concord-v2
  dependencies:
    - "mvn://com.walmartlabs.concord.plugins.basic:input-params-assert:1.102.1-SNAPSHOT"
  arguments:
    param1: "global"

flows:
  default:
    - call: test
      in:
#        param2: true
        additionalParam: "value"

  ##
  #  in:
  #    param1: string, mandatory, param1 description
  #    param2: boolean, mandatory, param2 description
  ##
  test:
    - log: "in test"
```

cli output:
```
14:43:06.792 [main] (concord.yml): Error @ line: 11, col: 7. Input params validation failed: [$.param2: is missing but it is required]
```