### PR TITLE
concord-server: option to permanently disable a user

### DIFF
--- a/client2/pom.xml
+++ b/client2/pom.xml
@@ -139,6 +139,22 @@
                 <artifactId>revapi-maven-plugin</artifactId>
                 <configuration>
                     <analysisConfiguration>
+                        <revapi.differences>
+                            <differences>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.attributeValueChanged</code>
+                                    <old>class com.walmartlabs.concord.client2.UserEntry</old>
+                                    <justification>Adding field to json-serializable class</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.field.serialVersionUIDUnchanged</code>
+                                    <old>field com.walmartlabs.concord.client2.UserEntry.serialVersionUID</old>
+                                    <justification>Adding field to json-serializable class</justification>
+                                </item>
+                            </differences>
+                        </revapi.differences>
                         <revapi.ignore>
                             <item>
                                 <code>java.class.nonPublicPartOfAPI</code>

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/LdapIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/LdapIT.java
@@ -32,7 +32,9 @@ import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.assertLog;
 import static com.walmartlabs.concord.it.common.ServerClient.waitForCompletion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class LdapIT extends AbstractServerIT {
@@ -106,6 +108,32 @@ public class LdapIT extends AbstractServerIT {
         UserEntry ue = usersApi.findByUsername(username.toLowerCase());
         assertNotNull(ue);
         assertEquals(ue.getName(), username.toLowerCase());
+    }
+
+    @Test
+    void testDisableLdapUser() throws Exception {
+        String username = "tester_" + randomString();
+        createLdapUser(username);
+
+        UsersApi usersApi = new UsersApi(getApiClient());
+        usersApi.createOrUpdateUser(new CreateUserRequest()
+                .username(username)
+                .type(CreateUserRequest.TypeEnum.LDAP));
+
+        UserEntry ue = usersApi.findByUsername(username);
+        assertNotNull(ue);
+        assertFalse(ue.getDisabled());
+        assertFalse(ue.getPermanentlyDisabled());
+
+        ue = usersApi.disableUser(ue.getId(), false);
+        assertNotNull(ue);
+        assertTrue(ue.getDisabled());
+        assertFalse(ue.getPermanentlyDisabled());
+
+        ue = usersApi.disableUser(ue.getId(), true);
+        assertNotNull(ue);
+        assertTrue(ue.getDisabled());
+        assertTrue(ue.getPermanentlyDisabled());
     }
 
     public static DirContext createContext() throws Exception {

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -111,5 +111,6 @@
     <include file="v1.103.0.xml" relativeToChangelogFile="true"/>
     <include file="v1.104.0.xml" relativeToChangelogFile="true"/>
     <include file="v2.8.0.xml" relativeToChangelogFile="true"/>
+    <include file="v2.9.0.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
@@ -27,12 +27,4 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="280010" author="benjamin.broadaway@walmart.com">
-        <addColumn tableName="USERS">
-            <column name="IS_PERMANENTLY_DISABLED" type="boolean" defaultValueComputed="false">
-                <constraints nullable="false"/>
-            </column>
-        </addColumn>
-    </changeSet>
-
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
@@ -27,4 +27,12 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="280010" author="benjamin.broadaway@walmart.com">
+        <addColumn tableName="USERS">
+            <column name="IS_PERMANENTLY_DISABLED" type="boolean" defaultValueComputed="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.9.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.9.0.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="290000" author="benjamin.broadaway@walmart.com">
+        <addColumn tableName="USERS">
+            <column name="IS_PERMANENTLY_DISABLED" type="boolean" defaultValueComputed="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserDao.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server.user;
 
 import com.walmartlabs.concord.db.AbstractDao;
 import com.walmartlabs.concord.db.MainDB;
+import com.walmartlabs.concord.server.jooq.Tables;
 import com.walmartlabs.concord.server.jooq.tables.records.UsersRecord;
 import com.walmartlabs.concord.server.org.OrganizationEntry;
 import com.walmartlabs.concord.server.org.team.TeamRole;
@@ -89,14 +90,16 @@ public class UserDao extends AbstractDao {
     public void enable(UUID id) {
         tx(tx -> tx.update(USERS)
                 .set(USERS.IS_DISABLED, inline(false))
+                .set(USERS.IS_PERMANENTLY_DISABLED, inline(false))
                 .setNull(USERS.DISABLED_DATE)
                 .where(USERS.USER_ID.eq(id))
                 .execute());
     }
 
-    public void disable(UUID id) {
+    public void disable(UUID id, boolean permanent) {
         tx(tx -> tx.update(USERS)
                 .set(USERS.IS_DISABLED, inline(true))
+                .set(Tables.USERS.IS_PERMANENTLY_DISABLED, permanent)
                 .set(USERS.DISABLED_DATE, currentOffsetDateTime())
                 .where(USERS.USER_ID.eq(id))
                 .execute());
@@ -140,8 +143,8 @@ public class UserDao extends AbstractDao {
     public UserEntry get(UUID id) {
         DSLContext tx = dsl();
 
-        Record8<UUID, String, String, String, String, String, Boolean, OffsetDateTime> r =
-                tx.select(USERS.USER_ID, USERS.USER_TYPE, USERS.USERNAME, USERS.DOMAIN, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED, USERS.DISABLED_DATE)
+        Record9<UUID, String, String, String, String, String, Boolean, Boolean, OffsetDateTime> r =
+                tx.select(USERS.USER_ID, USERS.USER_TYPE, USERS.USERNAME, USERS.DOMAIN, USERS.DISPLAY_NAME, USERS.USER_EMAIL, USERS.IS_DISABLED, USERS.IS_PERMANENTLY_DISABLED, USERS.DISABLED_DATE)
                         .from(USERS)
                         .where(USERS.USER_ID.eq(id))
                         .fetchOne();
@@ -269,7 +272,8 @@ public class UserDao extends AbstractDao {
                         r.get(USERS.USER_EMAIL),
                         null,
                         r.get(USERS.IS_DISABLED),
-                        r.get(USERS.DISABLED_DATE)));
+                        r.get(USERS.DISABLED_DATE),
+                        r.get(USERS.IS_PERMANENTLY_DISABLED)));
     }
 
     public List<LdapGroupSearchResult> searchLdapGroups(String filter) {
@@ -302,7 +306,7 @@ public class UserDao extends AbstractDao {
                 .execute();
     }
 
-    private UserEntry getUserInfo(DSLContext tx, Record8<UUID, String, String, String, String, String, Boolean, OffsetDateTime> r) {
+    private UserEntry getUserInfo(DSLContext tx, Record9<UUID, String, String, String, String, String, Boolean, Boolean, OffsetDateTime> r) {
         // TODO join?
         Field<String> orgNameField = select(ORGANIZATIONS.ORG_NAME)
                 .from(ORGANIZATIONS)
@@ -341,7 +345,8 @@ public class UserDao extends AbstractDao {
                 r.get(USERS.USER_EMAIL),
                 new HashSet<>(roles),
                 r.get(USERS.IS_DISABLED),
-                r.get(USERS.DISABLED_DATE));
+                r.get(USERS.DISABLED_DATE),
+                r.get(USERS.IS_PERMANENTLY_DISABLED));
     }
 
     private static String toLowerCase(String s) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserEntry.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserEntry.java
@@ -65,6 +65,8 @@ public class UserEntry implements Serializable {
 
     private final boolean disabled;
 
+    private final boolean permanentlyDisabled;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     private final OffsetDateTime disabledDate;
 
@@ -78,7 +80,8 @@ public class UserEntry implements Serializable {
                      @JsonProperty("email") String email,
                      @JsonProperty("roles") Set<RoleEntry> roles,
                      @JsonProperty("disabled") boolean disabled,
-                     @JsonProperty("disabledDate") OffsetDateTime disabledDate) {
+                     @JsonProperty("disabledDate") OffsetDateTime disabledDate,
+                     @JsonProperty("permanentlyDisabled") boolean permanentlyDisabled) {
 
         this.id = id;
         this.name = name;
@@ -90,6 +93,7 @@ public class UserEntry implements Serializable {
         this.roles = roles;
         this.disabled = disabled;
         this.disabledDate = disabledDate;
+        this.permanentlyDisabled = permanentlyDisabled;
     }
 
     public UUID getId() {
@@ -132,6 +136,10 @@ public class UserEntry implements Serializable {
         return disabledDate;
     }
 
+    public boolean isPermanentlyDisabled() {
+        return permanentlyDisabled;
+    }
+
     @Override
     public String toString() {
         return "UserEntry{" +
@@ -145,6 +153,7 @@ public class UserEntry implements Serializable {
                 ", roles=" + roles +
                 ", disabled=" + disabled +
                 ", disabledDate=" + disabledDate +
+                ", permanentlyDisabled=" + permanentlyDisabled +
                 '}';
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResource.java
@@ -92,7 +92,7 @@ public class UserResource implements Resource {
      * Finds an existing user by username.
      *
      * @param username
-     * @return
+     * @return user details
      */
     @GET
     @Path("/{username}")
@@ -109,9 +109,33 @@ public class UserResource implements Resource {
     }
 
     /**
+     * Disables an existing user. Optionally allows permanent disabling of the user.
+     *
+     * @param id ID of user to disable
+     * @param permanent When <code>true</code>, user cannot be automatically re-enabled on login
+     * @return updated user details
+     */
+    @PUT
+    @Path("/{id}/disable")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Validate
+    @Operation(description = "Disable a user")
+    public UserEntry disableUser(@PathParam("id") UUID id, @QueryParam("permanent") boolean permanent) {
+        assertAdmin();
+
+        if (permanent) {
+            userManager.permanentlyDisable(id);
+        } else {
+            userManager.disable(id);
+        }
+
+        return userDao.get(id);
+    }
+
+    /**
      * Removes an existing user.
      *
-     * @param id
+     * @param id User's database ID
      * @return
      */
     @DELETE

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/org/secret/PasswordCheckerTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/org/secret/PasswordCheckerTest.java
@@ -47,7 +47,7 @@ public class PasswordCheckerTest {
         SecurityManager securityManager = new DefaultSecurityManager();
         ThreadContext.bind(securityManager);
 
-        UserPrincipal p = new UserPrincipal("test", new UserEntry(UUID.randomUUID(), USERNAME, null, null, null, null, null, null, false, null));
+        UserPrincipal p = new UserPrincipal("test", new UserEntry(UUID.randomUUID(), USERNAME, null, null, null, null, null, null, false, null, false));
         SubjectContext ctx = new DefaultSubjectContext();
         ctx.setAuthenticated(true);
         ctx.setPrincipals(new SimplePrincipalCollection(p, p.getRealm()));

--- a/server/plugins/pfed-sso/src/main/java/com/walmartlabs/concord/server/plugins/pfedsso/SsoRealm.java
+++ b/server/plugins/pfed-sso/src/main/java/com/walmartlabs/concord/server/plugins/pfedsso/SsoRealm.java
@@ -75,6 +75,10 @@ public class SsoRealm extends AuthorizingRealm {
             u = userManager.create(t.getUsername(), t.getDomain(), t.getDisplayName(), t.getMail(), UserType.SSO, null);
         }
 
+        if (!u.isPermanentlyDisabled()) {
+            return null;
+        }
+
         // we consider the account active if the authentication was successful
         userManager.enable(u.getId());
 


### PR DESCRIPTION
For the times when a user is up to no good. Currently, `UserLdapGroupSynchronizer` or a UI login will automatically re-enable an LDAP user. This change sets and option that indicates a user should not be automatically re-enabled.