### PR TITLE
project: allow usage of Github-hosted runners

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+        <profile>
+            <id>gha</id>
+            <properties>
+                <it.skipDocker>true</it.skipDocker>
+            </properties>
+        </profile>
+    </profiles>
+</settings>
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,23 +14,12 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk_version: ['17']
+        jdk_version: [ '17' ]
       fail-fast: false
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Clear /tmp
-        run: |
-          docker run --rm -v /tmp:/data alpine find /data -ctime +2 -exec rm -rf '{}' \; 2>&1 > /dev/null || true
-
-      - name: Clear old Docker resources
-        run: |
-          docker rm -f $(docker ps -aq) || true
-          docker volume rm $(docker volume ps -q) || true
-          docker system prune -af || true
-          docker image prune -af || true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -42,21 +31,17 @@ jobs:
           username: ${{ secrets.OSS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.OSS_DOCKERHUB_PASSWORD }}
 
-      - uses: actions/checkout@v3
-
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '${{ matrix.jdk_version }}'
           distribution: 'temurin'
 
-      - name: Remove old Concord artifacts
-        run: |
-          rm -rf ~/.m2/repository/com/walmartlabs/concord
-          rm -rf ~/actions-runner/.m2/repository/com/walmartlabs/concord
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Build and test with Maven
-        run: ./mvnw -B clean install -Pdocker -Pit -Pjdk${{ matrix.jdk_version }}
-        
+        run: ./mvnw -s .github/settings.xml -B clean install -Pgha -Pdocker -Pit -Pjdk${{ matrix.jdk_version }}
+
       - name: Build with debian docker images
-        run: ./mvnw -C -B -f docker-images install -DskipTests -Pdocker -Pdebian -Pjdk${{ matrix.jdk_version }}
+        run: ./mvnw -s .github/settings.xml -C -B -f docker-images install -DskipTests -Pgha -Pdocker -Pdebian -Pjdk${{ matrix.jdk_version }}

--- a/it/server/pom.xml
+++ b/it/server/pom.xml
@@ -29,6 +29,7 @@
         <it.ldap.addr>ldap-node:389</it.ldap.addr>
         <it.server.network.mode>custom</it.server.network.mode>
         <it.server.port>8001</it.server.port>
+        <it.skipDocker>false</it.skipDocker>
         <local.repository.src.mount>${settings.localRepository}</local.repository.src.mount>
         <network>net-server-it</network>
         <oldap.image>osixia/openldap</oldap.image>
@@ -268,6 +269,7 @@
                         <IT_LDAP_URL>ldap://localhost:${it.ldap.port}</IT_LDAP_URL>
                         <IT_PROJECT_VERSION>${project.version}</IT_PROJECT_VERSION>
                         <IT_SERVER_PORT>${it.server.port}</IT_SERVER_PORT>
+                        <IT_SKIP_DOCKER_TESTS>${it.skipDocker}</IT_SKIP_DOCKER_TESTS>
                     </environmentVariables>
                     <systemProperties>
                         <java.io.tmpdir>${tmp.dir}</java.io.tmpdir>

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
@@ -214,4 +214,8 @@ public abstract class AbstractServerIT {
         }
         return v;
     }
+
+    public static boolean shouldSkipDockerTests() {
+        return Boolean.parseBoolean(System.getenv("IT_SKIP_DOCKER_TESTS"));
+    }
 }

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/DockerAnsibleIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/DockerAnsibleIT.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.ProcessEntry;
 import com.walmartlabs.concord.client.StartProcessResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import java.io.File;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import static com.walmartlabs.concord.it.common.ServerClient.waitForCompletion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@DisabledIf(value = "shouldSkipDockerTests", disabledReason = "Requires dockerd listening on a tcp socket. Not available in a typical CI environment")
 public class DockerAnsibleIT extends AbstractServerIT {
 
     @Test

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/DockerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/DockerIT.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.client.ProcessApi;
 import com.walmartlabs.concord.client.ProcessEntry;
 import com.walmartlabs.concord.client.StartProcessResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +33,7 @@ import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@DisabledIf(value = "shouldSkipDockerTests", disabledReason = "Requires dockerd listening on a tcp socket. Not available in a typical CI environment")
 public class DockerIT extends AbstractServerIT {
 
     @Test


### PR DESCRIPTION
Only two test classes require our custom Docker setup (i.e. the 2375 port).