### PR TITLE
project: attach javadoc jars only on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
         <junit.version>5.8.2</junit.version>
         <liquibase.version>3.5.1
         </liquibase.version> <!-- the newer versions (up to 3.5.3) have incorrect mappings for PG's blob/bytea -->
-        <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
         <node.version>16.13.1</node.version>
         <frontend.plugin.version>1.12.0</frontend.plugin.version>
 
@@ -414,24 +413,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${maven.dependency.plugin.version}</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.2.0</version>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <quiet>true</quiet>
-                        <doclint>none</doclint>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -465,6 +452,22 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <quiet>true</quiet>
+                            <doclint>none</doclint>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Javadoc JARs are rarely needed for local development, skipping maven-javadoc-plugin in regular builds speeds things up a bit.