### PR TITLE
concord-server: fix Jetty metrics

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/JettySessionMetricsModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/JettySessionMetricsModule.java
@@ -63,7 +63,7 @@ public class JettySessionMetricsModule extends AbstractModule {
     private static Object getAttribute(String attribute) {
         try {
             MBeanServer mBeans = ManagementFactory.getPlatformMBeanServer();
-            return mBeans.getAttribute(new ObjectName("org.eclipse.jetty.server.session:context=ROOT,id=0,type=defaultsessioncache"), attribute);
+            return mBeans.getAttribute(new ObjectName("org.eclipse.jetty.session:context=ROOT,id=0,type=defaultsessioncache"), attribute);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/server/plugins/noderoster/impl/pom.xml
+++ b/server/plugins/noderoster/impl/pom.xml
@@ -158,10 +158,6 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jetty9</artifactId>
-        </dependency>
 
         <!-- immutables -->
         <dependency>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -102,7 +102,7 @@
         <maven.model.builder.version>3.8.4</maven.model.builder.version>
         <maven.resolver.version>1.7.3</maven.resolver.version>
         <maven.resolver.version.concord>0.0.4</maven.resolver.version.concord>
-        <metrics.version>4.2.13</metrics.version>
+        <metrics.version>4.2.25</metrics.version>
         <mockito.version>4.9.0</mockito.version>
         <mustache.version>0.9.10</mustache.version>
         <nimbus.jwt.version>8.8</nimbus.jwt.version>
@@ -118,7 +118,7 @@
         <shiro.version>1.10.1</shiro.version>
         <siesta.version>2.3.2</siesta.version>
         <sisu.version>0.9.0.M2</sisu.version>
-        <slf4j.version>2.0.10</slf4j.version>
+        <slf4j.version>2.0.11</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <sshd.version>2.8.0</sshd.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
@@ -455,7 +455,7 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jetty9</artifactId>
+                <artifactId>metrics-jetty12</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Upgrade Dropwizard Metrics and fix Jetty session metrics exporter for Jetty 12 compatibility.