### PR TITLE
project: update Liquibase to 4.8.0

### DIFF
--- a/server/db/src/main/java/com/walmartlabs/concord/db/DataSourceUtils.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/DataSourceUtils.java
@@ -23,10 +23,12 @@ package com.walmartlabs.concord.db;
 import com.codahale.metrics.MetricRegistry;
 import com.zaxxer.hikari.HikariDataSource;
 import liquibase.Liquibase;
+import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.ui.LoggerUIService;
 import org.jooq.Configuration;
 import org.jooq.SQLDialect;
 import org.jooq.conf.RenderNameStyle;
@@ -133,6 +135,7 @@ public final class DataSourceUtils {
             params.forEach(lb::setChangeLogParameter);
         }
 
+        Scope.enter(Map.of(Scope.Attr.ui.name(), new LoggerUIService()));
         lb.update((String) null);
     }
 

--- a/server/db/src/main/java/com/walmartlabs/concord/db/DataSourceUtils.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/DataSourceUtils.java
@@ -26,8 +26,6 @@ import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.logging.LogFactory;
-import liquibase.logging.LogLevel;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.jooq.Configuration;
 import org.jooq.SQLDialect;
@@ -123,9 +121,9 @@ public final class DataSourceUtils {
                                   String lockTable,
                                   Map<String, Object> params) throws Exception {
 
-        LogFactory.getInstance().setDefaultLoggingLevel(LogLevel.WARNING);
+        Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(conn));
 
-        Database db = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(conn));
         db.setDatabaseChangeLogTableName(logTable);
         db.setDatabaseChangeLogLockTableName(lockTable);
 

--- a/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogService.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogService.java
@@ -1,0 +1,53 @@
+package com.walmartlabs.concord.db;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import liquibase.logging.LogMessageFilter;
+import liquibase.logging.LogService;
+import liquibase.logging.Logger;
+
+public class LiquibaseLogService implements LogService {
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_SPECIALIZED;
+    }
+
+    @Override
+    public Logger getLog(Class clazz) {
+        return new LiquibaseLogger();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public LogMessageFilter getFilter() {
+        return null;
+    }
+
+    @Override
+    public void setFilter(LogMessageFilter filter) {
+
+    }
+}

--- a/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogger.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogger.java
@@ -1,0 +1,86 @@
+package com.walmartlabs.concord.db;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import liquibase.logging.core.AbstractLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.logging.Level;
+
+public class LiquibaseLogger extends AbstractLogger {
+
+    private static final Logger log = LoggerFactory.getLogger("liquibase");
+
+    public LiquibaseLogger() {
+        super(null);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable e) {
+        log.atLevel(org.slf4j.event.Level.INFO).log(message, e);
+    }
+
+    @Override
+    public void severe(String message) {
+        log.error(message);
+    }
+
+    @Override
+    public void severe(String message, Throwable e) {
+        log.error(message, e);
+    }
+
+    @Override
+    public void warning(String message) {
+        log.warn(message);
+    }
+
+    @Override
+    public void warning(String message, Throwable e) {
+        log.warn(message, e);
+    }
+
+    @Override
+    public void info(String message) {
+        log.info(message);
+    }
+
+    @Override
+    public void info(String message, Throwable e) {
+        log.info(message, e);
+    }
+
+    @Override
+    public void debug(String message) {
+        log.debug(message);
+    }
+
+    @Override
+    public void debug(String message, Throwable e) {
+        log.debug(message, e);
+    }
+}

--- a/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogger.java
+++ b/server/db/src/main/java/com/walmartlabs/concord/db/LiquibaseLogger.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.db;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.logging.Level;
+
+import static java.util.logging.Level.CONFIG;
 
 public class LiquibaseLogger extends AbstractLogger {
 
@@ -41,46 +43,15 @@ public class LiquibaseLogger extends AbstractLogger {
 
     @Override
     public void log(Level level, String message, Throwable e) {
-        log.atLevel(org.slf4j.event.Level.INFO).log(message, e);
-    }
-
-    @Override
-    public void severe(String message) {
-        log.error(message);
-    }
-
-    @Override
-    public void severe(String message, Throwable e) {
-        log.error(message, e);
-    }
-
-    @Override
-    public void warning(String message) {
-        log.warn(message);
-    }
-
-    @Override
-    public void warning(String message, Throwable e) {
-        log.warn(message, e);
-    }
-
-    @Override
-    public void info(String message) {
-        log.info(message);
-    }
-
-    @Override
-    public void info(String message, Throwable e) {
-        log.info(message, e);
-    }
-
-    @Override
-    public void debug(String message) {
-        log.debug(message);
-    }
-
-    @Override
-    public void debug(String message, Throwable e) {
-        log.debug(message, e);
+        var l = level.intValue();
+        if (l < CONFIG.intValue()) {
+            log.debug(message, e);
+        } else if (l < Level.WARNING.intValue()) {
+            log.info(message, e);
+        } else if (l < Level.SEVERE.intValue()) {
+            log.warn(message, e);
+        } else {
+            log.error(message, e);
+        }
     }
 }

--- a/server/db/src/main/resources/META-INF/services/liquibase.logging.LogService
+++ b/server/db/src/main/resources/META-INF/services/liquibase.logging.LogService
@@ -1,0 +1,1 @@
+com.walmartlabs.concord.db.LiquibaseLogService

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.0.1.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.0.1.xml
@@ -149,6 +149,7 @@
 
     <changeSet id="1500" author="ibodrov@gmail.com">
         <validCheckSum>7:85e7d9c068eb963a250712db421e04ba</validCheckSum>
+        <validCheckSum>7:a9c6beedd779af780cc8045ebf515bb9</validCheckSum>
         <createTable tableName="SECRETS">
             <column name="SECRET_NAME" type="varchar(128)" remarks="Name (key) of a secret">
                 <constraints primaryKey="true" nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.0.1.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.0.1.xml
@@ -43,7 +43,7 @@
             <column name="DEFINITION_TYPE" type="varchar(128)" remarks="Type of data">
                 <constraints nullable="false"/>
             </column>
-            <column name="DEFINITION_DATA" type="blob" remarks="Source file">
+            <column name="DEFINITION_DATA" type="longblob" remarks="Source file">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -148,6 +148,7 @@
     <!-- SECRETS -->
 
     <changeSet id="1500" author="ibodrov@gmail.com">
+        <validCheckSum>7:85e7d9c068eb963a250712db421e04ba</validCheckSum>
         <createTable tableName="SECRETS">
             <column name="SECRET_NAME" type="varchar(128)" remarks="Name (key) of a secret">
                 <constraints primaryKey="true" nullable="false"/>
@@ -155,7 +156,7 @@
             <column name="SECRET_TYPE" type="varchar(32)" remarks="Type: SSH_KEY, HTTP_BASIC">
                 <constraints nullable="false"/>
             </column>
-            <column name="SECRET_DATA" type="blob">
+            <column name="SECRET_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -213,7 +214,7 @@
             <column name="TEMPLATE_NAME" type="varchar(128)" remarks="Name (key) of a project template">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="TEMPLATE_DATA" type="blob">
+            <column name="TEMPLATE_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -249,7 +250,7 @@
             <column name="ATTACHMENT_NAME" type="varchar(128)">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="ATTACHMENT_DATA" type="blob">
+            <column name="ATTACHMENT_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.18.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.18.0.xml
@@ -5,8 +5,10 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="18000" author="ibodrov@gmail.com">
+        <validCheckSum>8:1f438bcabb92d2e075e3d80256cebec7</validCheckSum>
+        <validCheckSum>7:23585689b24b220fb101b371a4124952</validCheckSum>
         <addColumn tableName="PROJECTS">
-            <column name="PROJECT_CFG" type="blob">
+            <column name="PROJECT_CFG" type="longblob"> <!-- "longblob" to force liquibase 3.5.x+ to use "bytea" here -->
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.18.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.18.0.xml
@@ -7,6 +7,7 @@
     <changeSet id="18000" author="ibodrov@gmail.com">
         <validCheckSum>8:1f438bcabb92d2e075e3d80256cebec7</validCheckSum>
         <validCheckSum>7:23585689b24b220fb101b371a4124952</validCheckSum>
+        <validCheckSum>7:df2c5f86dc6836bf48def6c26bbcb89b</validCheckSum>
         <addColumn tableName="PROJECTS">
             <column name="PROJECT_CFG" type="longblob"> <!-- "longblob" to force liquibase 3.5.x+ to use "bytea" here -->
                 <constraints nullable="true"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.20.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.20.0.xml
@@ -6,6 +6,7 @@
 
     <changeSet id="20000" author="ibodrov@gmail.com">
         <validCheckSum>7:6319e50c991241cbd35987dd32834a4e</validCheckSum>
+        <validCheckSum>7:b3d65d57ff394117447433f1912ce0ec</validCheckSum>
         <createTable tableName="PROCESS_STATE">
             <column name="INSTANCE_ID" type="varchar(36)">
                 <constraints primaryKey="true" nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.20.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.20.0.xml
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="20000" author="ibodrov@gmail.com">
+        <validCheckSum>7:6319e50c991241cbd35987dd32834a4e</validCheckSum>
         <createTable tableName="PROCESS_STATE">
             <column name="INSTANCE_ID" type="varchar(36)">
                 <constraints primaryKey="true" nullable="false"/>
@@ -12,7 +13,7 @@
             <column name="ITEM_PATH" type="varchar(2048)">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="ITEM_DATA" type="blob">
+            <column name="ITEM_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.21.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.21.0.xml
@@ -7,6 +7,7 @@
     <!-- AGENT_COMMANDS -->
 
     <changeSet id="21000" author="ibodrov@gmail.com">
+        <validCheckSum>7:8bbd692e592acdfe7fb37e647589a978</validCheckSum>
         <createTable tableName="AGENT_COMMANDS">
             <column name="COMMAND_ID" type="varchar(36)">
                 <constraints primaryKey="true" nullable="false"/>
@@ -20,7 +21,7 @@
             <column name="CREATED_AT" type="timestamp">
                 <constraints nullable="false"/>
             </column>
-            <column name="COMMAND_DATA" type="blob">
+            <column name="COMMAND_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.22.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.22.0.xml
@@ -35,7 +35,7 @@
             <column name="CHUNK_RANGE" type="int4range">
                 <constraints nullable="false"/>
             </column>
-            <column name="CHUNK_DATA" type="blob">
+            <column name="CHUNK_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.64.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.64.0.xml
@@ -40,6 +40,8 @@
         </createTable>
     </changeSet>
 
+    <!-- replaced in 0.67.0 -->
+    <!--
     <changeSet id="64101" author="ibodrov@gmail.com">
         <createView viewName="V_AUDIT_LOG">
             select
@@ -53,6 +55,7 @@
             from AUDIT_LOG a
         </createView>
     </changeSet>
+    -->
 
     <changeSet id="64200" author="ibodrov@gmail.com">
         <addUniqueConstraint tableName="POLICIES" columnNames="POLICY_NAME"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -26,6 +26,7 @@
     </changeSet>
 
     <changeSet id="67200" author="ibodrov@gmail.com">
+        <validCheckSum>7:79a6d80f1acc2473d9de8080c1b9a20d</validCheckSum>
         <addColumn tableName="AUDIT_LOG">
             <column name="ENTRY_SEQ" type="bigserial"
                     remarks="Add sequences to enable forwarding">
@@ -33,6 +34,8 @@
             </column>
         </addColumn>
 
+        <!-- replaced in 1.58.0 -->
+        <!--
         <createView viewName="V_AUDIT_LOG" replaceIfExists="true">
             select
                 ENTRY_SEQ,
@@ -44,6 +47,7 @@
                 ENTRY_DETAILS
             from AUDIT_LOG a
         </createView>
+        -->
 
         <dropColumn tableName="AUDIT_LOG">
             <column name="ENTRY_ID"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -35,6 +35,7 @@
         </addColumn>
 
         <!-- replaced in 1.58.0 -->
+        <!--
         <createView viewName="V_AUDIT_LOG" replaceIfExists="true">
             select
                 ENTRY_SEQ,
@@ -46,6 +47,7 @@
                 ENTRY_DETAILS
             from AUDIT_LOG a
         </createView>
+        -->
 
         <dropColumn tableName="AUDIT_LOG">
             <column name="ENTRY_ID"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -17,6 +17,7 @@
     -->
 
     <changeSet id="67100" author="matthew.kunkel@walmartlabs.com">
+        <validCheckSum>7:b4f3446d4438acc4201a76cf9ab37959</validCheckSum>
         <addColumn tableName="PROCESS_EVENTS">
             <column name="EVENT_SEQ" type="bigserial"
                     remarks="Add sequences to enable forwarding">

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -28,6 +28,7 @@
 
     <changeSet id="67200" author="ibodrov@gmail.com">
         <validCheckSum>7:79a6d80f1acc2473d9de8080c1b9a20d</validCheckSum>
+        <validCheckSum>7:148f09276f67cb16502d0df0b9f4796c</validCheckSum>
         <addColumn tableName="AUDIT_LOG">
             <column name="ENTRY_SEQ" type="bigserial" autoIncrement="true"
                     remarks="Add sequences to enable forwarding">

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -29,6 +29,7 @@
         <validCheckSum>7:79a6d80f1acc2473d9de8080c1b9a20d</validCheckSum>
         <addColumn tableName="AUDIT_LOG">
             <column name="ENTRY_SEQ" type="bigserial"
+                    autoIncrement="true"
                     remarks="Add sequences to enable forwarding">
                 <constraints nullable="false"/>
             </column>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -19,7 +19,7 @@
     <changeSet id="67100" author="matthew.kunkel@walmartlabs.com">
         <validCheckSum>7:b4f3446d4438acc4201a76cf9ab37959</validCheckSum>
         <addColumn tableName="PROCESS_EVENTS">
-            <column name="EVENT_SEQ" type="bigserial"
+            <column name="EVENT_SEQ" type="bigserial" autoIncrement="true"
                     remarks="Add sequences to enable forwarding">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
@@ -29,8 +29,7 @@
     <changeSet id="67200" author="ibodrov@gmail.com">
         <validCheckSum>7:79a6d80f1acc2473d9de8080c1b9a20d</validCheckSum>
         <addColumn tableName="AUDIT_LOG">
-            <column name="ENTRY_SEQ" type="bigserial"
-                    autoIncrement="true"
+            <column name="ENTRY_SEQ" type="bigserial" autoIncrement="true"
                     remarks="Add sequences to enable forwarding">
                 <constraints nullable="false"/>
             </column>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.67.0.xml
@@ -35,7 +35,6 @@
         </addColumn>
 
         <!-- replaced in 1.58.0 -->
-        <!--
         <createView viewName="V_AUDIT_LOG" replaceIfExists="true">
             select
                 ENTRY_SEQ,
@@ -47,7 +46,6 @@
                 ENTRY_DETAILS
             from AUDIT_LOG a
         </createView>
-        -->
 
         <dropColumn tableName="AUDIT_LOG">
             <column name="ENTRY_ID"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.84.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.84.0.xml
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="84000" author="ybrigo@gmail.com">
+        <validCheckSum>7:3eef780cd96bb43b6005272baa83c9b8</validCheckSum>
         <createTable tableName="PROCESS_CHECKPOINTS">
             <column name="CHECKPOINT_ID" type="uuid">
                 <constraints primaryKey="true" nullable="false"/>
@@ -12,7 +13,7 @@
             <column name="INSTANCE_ID" type="uuid">
                 <constraints nullable="false"/>
             </column>
-            <column name="CHECKPOINT_DATA" type="blob">
+            <column name="CHECKPOINT_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.84.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.84.0.xml
@@ -6,6 +6,7 @@
 
     <changeSet id="84000" author="ybrigo@gmail.com">
         <validCheckSum>7:3eef780cd96bb43b6005272baa83c9b8</validCheckSum>
+        <validCheckSum>7:a8f71a204534c7b933683b7c35e434b9</validCheckSum>
         <createTable tableName="PROCESS_CHECKPOINTS">
             <column name="CHECKPOINT_ID" type="uuid">
                 <constraints primaryKey="true" nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.86.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.86.0.xml
@@ -6,6 +6,7 @@
 
     <changeSet id="86000" author="ibodrov@gmail.com">
         <validCheckSum>7:c24cac0e183b9520896b9e93207e3c49</validCheckSum>
+        <validCheckSum>7:0bd22f258406490fd222f5b634c16ce5</validCheckSum>
         <addColumn tableName="PROJECTS">
             <column name="SECRET_KEY" type="longblob">
                 <constraints nullable="true"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.86.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v0.86.0.xml
@@ -5,8 +5,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="86000" author="ibodrov@gmail.com">
+        <validCheckSum>7:c24cac0e183b9520896b9e93207e3c49</validCheckSum>
         <addColumn tableName="PROJECTS">
-            <column name="SECRET_KEY" type="blob">
+            <column name="SECRET_KEY" type="longblob">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
@@ -52,6 +52,7 @@
     </changeSet>
 
     <changeSet id="1490020" author="ybrigo@gmail.com">
+        <validCheckSum>7:99d9858515f12b793572e5b88b2550e6</validCheckSum>
         <createTable tableName="PROCESS_LOG_DATA">
             <column name="INSTANCE_ID" type="uuid">
                 <constraints nullable="false"/>
@@ -68,7 +69,7 @@
             <column name="SEGMENT_RANGE" type="int4range">
                 <constraints nullable="false"/>
             </column>
-            <column name="CHUNK_DATA" type="blob">
+            <column name="CHUNK_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
             <column name="LOG_SEQ" type="bigserial">

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
@@ -13,6 +13,7 @@
     </changeSet>
 
     <changeSet id="1490010" author="ybrigo@gmail.com">
+        <validCheckSum>7:b70de8118884fd89025bb9ed8a8b0572</validCheckSum>
         <createTable tableName="PROCESS_LOG_SEGMENTS">
             <column name="INSTANCE_ID" type="uuid">
                 <constraints nullable="false"/>
@@ -52,7 +53,7 @@
     </changeSet>
 
     <changeSet id="1490020" author="ybrigo@gmail.com">
-        <validCheckSum>7:99d9858515f12b793572e5b88b2550e6</validCheckSum>
+        <validCheckSum>7:10ab12d5b908de504f897e6e2a773036</validCheckSum>
         <createTable tableName="PROCESS_LOG_DATA">
             <column name="INSTANCE_ID" type="uuid">
                 <constraints nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.49.0.xml
@@ -21,7 +21,7 @@
             <column name="INSTANCE_CREATED_AT" type="timestamp">
                 <constraints nullable="false"/>
             </column>
-            <column name="SEGMENT_ID" type="bigserial">
+            <column name="SEGMENT_ID" type="bigserial" autoIncrement="true">
                 <constraints nullable="false"/>
             </column>
             <column name="SEGMENT_NAME" type="text">
@@ -61,7 +61,7 @@
             <column name="INSTANCE_CREATED_AT" type="timestamp">
                 <constraints nullable="false"/>
             </column>
-            <column name="SEGMENT_ID" type="bigserial">
+            <column name="SEGMENT_ID" type="bigserial" autoIncrement="true">
                 <constraints nullable="false"/>
             </column>
             <column name="LOG_RANGE" type="int4range">
@@ -73,7 +73,7 @@
             <column name="CHUNK_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
-            <column name="LOG_SEQ" type="bigserial">
+            <column name="LOG_SEQ" type="bigserial" autoIncrement="true">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.56.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.56.0.xml
@@ -38,6 +38,7 @@
     </changeSet>
 
     <changeSet id="1560050" author="ybrigo@gmail.com">
+        <validCheckSum>7:814490917fd400b881b94490dc4912e1</validCheckSum>
         <addColumn tableName="PROCESS_QUEUE">
             <column name="ID_SEQ" type="bigserial">
                 <constraints nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.56.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.56.0.xml
@@ -40,7 +40,7 @@
     <changeSet id="1560050" author="ybrigo@gmail.com">
         <validCheckSum>7:814490917fd400b881b94490dc4912e1</validCheckSum>
         <addColumn tableName="PROCESS_QUEUE">
-            <column name="ID_SEQ" type="bigserial">
+            <column name="ID_SEQ" type="bigserial" autoIncrement="true">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.83.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.83.0.xml
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="1830000" author="ybrigo@gmail.com">
+        <validCheckSum>7:a08819b929a9488573c3ea5d8f2f67a9</validCheckSum>
         <createTable tableName="PROCESS_WAIT_CONDITIONS">
             <column name="INSTANCE_ID" type="uuid">
                 <constraints nullable="false"/>
@@ -18,7 +19,7 @@
             <column name="WAIT_CONDITIONS" type="jsonb">
                 <constraints nullable="true"/>
             </column>
-            <column name="ID_SEQ" type="bigserial">
+            <column name="ID_SEQ" type="bigserial" autoIncrement="true">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.98.1.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.98.1.xml
@@ -43,13 +43,14 @@
     </changeSet>
 
     <changeSet id="1981030" author="g0h04k0@walmart.com">
+        <validCheckSum>7:bc92a99fabceb83a0e43e3fb6190c30d</validCheckSum>
         <addColumn tableName="SECRETS">
             <column name="LAST_UPDATED_AT" type="timestamptz">
                 <constraints nullable="true"/>
             </column>
         </addColumn>
         <addColumn tableName="SECRETS">
-            <column name="SECRET_SALT" type="blob">
+            <column name="SECRET_SALT" type="longblob">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.98.1.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v1.98.1.xml
@@ -44,6 +44,7 @@
 
     <changeSet id="1981030" author="g0h04k0@walmart.com">
         <validCheckSum>7:bc92a99fabceb83a0e43e3fb6190c30d</validCheckSum>
+        <validCheckSum>7:7a5abc67e92f25cb85f8e73fcd63a780</validCheckSum>
         <addColumn tableName="SECRETS">
             <column name="LAST_UPDATED_AT" type="timestamptz">
                 <constraints nullable="true"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
@@ -6,6 +6,7 @@
 
     <changeSet id="280000" author="ybrigo@gmail.com">
         <validCheckSum>7:3c18749b7f0a18dbf28ea1682c821138</validCheckSum>
+        <validCheckSum>7:1f544d2b211d758be8b7cec91502f84b</validCheckSum>
         <createTable tableName="PROCESS_INITIAL_STATE">
             <column name="INSTANCE_ID" type="uuid" remarks="Unique process ID">
                 <constraints primaryKey="true" nullable="false"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.8.0.xml
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="280000" author="ybrigo@gmail.com">
+        <validCheckSum>7:3c18749b7f0a18dbf28ea1682c821138</validCheckSum>
         <createTable tableName="PROCESS_INITIAL_STATE">
             <column name="INSTANCE_ID" type="uuid" remarks="Unique process ID">
                 <constraints primaryKey="true" nullable="false"/>
@@ -15,7 +16,7 @@
             <column name="ITEM_PATH" type="varchar(2048)">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="ITEM_DATA" type="blob">
+            <column name="ITEM_DATA" type="longblob">
                 <constraints nullable="false"/>
             </column>
             <column name="IS_ENCRYPTED" type="boolean" defaultValue="false">

--- a/server/impl/src/main/resources/logback.xml
+++ b/server/impl/src/main/resources/logback.xml
@@ -10,6 +10,7 @@
     <logger name="org.eclipse.jetty.server" level="WARN"/>
     <logger name="org.javers.core" level="WARN"/>
     <logger name="org.jooq" level="WARN"/>
+    <logger name="liquibase" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/server/impl/src/main/resources/logback.xml
+++ b/server/impl/src/main/resources/logback.xml
@@ -10,7 +10,6 @@
     <logger name="org.eclipse.jetty.server" level="WARN"/>
     <logger name="org.javers.core" level="WARN"/>
     <logger name="org.jooq" level="WARN"/>
-    <logger name="liquibase" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -92,8 +92,7 @@
         <kerby.version>2.0.1</kerby.version>
         <kubernetes.client.version>5.7.0</kubernetes.client.version>
         <launcher.version>0.128</launcher.version>
-        <liquibase.version>3.5.1
-        </liquibase.version> <!-- the newer versions (up to 3.5.3) have incorrect mappings for PG's blob/bytea -->
+        <liquibase.version>4.8.0</liquibase.version>
         <logback.version>1.4.14</logback.version>
         <maven.annotation.version>3.5</maven.annotation.version>
         <maven.api.version>3.0.5</maven.api.version>


### PR DESCRIPTION
Latest Liquibase -- requires changes in existing change sets. At some point Liquibase started mapping `blob` to `oid` instead of `bytea`. Now we need to use `longblob` if we want the old behavior.  We also need to specify `autoIncremen=true` explicitly for any `*serial` columns we have.