### PR TITLE
Minor improvements to the remember me cookie logic

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/filters/ConcordAuthenticatingFilter.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/filters/ConcordAuthenticatingFilter.java
@@ -144,7 +144,7 @@ public class ConcordAuthenticatingFilter extends AuthenticatingFilter {
         failedAuths.mark();
 
         Subject s = ThreadContext.getSubject();
-        if (s != null) {
+        if (s != null && (s.isRemembered() || s.isAuthenticated())) {
             s.logout();
         }
 


### PR DESCRIPTION
Before:

```
> curl -i http://localhost:8001/api/v1/org
HTTP/1.1 401 Unauthorized
Server: Jetty(12.0.7)
Date: Sun, 21 Apr 2024 11:11:50 GMT
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: *
Access-Control-Allow-Headers: Authorization, Content-Type, Range, Cookie, Origin
Access-Control-Expose-Headers: cache-control,content-language,expires,last-modified,content-range,content-length,accept-ranges
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Sat, 20-Apr-2024 11:11:53 GMT; SameSite=lax
WWW-Authenticate: Basic
WWW-Authenticate: ConcordApiToken
Content-Length: 0
```

After:

```
> curl -i http://localhost:8001/api/v1/org
HTTP/1.1 401 Unauthorized
Server: Jetty(12.0.7)
Date: Sun, 21 Apr 2024 11:05:51 GMT
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: *
Access-Control-Allow-Headers: Authorization, Content-Type, Range, Cookie, Origin
Access-Control-Expose-Headers: cache-control,content-language,expires,last-modified,content-range,content-length,accept-ranges
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0
WWW-Authenticate: Basic
WWW-Authenticate: ConcordApiToken
Content-Length: 0
```

Still removes the cookie on logout:
![image](https://github.com/walmartlabs/concord/assets/826959/1437ab78-dca3-4b37-9ed9-ae105ae3dd5b)
