### PR TITLE
concord-server: allow custom top-level API endpoints

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ApiDescriptor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ApiDescriptor.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.boot.resteasy;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2023 Walmart Inc.
+ * Copyright (C) 2017 - 2024 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,13 @@ package com.walmartlabs.concord.server.boot.resteasy;
  * =====
  */
 
-import org.eclipse.jetty.ee8.servlet.ServletHolder;
-import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+/**
+ * Declares an API.
+ */
+public interface ApiDescriptor {
 
-import javax.servlet.annotation.WebServlet;
-
-@WebServlet({
-        "/api/*",
-        "/events/github/*"
-})
-public class ResteasyServletHolder extends ServletHolder {
-
-    public ResteasyServletHolder() {
-        super(HttpServletDispatcher.class);
-    }
+    /**
+     * Path patterns of the API. E.g. {@code "/api/**"} or {@code "/events/foo"}.
+     */
+    String[] paths();
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ConcordApiDescriptor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ConcordApiDescriptor.java
@@ -1,0 +1,32 @@
+package com.walmartlabs.concord.server.boot.resteasy;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public class ConcordApiDescriptor implements ApiDescriptor {
+
+    @Override
+    public String[] paths() {
+        return new String[]{
+                "/api/*",
+                "/events/github/*"
+        };
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ResteasyModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/resteasy/ResteasyModule.java
@@ -29,13 +29,12 @@ import javax.servlet.ServletContextListener;
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.walmartlabs.concord.server.Utils.bindExceptionMapper;
-import static com.walmartlabs.concord.server.Utils.bindServletHolder;
 
 public class ResteasyModule implements Module {
 
     @Override
     public void configure(Binder binder) {
-        bindServletHolder(binder, ResteasyServletHolder.class);
+        newSetBinder(binder, ApiDescriptor.class).addBinding().to(ConcordApiDescriptor.class);
 
         newSetBinder(binder, ServletContextListener.class).addBinding().to(ResteasyListener.class);
 


### PR DESCRIPTION
Allow server plugins to supply their own top-level JAX-RS endpoints in addition to the default `/api/*` and `/events/*`.