### PR TITLE
concord-server: auto-wire modules in dist instead of impl

### DIFF
--- a/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
+++ b/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.it.testingserver;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,10 +40,11 @@ import static java.util.Objects.requireNonNull;
 
 public class TestingConcordServer implements AutoCloseable {
 
+    private final Map<String, String> extraConfiguration;
+    private final List<Function<Config, Module>> extraModules;
+
     private PostgreSQLContainer<?> db;
     private ConcordServer server;
-    private Map<String, String> extraConfiguration;
-    private List<Function<Config, Module>> extraModules;
 
     public TestingConcordServer(Map<String, String> extraConfiguration, List<Function<Config, Module>> extraModules) {
         this.extraConfiguration = requireNonNull(extraConfiguration);
@@ -119,10 +120,24 @@ public class TestingConcordServer implements AutoCloseable {
         return Base64.getEncoder().encodeToString(ab);
     }
 
+    /**
+     * Just an example.
+     */
     public static void main(String[] args) throws Exception {
         try (TestingConcordServer server = new TestingConcordServer(Map.of("process.watchdogPeriod", "10 seconds"), List.of())) {
             server.start();
-            Thread.sleep(100000);
+
+            System.out.println("""
+                    ==============================================================
+                                        
+                      UI: http://localhost:8001/
+                      DB:
+                        JDBC URL: %s
+                        username: %s
+                        password: %s
+                    """.formatted(server.getDb().getJdbcUrl(), server.getDb().getUsername(), server.getDb().getPassword()));
+
+            Thread.currentThread().join();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,9 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -106,10 +107,6 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -146,10 +143,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.1</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>

--- a/server/dist/src/main/java/com/walmartlabs/concord/server/dist/Main.java
+++ b/server/dist/src/main/java/com/walmartlabs/concord/server/dist/Main.java
@@ -22,6 +22,10 @@ package com.walmartlabs.concord.server.dist;
 
 import com.walmartlabs.concord.server.ConcordServer;
 import com.walmartlabs.concord.server.Version;
+import org.eclipse.sisu.space.BeanScanning;
+import org.eclipse.sisu.space.SpaceModule;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.eclipse.sisu.wire.WireModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -38,10 +42,15 @@ public class Main {
 
         long t1 = System.currentTimeMillis();
 
-        ConcordServer.withAutoWiring()
-                .start();
+        autoWire().start();
 
         long t2 = System.currentTimeMillis();
         log.info("main -> started in {}ms", (t2 - t1));
+    }
+
+    public static ConcordServer autoWire() throws Exception {
+        // works as a plugin system by automatically wiring all @Named modules and beans in the classpath
+        ClassLoader cl = ConcordServer.class.getClassLoader();
+        return ConcordServer.withModules(new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ConcordServer.java
@@ -25,10 +25,6 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.walmartlabs.concord.server.boot.BackgroundTasks;
 import com.walmartlabs.concord.server.boot.HttpServer;
-import org.eclipse.sisu.space.BeanScanning;
-import org.eclipse.sisu.space.SpaceModule;
-import org.eclipse.sisu.space.URLClassSpace;
-import org.eclipse.sisu.wire.WireModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,16 +46,6 @@ public final class ConcordServer {
     private HttpServer server;
 
     private final Object controlMutex = new Object();
-
-    /**
-     * Start ConcordServer by scanning the local class path for the implementations of
-     * {@link HttpServer} or {@link BackgroundTasks}.
-     */
-    public static ConcordServer withAutoWiring() throws Exception {
-        ClassLoader cl = ConcordServer.class.getClassLoader();
-        return withModules(
-                new WireModule(new SpaceModule(new URLClassSpace(cl), BeanScanning.GLOBAL_INDEX)));
-    }
 
     public static ConcordServer withModules(Module... modules) throws Exception {
         return withModules(List.of(modules));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessHeartbeatResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessHeartbeatResource.java
@@ -26,15 +26,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sonatype.siesta.Resource;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import java.util.UUID;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "ProcessHeartbeat")
 public class ProcessHeartbeatResource implements Resource {
@@ -45,7 +41,6 @@ public class ProcessHeartbeatResource implements Resource {
     public ProcessHeartbeatResource(ProcessQueueDao queueDao) {
         this.queueDao = queueDao;
     }
-
 
     @POST
     @Path("{id}/ping")

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessKvResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessKvResource.java
@@ -31,14 +31,10 @@ import org.slf4j.LoggerFactory;
 import org.sonatype.siesta.Resource;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.UUID;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "Process KV store")
 public class ProcessKvResource implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessLogResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessLogResourceV2.java
@@ -39,8 +39,6 @@ import org.sonatype.siesta.Resource;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -56,8 +54,6 @@ import static com.walmartlabs.concord.server.process.logs.ProcessLogsDao.Process
 /**
  * API to work with segmented process logs.
  */
-@Named
-@Singleton
 @Path("/api/v2/process")
 @Tag(name = "ProcessLogV2")
 public class ProcessLogResourceV2 implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.server.process;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,11 @@ package com.walmartlabs.concord.server.process;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.walmartlabs.concord.imports.ImportManager;
+import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointResource;
+import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV2Resource;
+import com.walmartlabs.concord.server.process.event.ProcessEventResource;
+import com.walmartlabs.concord.server.process.form.FormResource;
+import com.walmartlabs.concord.server.process.locks.ProcessLocksResource;
 import com.walmartlabs.concord.server.process.locks.ProcessLocksWatchdog;
 import com.walmartlabs.concord.server.process.pipelines.processors.ExclusiveGroupProcessor;
 import com.walmartlabs.concord.server.process.pipelines.processors.policy.*;
@@ -40,6 +45,7 @@ import com.walmartlabs.concord.server.sdk.log.ProcessLogListener;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.walmartlabs.concord.server.Utils.bindJaxRsResource;
 import static com.walmartlabs.concord.server.Utils.bindSingletonScheduledTask;
 
 public class ProcessModule implements Module {
@@ -77,5 +83,16 @@ public class ProcessModule implements Module {
         newSetBinder(binder, PolicyApplier.class).addBinding().to(ProcessRuntimePolicyApplier.class);
         newSetBinder(binder, PolicyApplier.class).addBinding().to(ProcessTimeoutPolicyApplier.class);
         newSetBinder(binder, PolicyApplier.class).addBinding().to(WorkspacePolicyApplier.class);
+
+        bindJaxRsResource(binder, FormResource.class);
+        bindJaxRsResource(binder, ProcessCheckpointResource.class);
+        bindJaxRsResource(binder, ProcessCheckpointV2Resource.class);
+        bindJaxRsResource(binder, ProcessEventResource.class);
+        bindJaxRsResource(binder, ProcessHeartbeatResource.class);
+        bindJaxRsResource(binder, ProcessKvResource.class);
+        bindJaxRsResource(binder, ProcessLocksResource.class);
+        bindJaxRsResource(binder, ProcessLogResourceV2.class);
+        bindJaxRsResource(binder, ProcessResource.class);
+        bindJaxRsResource(binder, ProcessResourceV2.class);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -79,15 +79,16 @@ import org.sonatype.siesta.Validate;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.Status;
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -98,8 +99,6 @@ import java.util.stream.Collectors;
 import static com.walmartlabs.concord.server.process.state.ProcessStateManager.path;
 import static com.walmartlabs.concord.server.process.state.ProcessStateManager.zipTo;
 
-@Named
-@Singleton
 @javax.ws.rs.Path("/api/v1/process")
 @Tag(name = "Process")
 public class ProcessResource implements Resource {
@@ -260,7 +259,6 @@ public class ProcessResource implements Resource {
 
     /**
      * Starts a new process instance.
-     *
      */
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -478,9 +476,9 @@ public class ProcessResource implements Resource {
 
             ProcessStatus s = r.status();
             if (s == ProcessStatus.FINISHED ||
-                    s == ProcessStatus.FAILED ||
-                    s == ProcessStatus.CANCELLED ||
-                    s == ProcessStatus.TIMED_OUT) {
+                s == ProcessStatus.FAILED ||
+                s == ProcessStatus.CANCELLED ||
+                s == ProcessStatus.TIMED_OUT) {
                 return r;
             }
 
@@ -758,6 +756,7 @@ public class ProcessResource implements Resource {
 
     /**
      * Appends a process' log.
+     *
      * @deprecated in favor of the /api/v2/process/{id}/log* endpoints
      */
     @POST
@@ -1033,7 +1032,7 @@ public class ProcessResource implements Resource {
         }
 
         throw new UnauthorizedException("The current user (" + principal.getUsername() + ") doesn't have " +
-                "the necessary permissions to the download " + downloadEntity + " : " + pe.instanceId());
+                                        "the necessary permissions to the download " + downloadEntity + " : " + pe.instanceId());
     }
 
     private void assertResourceAccess(ProcessEntry pe, String resource) {
@@ -1109,7 +1108,7 @@ public class ProcessResource implements Resource {
 
     private static RuntimeException syncIsForbidden() {
         return new ConcordApplicationException("The 'sync' mode is no longer available. " +
-                "Please use sync=false and poll for the status updates.", Status.BAD_REQUEST);
+                                               "Please use sync=false and poll for the status updates.", Status.BAD_REQUEST);
     }
 
     private void assertAttachmentsPolicy(Path tmpDir, ProcessEntry entry) throws IOException {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResourceV2.java
@@ -43,31 +43,23 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.siesta.Resource;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import java.util.*;
 
 import static com.walmartlabs.concord.server.Utils.unwrap;
 
-@Named
-@Singleton
 @Path("/api/v2/process")
 @Tag(name = "ProcessV2")
 public class ProcessResourceV2 implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
@@ -23,7 +23,6 @@ package com.walmartlabs.concord.server.process.checkpoint;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.common.TemporaryPath;
 import com.walmartlabs.concord.server.MultipartUtils;
-import com.walmartlabs.concord.server.org.secret.SecretResource;
 import com.walmartlabs.concord.server.process.ProcessEntry;
 import com.walmartlabs.concord.server.process.ProcessEntry.ProcessCheckpointEntry;
 import com.walmartlabs.concord.server.process.ProcessManager;
@@ -45,8 +44,6 @@ import org.sonatype.siesta.Validate;
 import org.sonatype.siesta.ValidationErrorsException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -58,8 +55,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.UUID;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "Checkpoint")
 public class ProcessCheckpointResource implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointV2Resource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointV2Resource.java
@@ -39,8 +39,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.UUID;
 
-@Named
-@Singleton
 @Path("/api/v2/process")
 @Tag(name = "CheckpointV2")
 public class ProcessCheckpointV2Resource implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/ProcessEventResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/event/ProcessEventResource.java
@@ -49,8 +49,6 @@ import java.util.stream.Collectors;
 
 import static com.walmartlabs.concord.server.Utils.unwrap;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "Process Events")
 public class ProcessEventResource implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/form/FormResource.java
@@ -42,8 +42,6 @@ import java.util.UUID;
 
 import static com.walmartlabs.concord.server.process.state.ProcessStateManager.path;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "Process Forms")
 public class FormResource implements Resource {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/locks/ProcessLocksResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/locks/ProcessLocksResource.java
@@ -39,8 +39,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
 
-@Named
-@Singleton
 @Path("/api/v1/process")
 @Tag(name = "Process Locks")
 public class ProcessLocksResource implements Resource {


### PR DESCRIPTION
Gives the option of excluding sisu from the classpath if auto-wiring is not required.

+ more @Named removed