### PR TITLE
concord-server: expose fetch with version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ target/
 yarn.lock
 .mvn/wrapper/maven-wrapper.jar
 .java-version
+.attach_pid*

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
@@ -102,7 +102,7 @@ public class RepositoryManager {
                             .version(FetchRequest.Version.commitWithBranch(commitId, branch))
                             .secret(secret)
                             .destination(tmpDir)
-                    .build(), path);
+                            .build(), path);
 
             if (repoCfg.isConcordFileValidationEnabled()) {
                 if (!ProjectLoader.isConcordFileExists(repo.path())) {
@@ -123,6 +123,20 @@ public class RepositoryManager {
         }
     }
 
+    public Repository fetch(String url, FetchRequest.Version version, String path, Secret secret, boolean withCommitInfo) {
+        Path dest = repositoryCache.getPath(url);
+        return providers.fetch(
+                FetchRequest.builder()
+                        .url(url)
+                        .shallow(gitCfg.isShallowClone())
+                        .checkAlreadyFetched(gitCfg.isCheckAlreadyFetched())
+                        .version(version)
+                        .secret(secret)
+                        .destination(dest)
+                        .withCommitInfo(withCommitInfo)
+                        .build(), path);
+    }
+
     public Repository fetch(String url, String branch, String commitId, String path, Secret secret, boolean withCommitInfo) {
         String fetchedCommitId = commitId;
         long start = System.currentTimeMillis();
@@ -138,7 +152,7 @@ public class RepositoryManager {
                             .secret(secret)
                             .destination(dest)
                             .withCommitInfo(withCommitInfo)
-                    .build(), path);
+                            .build(), path);
             fetchedCommitId = result.fetchResult() != null ? Objects.requireNonNull(result.fetchResult()).head() : null;
             return result;
         } finally {


### PR DESCRIPTION
*I think* the new fetch-with-version is fully compatible with the old one that accepted branch or commitId separately.