### PR TITLE
concord-server: remove more @Named

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -26,6 +26,8 @@
         <module>runtime-v1</module>
         <module>runtime-v2</module>
         <module>compat</module>
+
+        <module>testing-server</module>
     </modules>
 
     <properties>

--- a/it/testing-server/pom.xml
+++ b/it/testing-server/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.walmartlabs.concord.it</groupId>
+        <artifactId>parent</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>testing-concord-server</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.walmartlabs.concord.server</groupId>
+            <artifactId>concord-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.walmartlabs.concord.server.plugins.ansible</groupId>
+                    <artifactId>concord-ansible-plugin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.walmartlabs.concord.server.plugins</groupId>
+                    <artifactId>concord-oneops-plugin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.walmartlabs.concord.server.plugins.noderoster</groupId>
+                    <artifactId>concord-noderoster-plugin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.walmartlabs.concord.server.plugins</groupId>
+                    <artifactId>pfed-sso</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
+++ b/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
@@ -1,0 +1,97 @@
+package com.walmartlabs.concord.it.testingserver;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigResolveOptions;
+import com.walmartlabs.concord.server.ConcordServer;
+import com.walmartlabs.concord.server.ConcordServerModule;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+public class TestingConcordServer implements AutoCloseable {
+
+    private PostgreSQLContainer<?> db;
+    private ConcordServer server;
+
+    public TestingConcordServer start() throws Exception {
+        db = new PostgreSQLContainer<>("postgres:15-alpine");
+        db.start();
+
+        server = ConcordServer.withModules(new ConcordServerModule(prepareConfig(db)))
+                .start();
+
+        return this;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.stop();
+    }
+
+    public void stop() throws Exception {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+
+        if (db != null) {
+            db.stop();
+            db = null;
+        }
+    }
+
+    private static Config prepareConfig(PostgreSQLContainer<?> db) {
+        Config testConfig = ConfigFactory.parseMap(Map.of(
+                "db.url", db.getJdbcUrl(),
+                "db.appUsername", db.getUsername(),
+                "db.appPassword", db.getPassword(),
+                "db.inventoryUsername", db.getUsername(),
+                "db.inventoryPassword", db.getPassword(),
+                "db.changeLogParameters.defaultAdminToken", "foobar",
+                "secretStore.serverPassword", randomString(),
+                "secretStore.secretStoreSalt", randomString(),
+                "secretStore.projectSecretSalt", randomString()
+        ));
+
+        Config defaultConfig = ConfigFactory.load("concord-server.conf", ConfigParseOptions.defaults(), ConfigResolveOptions.defaults().setAllowUnresolved(true))
+                .getConfig("concord-server");
+
+        return testConfig.withFallback(defaultConfig).resolve();
+    }
+
+    private static String randomString() {
+        byte[] ab = new byte[64];
+        new SecureRandom().nextBytes(ab);
+        return Base64.getEncoder().encodeToString(ab);
+    }
+
+    public static void main(String[] args) throws Exception {
+        TestingConcordServer server = new TestingConcordServer().start();
+        Thread.sleep(100000);
+        server.stop();
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
@@ -55,7 +55,8 @@ public final class ConcordServer {
      */
     public static ConcordServer withAutoWiring() throws Exception {
         ClassLoader cl = ConcordServer.class.getClassLoader();
-        return withModules(new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
+        return withModules(
+                new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
     }
 
     /**

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServerModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServerModule.java
@@ -24,18 +24,22 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.typesafe.config.Config;
 import com.walmartlabs.concord.db.DatabaseModule;
+import com.walmartlabs.concord.dependencymanager.DependencyManagerConfiguration;
 import com.walmartlabs.concord.server.agent.AgentModule;
 import com.walmartlabs.concord.server.audit.AuditLogModule;
 import com.walmartlabs.concord.server.boot.BackgroundTasks;
 import com.walmartlabs.concord.server.cfg.ConfigurationModule;
 import com.walmartlabs.concord.server.cfg.DatabaseConfigurationModule;
 import com.walmartlabs.concord.server.console.ConsoleModule;
+import com.walmartlabs.concord.server.events.EventModule;
 import com.walmartlabs.concord.server.metrics.MetricModule;
+import com.walmartlabs.concord.server.org.secret.SecretModule;
 import com.walmartlabs.concord.server.org.triggers.TriggersModule;
 import com.walmartlabs.concord.server.policy.PolicyModule;
 import com.walmartlabs.concord.server.process.ProcessModule;
 import com.walmartlabs.concord.server.repository.RepositoryModule;
 import com.walmartlabs.concord.server.role.RoleModule;
+import com.walmartlabs.concord.server.security.SecurityModule;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyModule;
 import com.walmartlabs.concord.server.task.TaskSchedulerModule;
 import com.walmartlabs.concord.server.template.TemplateModule;
@@ -75,15 +79,20 @@ public class ConcordServerModule implements Module {
         binder.install(new TaskSchedulerModule());
         binder.bind(BackgroundTasks.class).in(SINGLETON);
 
+        binder.bind(DependencyManagerConfiguration.class).toProvider(DependencyManagerConfigurationProvider.class);
+
         binder.install(new AgentModule());
         binder.install(new ApiKeyModule());
-        binder.install(new ConsoleModule());
         binder.install(new ApiServerModule());
         binder.install(new AuditLogModule());
+        binder.install(new ConsoleModule());
+        binder.install(new EventModule());
         binder.install(new PolicyModule());
         binder.install(new ProcessModule());
         binder.install(new RepositoryModule());
         binder.install(new RoleModule());
+        binder.install(new SecretModule());
+        binder.install(new SecurityModule());
         binder.install(new TemplateModule());
         binder.install(new TriggersModule());
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServerModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServerModule.java
@@ -11,7 +11,7 @@ package com.walmartlabs.concord.server;
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.typesafe.config.Config;
 import com.walmartlabs.concord.db.DatabaseModule;
 import com.walmartlabs.concord.server.agent.AgentModule;
 import com.walmartlabs.concord.server.audit.AuditLogModule;
@@ -38,6 +39,9 @@ import com.walmartlabs.concord.server.role.RoleModule;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyModule;
 import com.walmartlabs.concord.server.task.TaskSchedulerModule;
 import com.walmartlabs.concord.server.template.TemplateModule;
+import com.walmartlabs.ollie.config.ConfigurationProcessor;
+import com.walmartlabs.ollie.config.Environment;
+import com.walmartlabs.ollie.config.EnvironmentSelector;
 
 import javax.inject.Named;
 
@@ -50,9 +54,19 @@ import static com.walmartlabs.concord.server.Utils.bindJaxRsResource;
 @Named
 public class ConcordServerModule implements Module {
 
+    private final Config config;
+
+    public ConcordServerModule() {
+        this(loadDefaultConfig());
+    }
+
+    public ConcordServerModule(Config config) {
+        this.config = config;
+    }
+
     @Override
     public void configure(Binder binder) {
-        binder.install(new ConfigurationModule());
+        binder.install(new ConfigurationModule(config));
         binder.install(new MetricModule());
 
         binder.install(new DatabaseConfigurationModule());
@@ -74,5 +88,10 @@ public class ConcordServerModule implements Module {
         binder.install(new TriggersModule());
 
         bindJaxRsResource(binder, ServerResource.class);
+    }
+
+    private static Config loadDefaultConfig() {
+        Environment env = new EnvironmentSelector().select();
+        return new ConfigurationProcessor("concord-server", env, null, null).process();
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/DependencyManagerConfigurationProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/DependencyManagerConfigurationProvider.java
@@ -24,11 +24,9 @@ import com.walmartlabs.concord.dependencymanager.DependencyManagerConfiguration;
 import com.walmartlabs.concord.server.cfg.DependenciesConfiguration;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-@Named
 @Singleton
 public class DependencyManagerConfigurationProvider implements Provider<DependencyManagerConfiguration> {
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ConfigurationModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ConfigurationModule.java
@@ -22,20 +22,21 @@ package com.walmartlabs.concord.server.cfg;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.walmartlabs.ollie.config.ConfigurationProcessor;
-import com.walmartlabs.ollie.config.Environment;
-import com.walmartlabs.ollie.config.EnvironmentSelector;
-import com.walmartlabs.ollie.config.OllieConfigurationModule;
+import com.typesafe.config.Config;
 
 import static com.google.inject.Scopes.SINGLETON;
 
 public class ConfigurationModule implements Module {
 
+    private final Config config;
+
+    public ConfigurationModule(Config config) {
+        this.config = config;
+    }
+
     @Override
     public void configure(Binder binder) {
-        Environment env = new EnvironmentSelector().select();
-        com.typesafe.config.Config config = new ConfigurationProcessor("concord-server", env, null, null).process();
-        binder.install(new OllieConfigurationModule("com.walmartlabs.concord.server", config));
+        binder.install(new com.walmartlabs.ollie.config.OllieConfigurationModule("com.walmartlabs.concord.server", config));
 
         binder.bind(AgentConfiguration.class).in(SINGLETON);
         binder.bind(ApiKeyConfiguration.class).in(SINGLETON);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/EventModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/EventModule.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.server.audit;
+package com.walmartlabs.concord.server.events;
 
 /*-
  * *****
@@ -22,18 +22,14 @@ package com.walmartlabs.concord.server.audit;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.walmartlabs.concord.server.sdk.audit.AuditLogListener;
+import com.walmartlabs.concord.server.sdk.events.ProcessEventListener;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-import static com.walmartlabs.concord.server.Utils.bindJaxRsResource;
-import static com.walmartlabs.concord.server.Utils.bindSingletonScheduledTask;
 
-public class AuditLogModule implements Module {
+public class EventModule implements Module {
 
     @Override
     public void configure(Binder binder) {
-        newSetBinder(binder, AuditLogListener.class);
-        bindSingletonScheduledTask(binder, AuditLogCleaner.class);
-        bindJaxRsResource(binder, AuditLogResource.class);
+        newSetBinder(binder, ProcessEventListener.class);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/MetricModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/MetricModule.java
@@ -24,9 +24,11 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.matcher.Matchers;
+import com.walmartlabs.concord.server.sdk.metrics.GaugeProvider;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 
 import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.walmartlabs.concord.server.Utils.bindServletHolder;
 import static com.walmartlabs.concord.server.Utils.bindSingletonBackgroundTask;
 import static com.walmartlabs.concord.server.metrics.NoSyntheticMethodMatcher.INSTANCE;
@@ -35,6 +37,10 @@ public class MetricModule implements Module {
 
     @Override
     public void configure(Binder binder) {
+        // common
+
+        newSetBinder(binder, GaugeProvider.class);
+
         // registry
 
         binder.bind(MetricRegistry.class).toProvider(MetricRegistryProvider.class).in(SINGLETON);
@@ -50,9 +56,9 @@ public class MetricModule implements Module {
 
         // tasks
 
-        bindSingletonBackgroundTask(binder, MetricsRegistrator.class);
         bindSingletonBackgroundTask(binder, FailedTaskMetrics.class);
         bindSingletonBackgroundTask(binder, WorkerMetrics.class);
+        bindSingletonBackgroundTask(binder, MetricsRegistrator.class);
 
         // the /metrics endpoint
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/MetricsRegistrator.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/MetricsRegistrator.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.server.metrics;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,10 +33,10 @@ import java.util.Set;
 public class MetricsRegistrator implements BackgroundTask {
 
     private final MetricRegistry registry;
-    private final Set<GaugeProvider<?>> gauges;
+    private final Set<GaugeProvider> gauges;
 
     @Inject
-    public MetricsRegistrator(MetricRegistry registry, Set<GaugeProvider<?>> gauges) {
+    public MetricsRegistrator(MetricRegistry registry, Set<GaugeProvider> gauges) {
         this.registry = registry;
         this.gauges = gauges;
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/SecretModule.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.server.audit;
+package com.walmartlabs.concord.server.org.secret;
 
 /*-
  * *****
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.server.audit;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,18 +22,15 @@ package com.walmartlabs.concord.server.audit;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.walmartlabs.concord.server.sdk.audit.AuditLogListener;
+import com.walmartlabs.concord.server.org.secret.store.SecretStore;
+import com.walmartlabs.concord.server.org.secret.store.concord.ConcordSecretStore;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-import static com.walmartlabs.concord.server.Utils.bindJaxRsResource;
-import static com.walmartlabs.concord.server.Utils.bindSingletonScheduledTask;
 
-public class AuditLogModule implements Module {
+public class SecretModule implements Module {
 
     @Override
     public void configure(Binder binder) {
-        newSetBinder(binder, AuditLogListener.class);
-        bindSingletonScheduledTask(binder, AuditLogCleaner.class);
-        bindJaxRsResource(binder, AuditLogResource.class);
+        newSetBinder(binder, SecretStore.class).addBinding().to(ConcordSecretStore.class);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/provider/SecretStoreProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/provider/SecretStoreProvider.java
@@ -27,16 +27,17 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 
 @Named
 public class SecretStoreProvider {
 
-    private final Collection<SecretStore> stores;
+    private final Set<SecretStore> stores;
     private final int maxSecretDataSize;
     private final String defaultSecretStoreType;
 
     @Inject
-    public SecretStoreProvider(Collection<SecretStore> stores,
+    public SecretStoreProvider(Set<SecretStore> stores,
                                @Config("secretStore.maxSecretDataSize") int maxSecretDataSize,
                                @Config("secretStore.default") String defaultStore) {
         this.stores = stores;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/concord/ConcordSecretStore.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/secret/store/concord/ConcordSecretStore.java
@@ -30,8 +30,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.UUID;
 
-@Named("concordSecretStore")
-@Singleton
 public class ConcordSecretStore implements SecretStore {
 
     private static final String TYPE = "concord";

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ImportManagerProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ImportManagerProvider.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.server;
+package com.walmartlabs.concord.server.process;
 
 /*-
  * *****
@@ -35,13 +35,11 @@ import com.walmartlabs.concord.server.org.secret.SecretManager;
 import com.walmartlabs.concord.server.repository.RepositoryManager;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
 
-@Named
 public class ImportManagerProvider implements Provider<ImportManager> {
 
     private final ImportManagerFactory factory;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ExclusiveGroupProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ExclusiveGroupProcessor.java
@@ -262,11 +262,11 @@ public class ExclusiveGroupProcessor implements PayloadProcessor {
 
         public boolean exists(DSLContext tx, UUID currentInstanceId, UUID parentInstanceId, UUID projectId, String exclusiveGroup) {
             SelectConditionStep<Record1<Integer>> s = tx.selectOne()
-                    .from(PROCESS_QUEUE)
-                    .where(jsonbText(PROCESS_QUEUE.EXCLUSIVE, "group").eq(exclusiveGroup)
-                            .and(PROCESS_QUEUE.PROJECT_ID.eq(projectId)
-                                    .and(PROCESS_QUEUE.INSTANCE_ID.notEqual(currentInstanceId)
-                                            .and(PROCESS_QUEUE.CURRENT_STATUS.in(RUNNING_STATUSES)))));
+                            .from(PROCESS_QUEUE)
+                            .where(jsonbText(PROCESS_QUEUE.EXCLUSIVE, "group").eq(exclusiveGroup)
+                                    .and(PROCESS_QUEUE.PROJECT_ID.eq(projectId)
+                                            .and(PROCESS_QUEUE.INSTANCE_ID.notEqual(currentInstanceId)
+                                                    .and(PROCESS_QUEUE.CURRENT_STATUS.in(RUNNING_STATUSES)))));
 
             // parent's
             if (parentInstanceId != null) {
@@ -326,14 +326,14 @@ public class ExclusiveGroupProcessor implements PayloadProcessor {
                                             .and(PROCESS_QUEUE.CURRENT_STATUS.in(CANCELLABLE_STATUSES)))));
 
             SelectJoinStep<Record1<UUID>> children = tx.withRecursive("children").as(
-                            select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID).from(ProcessQueue.PROCESS_QUEUE)
-                                    .where(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(currentProcessKey.getInstanceId()))
-                                    .unionAll(
-                                            select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID)
-                                                    .from(ProcessQueue.PROCESS_QUEUE)
-                                                    .join(name("children"))
-                                                    .on(ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID.eq(
-                                                            field(name("children", "INSTANCE_ID"), UUID.class)))))
+                    select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID).from(ProcessQueue.PROCESS_QUEUE)
+                            .where(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(currentProcessKey.getInstanceId()))
+                            .unionAll(
+                                    select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID)
+                                            .from(ProcessQueue.PROCESS_QUEUE)
+                                            .join(name("children"))
+                                            .on(ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID.eq(
+                                                    field(name("children", "INSTANCE_ID"), UUID.class)))))
                     .select(field("children.INSTANCE_ID", UUID.class))
                     .from(name("children"));
 
@@ -346,14 +346,14 @@ public class ExclusiveGroupProcessor implements PayloadProcessor {
 
     private static SelectJoinStep<Record1<UUID>> parents(DSLContext tx, UUID parentInstanceId) {
         return tx.withRecursive("parents").as(
-                        select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID).from(ProcessQueue.PROCESS_QUEUE)
-                                .where(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(parentInstanceId))
-                                .unionAll(
-                                        select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID)
-                                                .from(ProcessQueue.PROCESS_QUEUE)
-                                                .join(name("parents"))
-                                                .on(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(
-                                                        field(name("parents", "PARENT_INSTANCE_ID"), UUID.class)))))
+                select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID).from(ProcessQueue.PROCESS_QUEUE)
+                        .where(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(parentInstanceId))
+                        .unionAll(
+                                select(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID, ProcessQueue.PROCESS_QUEUE.PARENT_INSTANCE_ID)
+                                        .from(ProcessQueue.PROCESS_QUEUE)
+                                        .join(name("parents"))
+                                        .on(ProcessQueue.PROCESS_QUEUE.INSTANCE_ID.eq(
+                                                field(name("parents", "PARENT_INSTANCE_ID"), UUID.class)))))
                 .select(field("parents.INSTANCE_ID", UUID.class))
                 .from(name("parents"));
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ForkPolicyProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ForkPolicyProcessor.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.server.process.pipelines.processors;
  */
 
 import com.walmartlabs.concord.db.AbstractDao;
+import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.policyengine.CheckResult;
 import com.walmartlabs.concord.policyengine.ForkDepthRule;
 import com.walmartlabs.concord.policyengine.PolicyEngine;
@@ -106,7 +107,7 @@ public class ForkPolicyProcessor implements PayloadProcessor {
     private static class ForkDepthDao extends AbstractDao {
 
         @Inject
-        public ForkDepthDao(Configuration cfg) {
+        public ForkDepthDao(@MainDB Configuration cfg) {
             super(cfg);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ContainerPolicyApplier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ContainerPolicyApplier.java
@@ -33,7 +33,6 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.InjectCounter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -42,7 +41,6 @@ import java.util.Map;
 
 import static com.walmartlabs.concord.server.process.pipelines.processors.policy.PolicyApplier.appendMsg;
 
-@Named
 public class ContainerPolicyApplier implements PolicyApplier {
 
     private final ProcessLogManager logManager;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/FilePolicyApplier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/FilePolicyApplier.java
@@ -31,10 +31,8 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.InjectCounter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.nio.file.Path;
 
-@Named
 public class FilePolicyApplier implements PolicyApplier {
 
     private final ProcessLogManager logManager;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ProcessRuntimePolicyApplier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ProcessRuntimePolicyApplier.java
@@ -32,7 +32,6 @@ import com.walmartlabs.concord.server.process.logs.ProcessLogManager;
 import com.walmartlabs.concord.server.sdk.metrics.InjectCounter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -40,7 +39,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-@Named
 public class ProcessRuntimePolicyApplier implements PolicyApplier {
 
     private static final String DEFAULT_PROCESS_TIMEOUT_MSG = "{0} runtime version is not allowed";

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ProcessTimeoutPolicyApplier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/ProcessTimeoutPolicyApplier.java
@@ -32,11 +32,9 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.InjectCounter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.text.MessageFormat;
 import java.util.Map;
 
-@Named
 public class ProcessTimeoutPolicyApplier implements PolicyApplier {
 
     private static final String DEFAULT_PROCESS_TIMEOUT_MSG = "Maximum 'processTimeout' value exceeded: current {0}, limit {1}";

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/WorkspacePolicyApplier.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/policy/WorkspacePolicyApplier.java
@@ -31,12 +31,10 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.InjectCounter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.nio.file.Path;
 
 import static com.walmartlabs.concord.server.process.pipelines.processors.policy.PolicyApplier.appendMsg;
 
-@Named
 public class WorkspacePolicyApplier implements PolicyApplier {
 
     private final ProcessLogManager logManager;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ExternalProcessListenerHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ExternalProcessListenerHandler.java
@@ -28,14 +28,12 @@ import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import org.jooq.DSLContext;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.Collections;
 
 /**
  * Sends {@link EventType#PROCESS_STATUS} events to registered {@link com.walmartlabs.concord.server.sdk.events.ProcessEventListener}
  * instances.
  */
-@Named
 public class ExternalProcessListenerHandler implements ProcessStatusListener {
 
     private final ProcessEventManager eventManager;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueManager.java
@@ -49,7 +49,7 @@ public class ProcessQueueManager {
     private final ProcessKeyCache keyCache;
     private final ProcessEventManager eventManager;
     private final ProcessLogManager processLogManager;
-    private final Collection<ProcessStatusListener> statusListeners;
+    private final Set<ProcessStatusListener> statusListeners;
 
     private static final Set<ProcessStatus> TO_ENQUEUED_STATUSES = new HashSet<>(Arrays.asList(
             ProcessStatus.PREPARING, ProcessStatus.RESUMING, ProcessStatus.SUSPENDED
@@ -60,7 +60,7 @@ public class ProcessQueueManager {
                                ProcessKeyCache keyCache,
                                ProcessEventManager eventManager,
                                ProcessLogManager processLogManager,
-                               Collection<ProcessStatusListener> statusListeners) {
+                               Set<ProcessStatusListener> statusListeners) {
 
         this.queueDao = queueDao;
         this.eventManager = eventManager;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/ConcurrentProcessFilter.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/ConcurrentProcessFilter.java
@@ -33,7 +33,6 @@ import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import org.jooq.DSLContext;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.*;
 
 /**
@@ -41,7 +40,6 @@ import java.util.*;
  * The process won't be scheduled for execution until the number of currently running
  * processes in the same project exceeds the configured value.
  */
-@Named
 public class ConcurrentProcessFilter extends WaitProcessFinishFilter {
 
     private static final Set<ProcessStatus> FINAL_STATUSES = ImmutableSet.of(

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/ExclusiveProcessFilter.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/ExclusiveProcessFilter.java
@@ -27,7 +27,6 @@ import com.walmartlabs.concord.server.process.waits.ProcessWaitManager;
 import org.jooq.DSLContext;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.*;
 
 /**
@@ -35,7 +34,6 @@ import java.util.*;
  * Exclusive processes can't be executed when there is another process
  * running in the same project and group.
  */
-@Named
 public class ExclusiveProcessFilter extends WaitProcessFinishFilter {
 
     private final ExclusiveProcessFilterDao dao;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
@@ -43,7 +43,6 @@ import static com.walmartlabs.concord.server.process.waits.ProcessCompletionCond
 /**
  * Handles the processes that are waiting for other processes to finish.
  */
-@Named
 @Singleton
 public class WaitProcessFinishHandler implements ProcessWaitHandler<ProcessCompletionCondition> {
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessLockHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessLockHandler.java
@@ -26,14 +26,12 @@ import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
  * Handles the processes that are waiting for locks. Resumes a suspended process
  * if the lock was acquired successfully.
  */
-@Named
 @Singleton
 public class WaitProcessLockHandler implements ProcessWaitHandler<ProcessLockCondition> {
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessSleepHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessSleepHandler.java
@@ -23,7 +23,6 @@ package com.walmartlabs.concord.server.process.waits;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 
-import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Date;
 
@@ -31,7 +30,6 @@ import java.util.Date;
  * Handles the processes that are waiting for some timeout. Resumes a suspended process
  * if the timeout exceeded.
  */
-@Named
 @Singleton
 public class WaitProcessSleepHandler implements ProcessWaitHandler<ProcessSleepCondition> {
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessStatusListener.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessStatusListener.java
@@ -29,7 +29,6 @@ import javax.inject.Named;
 
 import static com.walmartlabs.concord.server.jooq.Tables.PROCESS_WAIT_CONDITIONS;
 
-@Named
 public class WaitProcessStatusListener implements ProcessStatusListener {
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/SecurityModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/SecurityModule.java
@@ -26,20 +26,16 @@ import com.walmartlabs.concord.server.security.apikey.ApiKeyRealm;
 import com.walmartlabs.concord.server.security.github.GithubRealm;
 import com.walmartlabs.concord.server.security.internal.InternalRealm;
 import com.walmartlabs.concord.server.security.internal.LocalUserInfoProvider;
-import com.walmartlabs.concord.server.security.ldap.LdapRealm;
-import com.walmartlabs.concord.server.security.ldap.LdapUserInfoProvider;
-import com.walmartlabs.concord.server.security.ldap.UserLdapGroupSynchronizer;
+import com.walmartlabs.concord.server.security.ldap.*;
 import com.walmartlabs.concord.server.security.sessionkey.SessionKeyRealm;
 import com.walmartlabs.concord.server.user.UserInfoProvider;
 import org.apache.shiro.realm.Realm;
-
-import javax.inject.Named;
+import org.apache.shiro.realm.ldap.LdapContextFactory;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.walmartlabs.concord.server.Utils.bindSingletonScheduledTask;
 
-@Named
 public class SecurityModule implements Module {
 
     @Override
@@ -49,6 +45,9 @@ public class SecurityModule implements Module {
         newSetBinder(binder, Realm.class).addBinding().to(InternalRealm.class);
         newSetBinder(binder, Realm.class).addBinding().to(LdapRealm.class);
         newSetBinder(binder, Realm.class).addBinding().to(SessionKeyRealm.class);
+
+        binder.bind(LdapManager.class).toProvider(LdapManagerProvider.class);
+        binder.bind(LdapContextFactory.class).toProvider(LdapContextFactoryProvider.class);
 
         bindSingletonScheduledTask(binder, UserLdapGroupSynchronizer.class);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapContextFactoryProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapContextFactoryProvider.java
@@ -28,7 +28,6 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.naming.NamingException;
 
-@Named
 public class LdapContextFactoryProvider implements Provider<LdapContextFactory> {
 
     private final LdapConfiguration cfg;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapManagerProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/ldap/LdapManagerProvider.java
@@ -24,18 +24,16 @@ import com.walmartlabs.concord.server.cfg.LdapConfiguration;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.time.Duration;
 
-@Named
 public class LdapManagerProvider implements Provider<LdapManager> {
 
     private final LdapManager ldapManager;
 
     @Inject
     public LdapManagerProvider(LdapConfiguration cfg,
-                                 LdapContextFactory ctxFactory) {
+                               LdapContextFactory ctxFactory) {
 
         LdapManager manager = new LdapManagerImpl(cfg, ctxFactory);
 

--- a/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaConnector.java
+++ b/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaConnector.java
@@ -28,14 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Properties;
 
-@Named
-@Singleton
 public class KafkaConnector implements BackgroundTask {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaConnector.class);

--- a/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaEventSink.java
+++ b/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaEventSink.java
@@ -31,11 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.Collections;
 import java.util.List;
 
-@Named
 public class KafkaEventSink implements ProcessEventListener, ProcessLogListener, AuditLogListener {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaEventSink.class);

--- a/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaEventSinkConfiguration.java
+++ b/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaEventSinkConfiguration.java
@@ -24,10 +24,8 @@ import com.walmartlabs.ollie.config.Config;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.Serializable;
 
-@Named
 public class KafkaEventSinkConfiguration implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaModule.java
+++ b/server/plugins/kafka-event-sink/src/main/java/com/walmartlabs/concord/server/plugins/eventsink/kafka/KafkaModule.java
@@ -1,0 +1,50 @@
+package com.walmartlabs.concord.server.plugins.eventsink.kafka;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.walmartlabs.concord.server.sdk.BackgroundTask;
+import com.walmartlabs.concord.server.sdk.audit.AuditLogListener;
+import com.walmartlabs.concord.server.sdk.events.ProcessEventListener;
+import com.walmartlabs.concord.server.sdk.log.ProcessLogListener;
+
+import javax.inject.Named;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+@Named
+public class KafkaModule implements Module {
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(KafkaEventSinkConfiguration.class).in(SINGLETON);
+
+        binder.bind(KafkaEventSink.class).in(SINGLETON);
+        newSetBinder(binder, ProcessEventListener.class).addBinding().to(KafkaEventSink.class);
+        newSetBinder(binder, ProcessLogListener.class).addBinding().to(KafkaEventSink.class);
+        newSetBinder(binder, AuditLogListener.class).addBinding().to(KafkaEventSink.class);
+
+        binder.bind(KafkaConnector.class).in(SINGLETON);
+        newSetBinder(binder, BackgroundTask.class).addBinding().to(KafkaConnector.class);
+    }
+}

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -1180,6 +1180,11 @@
                 <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>uk.org.lidalia</groupId>
                 <artifactId>sysout-over-slf4j</artifactId>
                 <version>${sysoutslf4j.version}</version>


### PR DESCRIPTION
Remove even more autoinjections.
Allows somewhat easier embedding of concord-server (see com.walmartlabs.concord.it.testingserver.TestingConcordServer for demo)