### PR TITLE
concord-server: do not invalidate sessions in onFailedLogin

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/filters/ConcordAuthenticatingFilter.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/filters/ConcordAuthenticatingFilter.java
@@ -42,7 +42,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
@@ -146,15 +145,6 @@ public class ConcordAuthenticatingFilter extends AuthenticatingFilter {
         Subject s = ThreadContext.getSubject();
         if (s != null && (s.isRemembered() || s.isAuthenticated())) {
             s.logout();
-        }
-
-        HttpSession session = ((HttpServletRequest) request).getSession(false);
-        if (session != null) {
-            session.invalidate();
-
-            // remove JSESSIONID cookie
-            HttpServletResponse resp = WebUtils.toHttp(response);
-            resp.addHeader("Set-Cookie", "JSESSIONID=; Path=/; HttpOnly");
         }
 
         return super.onLoginFailure(token, e, request, response);


### PR DESCRIPTION
This effectively reverts #859. The change broke redirect after login when the authentication times out (e.g. OIDC login). Unfortunaly, pax4j stores the "from" parameter in the session so we need it alive when we redirect the user between the app and the auth provider.

We might want to use a separate cookie or have a way to differentiate between onLoginFailure reasons when we make a decision to invalidate the session. Get rid of pax4j too.