### PR TITLE
agent: kill runner child PIDs

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/Utils.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Utils.java
@@ -23,30 +23,48 @@ package com.walmartlabs.concord.agent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Field;
+import java.util.List;
 
 public final class Utils {
 
     private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
     public static boolean kill(Process proc) {
-        if (!proc.isAlive()) {
+        return kill(proc.toHandle());
+    }
+
+    public static boolean kill(Process proc, boolean killDescendants) {
+        List<ProcessHandle> children = killDescendants ? List.of() : proc.children().toList();
+
+        // kill parent first which may gracefully clean up all descendents
+        boolean killed = kill(proc.toHandle());
+
+        // clean up orphaned processes that are still running
+        children.stream()
+                .flatMap(ProcessHandle::descendants)
+                .forEach(Utils::kill);
+
+        return killed;
+    }
+
+    private static boolean kill(ProcessHandle handle) {
+        if (!handle.isAlive()) {
             return false;
         }
 
-        String p = toString(proc);
+        String p = toString(handle);
 
         log.info("kill ['{}'] -> attempting to stop...", p);
-        proc.destroy();
+        handle.destroy();
 
-        if (proc.isAlive()) {
+        if (handle.isAlive()) {
             sleep(1000);
         }
 
-        while (proc.isAlive()) {
+        while (handle.isAlive()) {
             log.warn("kill ['{}'] -> waiting for the process to die...", p);
             sleep(3000);
-            proc.destroyForcibly();
+            handle.destroyForcibly();
         }
 
         return true;
@@ -60,13 +78,10 @@ public final class Utils {
         }
     }
 
-    private static String toString(Process proc) {
+    private static String toString(ProcessHandle proc) {
         try {
-            Field f = proc.getClass().getDeclaredField("pid");
-            f.setAccessible(true);
-
-            return "pid=" + f.get(proc);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return "pid=" + proc.pid();
+        } catch (UnsupportedOperationException e) {
             return proc.toString();
         }
     }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/Utils.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Utils.java
@@ -34,7 +34,7 @@ public final class Utils {
     }
 
     public static boolean kill(Process proc, boolean killDescendants) {
-        List<ProcessHandle> children = killDescendants ? List.of() : proc.children().toList();
+        List<ProcessHandle> children = killDescendants ? proc.children().toList() : List.of();
 
         // kill parent first which may gracefully clean up all descendents
         boolean killed = kill(proc.toHandle());

--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AbstractRunnerConfiguration.java
@@ -39,6 +39,7 @@ public abstract class AbstractRunnerConfiguration {
     private final String mainClass;
     private final boolean securityManagerEnabled;
     private final Path persistentWorkDir;
+    private final boolean cleanRunnerDescendants;
 
     public AbstractRunnerConfiguration(String prefix, Config cfg) {
         String path = getStringOrDefault(cfg, prefix + ".path", () -> {
@@ -58,6 +59,7 @@ public abstract class AbstractRunnerConfiguration {
         this.mainClass = cfg.getString(prefix + ".mainClass");
         this.securityManagerEnabled = cfg.getBoolean(prefix + ".securityManagerEnabled");
         this.persistentWorkDir = getOptionalAbsolutePath(cfg, prefix + ".persistentWorkDir");
+        this.cleanRunnerDescendants = cfg.getBoolean(prefix + ".cleanRunnerDescendants");
     }
 
     public Path getPath() {
@@ -88,6 +90,10 @@ public abstract class AbstractRunnerConfiguration {
 
     public Path getPersistentWorkDir() {
         return persistentWorkDir;
+    }
+
+    public boolean getCleanRunnerDescendants() {
+        return cleanRunnerDescendants;
     }
 
     private static String getJavaCmd(Config cfg, String prefix) {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
@@ -126,6 +126,7 @@ public class JobExecutorFactory {
                     .segmentedLogs(segmentedLogs)
                     .persistentWorkDir(runnerCfg.getPersistentWorkDir())
                     .preforkEnabled(preForkCfg.isEnabled())
+                    .cleanRunnerDescendants(runnerCfg.getCleanRunnerDescendants())
                     .build();
 
             JobExecutor delegate = new RunnerJobExecutor(runnerExecutorCfg, dependencyManager, defaultDependencies, attachmentsUploader, processPool, processLogFactory, executor);

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
@@ -216,7 +216,7 @@ public class RunnerJobExecutor implements JobExecutor {
         });
 
         // return a handle that can be used to cancel the process or wait for its completion
-        return new JobInstanceImpl(f, pe.getProcess());
+        return new JobInstanceImpl(f, pe.getProcess(), cfg.cleanRunnerDescendants());
     }
 
     private void persistWorkDir(UUID instanceId, Path src) {
@@ -776,6 +776,8 @@ public class RunnerJobExecutor implements JobExecutor {
 
         boolean preforkEnabled();
 
+        boolean cleanRunnerDescendants();
+
         static ImmutableRunnerJobExecutorConfiguration.Builder builder() {
             return ImmutableRunnerJobExecutorConfiguration.builder();
         }
@@ -785,12 +787,14 @@ public class RunnerJobExecutor implements JobExecutor {
 
         private final Future<?> f;
         private final Process proc;
+        private final boolean cleanRunnerDescendants;
 
         private transient boolean cancelled = false;
 
-        private JobInstanceImpl(Future<?> f, Process proc) {
+        private JobInstanceImpl(Future<?> f, Process proc, boolean cleanRunnerDescendants) {
             this.f = f;
             this.proc = proc;
+            this.cleanRunnerDescendants = cleanRunnerDescendants;
         }
 
         @Override
@@ -806,7 +810,7 @@ public class RunnerJobExecutor implements JobExecutor {
 
             cancelled = true;
 
-            Utils.kill(proc);
+            Utils.kill(proc, cleanRunnerDescendants);
         }
 
         @Override

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -235,6 +235,10 @@ concord-agent {
         # after the process ends (regardless of the status)
         # should not be used in production environments
         # persistentWorkDir = /path/to/dir
+
+        # if true, agent will forcibly kill any remaining child PIDs (i.e. zombies)
+        # of the runner process
+        cleanRunnerDescendants = false
     }
 
     # the default v1 runtime configuration


### PR DESCRIPTION
Funky child processes from the runner may persist even after the runner is killed due to cancel command or `processTimeout`. This change kills each child recursively if they are still alive after the runner is killed.