### PR TITLE
server: process wait conditions in batch mode

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ErrorWrapper.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ErrorWrapper.java
@@ -25,23 +25,23 @@ import com.walmartlabs.concord.svm.*;
 
 /**
  * Wraps the specified command into a new frame with an exception handler
- * consisting of a {@link ExposeLastErrorCommand} and the provided {@link #errorHandlingCommand}.
+ * consisting of a {@link ExposeLastErrorCommand} and the provided {@link #errorSteps}.
  */
 public class ErrorWrapper implements Command {
 
     private static final long serialVersionUID = 1L;
 
     private final Command cmd;
-    private final Command errorHandlingCommand;
+    private final Command errorSteps;
 
-    public ErrorWrapper(Command cmd, Command errorHandlingCommand) {
+    public ErrorWrapper(Command cmd, Command errorSteps) {
         this.cmd = cmd;
-        this.errorHandlingCommand = errorHandlingCommand;
+        this.errorSteps = errorSteps;
     }
 
     @Override
     public Command copy() {
-        return new ErrorWrapper(cmd, errorHandlingCommand.copy());
+        return new ErrorWrapper(cmd, errorSteps.copy());
     }
 
     @Override
@@ -53,7 +53,7 @@ public class ErrorWrapper implements Command {
         //  block:
         //    - ExposeLastErrorCommand
         //    - ...compiled steps from the "error" block...
-        BlockCommand exceptionHandler = new BlockCommand(new ExposeLastErrorCommand(), errorHandlingCommand);
+        BlockCommand exceptionHandler = new BlockCommand(new ExposeLastErrorCommand(), errorSteps);
 
         Frame inner = Frame.builder()
                 .nonRoot()

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -195,6 +195,8 @@ concord-server {
         waitCheckPeriod = "5 seconds"
         waitCheckPollLimit = 1000
 
+        waitProcessLimitForStatusQuery = 5000
+
         # hard limit for the process log size, bytes
         # should be less than 2^31
         logSizeLimit = 1073741824 # 1GB

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessWaitWatchdogConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessWaitWatchdogConfiguration.java
@@ -38,11 +38,19 @@ public class ProcessWaitWatchdogConfiguration implements Serializable {
     @Config("process.waitCheckPollLimit")
     private int pollLimit;
 
+    @Inject
+    @Config("process.waitProcessLimitForStatusQuery")
+    private int processLimitForStatusQuery;
+
     public Duration getPeriod() {
         return period;
     }
 
     public int getPollLimit() {
         return pollLimit;
+    }
+
+    public int getProcessLimitForStatusQuery() {
+        return processLimitForStatusQuery;
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessCompletionCondition.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessCompletionCondition.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Value.Immutable
+@Value.Modifiable
 @JsonSerialize(as = ImmutableProcessCompletionCondition.class)
 @JsonDeserialize(as = ImmutableProcessCompletionCondition.class)
 public abstract class ProcessCompletionCondition extends AbstractWaitCondition {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import static com.walmartlabs.concord.server.jooq.tables.ProcessQueue.PROCESS_QUEUE;
 import static com.walmartlabs.concord.server.process.waits.ProcessCompletionCondition.CompleteCondition;
+import static org.jooq.impl.DSL.any;
 
 /**
  * Handles the processes that are waiting for other processes to finish.
@@ -189,7 +190,7 @@ public class WaitProcessFinishHandler implements ProcessWaitHandler<ProcessCompl
                 ProcessQueue q = PROCESS_QUEUE.as("q");
                 return tx.select(q.INSTANCE_ID, q.CURRENT_STATUS)
                         .from(q)
-                        .where(q.INSTANCE_ID.in(processes))
+                        .where(q.INSTANCE_ID.equal(any(processes.toArray(UUID[]::new))))
                         .fetchMap(q.INSTANCE_ID, r -> r.get(q.CURRENT_STATUS, new EnumConverter<>(String.class, ProcessStatus.class)));
             });
             for (UUID key : processes) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandler.java
@@ -20,17 +20,27 @@ package com.walmartlabs.concord.server.process.waits;
  * =====
  */
 
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.walmartlabs.concord.db.AbstractDao;
+
+import com.walmartlabs.concord.server.cfg.ProcessWaitWatchdogConfiguration;
+import com.walmartlabs.concord.server.jooq.tables.ProcessQueue;
+
 import com.walmartlabs.concord.db.MainDB;
 import com.walmartlabs.concord.server.process.queue.ProcessQueueManager;
-import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import org.jooq.Configuration;
+import org.jooq.impl.EnumConverter;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.walmartlabs.concord.server.jooq.tables.ProcessQueue.PROCESS_QUEUE;
+import static com.walmartlabs.concord.server.process.waits.ProcessCompletionCondition.CompleteCondition;
 
 /**
  * Handles the processes that are waiting for other processes to finish.
@@ -38,11 +48,24 @@ import java.util.UUID;
 @Singleton
 public class WaitProcessFinishHandler implements ProcessWaitHandler<ProcessCompletionCondition> {
 
+    private final Dao dao;
+
+    private final int processLimitForStatusQuery;
+
     private final ProcessQueueManager processQueueManager;
 
+    private final Histogram waitProcessesHistogram;
+
+
     @Inject
-    public WaitProcessFinishHandler(ProcessQueueManager processQueueManager) {
+    public WaitProcessFinishHandler(Dao dao,
+                                    ProcessWaitWatchdogConfiguration cfg,
+                                    ProcessQueueManager processQueueManager,
+                                    MetricRegistry metricRegistry) {
+        this.dao = dao;
+        this.processLimitForStatusQuery = cfg.getProcessLimitForStatusQuery();
         this.processQueueManager = processQueueManager;
+        this.waitProcessesHistogram = metricRegistry.histogram("wait-process-finish-histogram");
     }
 
     @Override
@@ -52,16 +75,127 @@ public class WaitProcessFinishHandler implements ProcessWaitHandler<ProcessCompl
 
     @Override
     @WithTimer
-    public Result<ProcessCompletionCondition> process(ProcessKey processKey, ProcessCompletionCondition wait) {
-        Set<UUID> awaitProcesses = wait.processes();
-        if (!awaitProcesses.isEmpty()) {
-            return Result.of(wait);
+    public List<Result<ProcessCompletionCondition>> processBatch(List<WaitConditionItem<ProcessCompletionCondition>> items) {
+        Set<UUID> allProcesses = items.stream()
+                .flatMap(i -> i.waitCondition().processes().stream())
+                .collect(Collectors.toSet());
+
+        waitProcessesHistogram.update(allProcesses.size());
+
+        List<WaitConditionItem<ProcessCompletionCondition>> modifiableItems = new ArrayList<>();
+        for (WaitConditionItem<ProcessCompletionCondition> item : items) {
+            modifiableItems.add(toModifiable(item));
         }
 
-        if (wait.resumeEvent() != null) {
-            return Result.resume(wait.resumeEvent());
-        } else {
-            return Result.action(tx -> processQueueManager.updateExpectedStatus(tx, processKey, ProcessStatus.WAITING, ProcessStatus.ENQUEUED));
+        List<Set<UUID>> processesBatch = split(allProcesses, processLimitForStatusQuery);
+        List<Result<ProcessCompletionCondition>> results = new ArrayList<>();
+        for (Set<UUID> processes : processesBatch) {
+            Map<UUID, ProcessStatus> statuses = dao.findStatuses(processes);
+
+            for (var it = modifiableItems.iterator(); it.hasNext(); ) {
+                WaitConditionItem<ProcessCompletionCondition> item = it.next();
+
+                filterFinished(item.waitCondition(), statuses);
+                if (item.waitCondition().processes().isEmpty()) {
+                    results.add(toResult(item));
+                    it.remove();
+                }
+            }
+
+            if (modifiableItems.isEmpty()) {
+                break;
+            }
+        }
+
+        for (WaitConditionItem<ProcessCompletionCondition> item : modifiableItems) {
+            results.add(toResult(item));
+        }
+
+        return results;
+    }
+
+    private Result<ProcessCompletionCondition> toResult(WaitConditionItem<ProcessCompletionCondition> item) {
+        Set<UUID> newAwaitProcesses = item.waitCondition().processes();
+        if (newAwaitProcesses.isEmpty()) {
+            if (item.waitCondition().resumeEvent() != null) {
+                return Result.resume(item, item.waitCondition().resumeEvent());
+            } else {
+                return Result.action(item, tx -> processQueueManager.updateExpectedStatus(tx, item.processKey(), ProcessStatus.WAITING, ProcessStatus.ENQUEUED));
+            }
+        }
+
+        return Result.of(item.processKey(), item.waitConditionId(),
+                ProcessCompletionCondition.builder().from(item.waitCondition())
+                        .processes(newAwaitProcesses)
+                        .build());
+    }
+
+    private static WaitConditionItem<ProcessCompletionCondition> toModifiable(WaitConditionItem<ProcessCompletionCondition> item) {
+        return WaitConditionItem.of(item.processKey(), item.waitConditionId(), ModifiableProcessCompletionCondition.create().from(item.waitCondition()));
+    }
+
+    private static List<Set<UUID>> split(Set<UUID> processes, int maxProcessesItems) {
+        List<Set<UUID>> subsets = new ArrayList<>();
+        Set<UUID> currentSet = new HashSet<>();
+
+        for (UUID element : processes) {
+            currentSet.add(element);
+            if (currentSet.size() >= maxProcessesItems) {
+                subsets.add(new HashSet<>(currentSet));
+                currentSet.clear();
+            }
+        }
+
+        if (!currentSet.isEmpty()) {
+            subsets.add(currentSet);
+        }
+
+        return subsets;
+    }
+
+    private static void filterFinished(ProcessCompletionCondition condition, Map<UUID, ProcessStatus> statuses) {
+        if (condition.processes() == null || condition.processes().isEmpty()) {
+            return;
+        }
+
+        Iterator<UUID> it = condition.processes().iterator();
+        while (it.hasNext()) {
+            UUID proc = it.next();
+            if (statuses.containsKey(proc)) {
+                ProcessStatus status = statuses.get(proc);
+                if (status == null || condition.finalStatuses().contains(status)) {
+                    if (condition.completeCondition() == CompleteCondition.ALL) {
+                        it.remove();
+                    } else if (condition.completeCondition() == CompleteCondition.ONE_OF) {
+                        condition.processes().clear();
+                        return;
+                    } else {
+                        throw new RuntimeException("Unknown wait complete condition: " + condition.completeCondition());
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Dao extends AbstractDao {
+
+        @Inject
+        private Dao(@MainDB Configuration cfg) {
+            super(cfg);
+        }
+
+        public Map<UUID, ProcessStatus> findStatuses(Set<UUID> processes) {
+            Map<UUID, ProcessStatus> result = txResult(tx -> {
+                ProcessQueue q = PROCESS_QUEUE.as("q");
+                return tx.select(q.INSTANCE_ID, q.CURRENT_STATUS)
+                        .from(q)
+                        .where(q.INSTANCE_ID.in(processes))
+                        .fetchMap(q.INSTANCE_ID, r -> r.get(q.CURRENT_STATUS, new EnumConverter<>(String.class, ProcessStatus.class)));
+            });
+            for (UUID key : processes) {
+                result.putIfAbsent(key, null);
+            }
+            return result;
         }
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessSleepHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitProcessSleepHandler.java
@@ -25,6 +25,8 @@ import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 
 import javax.inject.Singleton;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Handles the processes that are waiting for some timeout. Resumes a suspended process
@@ -39,12 +41,18 @@ public class WaitProcessSleepHandler implements ProcessWaitHandler<ProcessSleepC
     }
 
     @Override
+    public List<Result<ProcessSleepCondition>> processBatch(List<WaitConditionItem<ProcessSleepCondition>> waits) {
+        return waits.stream()
+                .map(w -> process(w.processKey(), w.waitConditionId(), w.waitCondition()))
+                .collect(Collectors.toList());
+    }
+
     @WithTimer
-    public Result<ProcessSleepCondition> process(ProcessKey key, ProcessSleepCondition wait) {
+    public Result<ProcessSleepCondition> process(ProcessKey key, int waitConditionId, ProcessSleepCondition wait) {
         if (wait.until().before(new Date())) {
-            return Result.resume(wait.resumeEvent());
+            return Result.resume(key, waitConditionId, wait.resumeEvent());
         }
 
-        return Result.of(wait);
+        return Result.of(key, waitConditionId, wait);
     }
 }

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandlerTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/waits/WaitProcessFinishHandlerTest.java
@@ -1,0 +1,128 @@
+package com.walmartlabs.concord.server.process.waits;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.codahale.metrics.MetricRegistry;
+import com.walmartlabs.concord.server.cfg.ProcessWaitWatchdogConfiguration;
+import com.walmartlabs.concord.server.sdk.ProcessKey;
+import com.walmartlabs.concord.server.sdk.ProcessStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.walmartlabs.concord.server.process.waits.ProcessWaitHandler.WaitConditionItem;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anySet;
+import static com.walmartlabs.concord.server.process.waits.ProcessWaitHandler.*;
+import static org.mockito.Mockito.*;
+
+public class WaitProcessFinishHandlerTest {
+
+    private WaitProcessFinishHandler handler;
+    private WaitProcessFinishHandler.Dao dao;
+
+    @BeforeEach
+    public void setUp() {
+        var cfg = mock(ProcessWaitWatchdogConfiguration.class);
+        when(cfg.getProcessLimitForStatusQuery()).thenReturn(2);
+
+        dao = mock(WaitProcessFinishHandler.Dao.class);
+        handler = new WaitProcessFinishHandler(dao, cfg, null, new MetricRegistry());
+    }
+
+    @Test
+    public void testEmptyInput() {
+        List<WaitConditionItem<ProcessCompletionCondition>> items = new ArrayList<>();
+        List<Result<ProcessCompletionCondition>> results = handler.processBatch(items);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void testAllProcessesFinished() {
+        // ---
+        UUID p1 = UUID.randomUUID();
+        UUID p2 = UUID.randomUUID();
+        UUID p3 = UUID.randomUUID();
+
+        List<WaitConditionItem<ProcessCompletionCondition>> items = new ArrayList<>();
+        items.add(WaitConditionItem.of(ProcessKey.random(), 0, ProcessCompletionCondition.builder().resumeEvent("test-resume").addProcesses(p1, p2).build()));
+        items.add(WaitConditionItem.of(ProcessKey.random(), 1, ProcessCompletionCondition.builder().addProcesses(p1, p2, p3).build()));
+
+        when(dao.findStatuses(anySet())).thenAnswer(
+                (Answer<Map<UUID, ProcessStatus>>) invocation -> {
+                    Set<UUID> processes = invocation.getArgument(0);
+                    return processes.stream()
+                            .collect(Collectors.toMap(
+                                    p -> p,
+                                    p -> ProcessStatus.FINISHED
+                            ));
+                }
+        );
+
+        List<Result<ProcessCompletionCondition>> results = handler.processBatch(items);
+
+        assertEquals(items.size(), results.size(), "All items should be processed");
+        assertNull(results.get(0).waitCondition());
+        assertNull(results.get(1).waitCondition());
+
+        verify(dao, times(2)).findStatuses(anySet());
+    }
+
+    @Test
+    public void testNotALLProcessesFinished() {
+        // ---
+        UUID p1 = UUID.randomUUID();
+        UUID p2 = UUID.randomUUID();
+        UUID p3 = UUID.randomUUID();
+
+        List<WaitConditionItem<ProcessCompletionCondition>> items = new ArrayList<>();
+        items.add(WaitConditionItem.of(ProcessKey.random(), 0, ProcessCompletionCondition.builder().resumeEvent("test-resume").addProcesses(p1, p2).build()));
+        items.add(WaitConditionItem.of(ProcessKey.random(), 1, ProcessCompletionCondition.builder().addProcesses(p1, p2, p3).resumeEvent("my-event").exclusive(true).addFinalStatuses(ProcessStatus.FINISHED).build()));
+
+        when(dao.findStatuses(anySet())).thenAnswer(
+                (Answer<Map<UUID, ProcessStatus>>) invocation -> {
+                    Set<UUID> processes = invocation.getArgument(0);
+                    return processes.stream()
+                            .collect(Collectors.toMap(
+                                    p -> p,
+                                    p -> p == p3 ? ProcessStatus.RUNNING : ProcessStatus.FINISHED
+                            ));
+                }
+        );
+
+        List<Result<ProcessCompletionCondition>> results = handler.processBatch(items);
+
+        assertEquals(items.size(), results.size(), "All items should be processed");
+
+        assertNull(results.get(0).waitCondition());
+
+        assertNotNull(results.get(1).waitCondition());
+        assertEquals(Set.of(p3), results.get(1).waitCondition().processes());
+        assertEquals("my-event", results.get(1).waitCondition().resumeEvent());
+        assertTrue(results.get(1).waitCondition().exclusive());
+        assertEquals(Set.of(ProcessStatus.FINISHED), results.get(1).waitCondition().finalStatuses());
+
+        verify(dao, times(2)).findStatuses(anySet());
+    }
+}


### PR DESCRIPTION
the idea here is this: instead of processing each wait condition individually, we will process them in batches. As a result, instead of requesting the status for each process separately, we will request the statuses for a batch of processes at once