### PR TITLE
cli: active profiles fix

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -244,7 +244,7 @@ public class Run implements Callable<Integer> {
 
         System.out.println("Starting...");
 
-        ProcessConfiguration cfg = from(processDefinition.configuration(), processInfo(args), projectInfo(args))
+        ProcessConfiguration cfg = from(processDefinition.configuration(), processInfo(args, profiles), projectInfo(args))
                 .entryPoint(entryPoint)
                 .instanceId(instanceId)
                 .build();
@@ -283,7 +283,7 @@ public class Run implements Callable<Integer> {
     }
 
     @SuppressWarnings("unchecked")
-    private static ProcessInfo processInfo(Map<String, Object> args) {
+    private static ProcessInfo processInfo(Map<String, Object> args, List<String> profiles) {
         Object processInfoObject = args.get("processInfo");
         if (processInfoObject == null) {
             processInfoObject = fromExtraVars("processInfo", args);
@@ -296,6 +296,7 @@ public class Run implements Callable<Integer> {
 
         return ProcessInfo.builder()
                 .sessionToken(MapUtils.getString(processInfo, "sessionToken"))
+                .activeProfiles(profiles)
                 .build();
     }
 


### PR DESCRIPTION
active profiles for process configuration.

so this should work:
```
configuration:
  runtime: concord-v2

profiles:
  myProfile:
    flows:
      myFlow:
        - log: "From PROFILE"

flows:
  default:
    - call: myFlow

  myFlow:
    - log: "From MAIN"
```

should print `"From MAIN"` with `myProfile` 