### PR TITLE
runtime-v2: resume event to json serialization fix

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImpl.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImpl.java
@@ -20,11 +20,14 @@ package com.walmartlabs.concord.runtime.v2.runner.context;
  * =====
  */
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.walmartlabs.concord.runtime.v2.sdk.ResumeEvent;
 
 import java.io.Serializable;
 import java.util.Map;
 
+@JsonPropertyOrder({"eventName", "state"})
 public class ResumeEventImpl implements ResumeEvent {
 
     // for backward compatibility (java8 concord 1.92.0 version)
@@ -40,11 +43,13 @@ public class ResumeEventImpl implements ResumeEvent {
     }
 
     @Override
+    @JsonProperty("eventName")
     public String eventName() {
         return eventName;
     }
 
     @Override
+    @JsonProperty("state")
     public Map<String, Serializable> state() {
         return state;
     }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImplTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImplTest.java
@@ -1,0 +1,21 @@
+package com.walmartlabs.concord.runtime.v2.runner.context;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResumeEventImplTest {
+
+    @Test
+    public void jsonSerializationTest() throws Exception {
+        Map<String, Serializable> payload = Map.of("key", "key-value");
+
+        ResumeEventImpl event = new ResumeEventImpl("test", payload);
+        String json = new ObjectMapper().writeValueAsString(event);
+        assertEquals("{\"eventName\":\"test\",\"state\":{\"key\":\"key-value\"}}", json);
+    }
+}


### PR DESCRIPTION
just to avoid event send error:
```
[WARN ] send [{threadId=0, phase=pre, processDefinitionId=test, fileName=concord.yaml, in={0=ResumeEventImpl{eventName='... state={baseUrl=null, apiKey=null, jobs=[...], collectOutVars=false, ignoreFailures=false}}}, line=3, column=7, description=Task: Test, correlationId=...}] -> error while sending an event to the server: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class com.walmartlabs.concord.runtime.v2.runner.context.ResumeEventImpl and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.walmartlabs.concord.client2.ProcessEventRequest["data"]->java.util.HashMap["in"]->java.util.HashMap["0"])
```