### PR TITLE
runtime-v2: skip annotations for varargs

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptor.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptor.java
@@ -124,7 +124,7 @@ public class TaskCallInterceptor {
         static Method of(Object base, String methodName, List<Object> params) {
             List<List<Annotation>> annotations = Collections.emptyList();
             java.lang.reflect.Method m = ReflectionUtil.findMethod(base.getClass(), methodName, null, params.toArray());
-            if (m != null) {
+            if (m != null && !m.isVarArgs()) {
                 annotations = Arrays.stream(m.getParameterAnnotations())
                         .map(Arrays::asList)
                         .collect(Collectors.toList());

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptorTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptorTest.java
@@ -1,0 +1,29 @@
+package com.walmartlabs.concord.runtime.v2.runner.tasks;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TaskCallInterceptorTest {
+
+    @Test
+    public void methodAnnotationsTest() {
+        Base base = new Base();
+        String method = "varargs";
+        List<Object> params = Arrays.asList("one", "two");
+
+        TaskCallInterceptor.Method m = TaskCallInterceptor.Method.of(base, method, params);
+
+        assertEquals(0, m.annotations().size());
+    }
+
+    public static class Base {
+
+        public void varargs(Object ... args) {
+
+        }
+    }
+}


### PR DESCRIPTION
For varargs, some more complex logic is needed to determine annotations for arguments