### PR TITLE
Minor changes

### DIFF
--- a/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
+++ b/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
@@ -84,6 +84,10 @@ public class TestingConcordServer implements AutoCloseable {
         }
     }
 
+    public ConcordServer getServer() {
+        return server;
+    }
+
     public PostgreSQLContainer<?> getDb() {
         return db;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,9 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <skipSource>true</skipSource>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -468,6 +471,21 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipSource>false</skipSource>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
- attach source JARs only when running with `-Pconcord-release`. This shaves off some seconds from regular builds;
- expose a getter to retrive the server instance in TestingConcordServer. Useful for getting service references in tests.