### PR TITLE
dependency-manager: allow `LATEST` to pull latest version from remote repositories

### DIFF
--- a/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
+++ b/dependency-manager/src/main/java/com/walmartlabs/concord/dependencymanager/DependencyManager.java
@@ -156,9 +156,8 @@ public class DependencyManager {
         String scheme = item.getScheme();
         if (MAVEN_SCHEME.equalsIgnoreCase(scheme)) {
             String id = item.getAuthority();
-
-            Artifact artifactResult = resolveMavenSingle(new MavenDependency(new DefaultArtifact(id), JavaScopes.COMPILE), progressNotifier);
-            return toDependency(artifactResult);
+            Artifact artifact = resolveMavenSingle(new MavenDependency(new DefaultArtifact(id), JavaScopes.COMPILE), progressNotifier);
+            return toDependency(artifact);
         } else {
             return new DependencyEntity(resolveFile(item), item);
         }

--- a/dependency-manager/src/test/java/com/walmartlabs/concord/dependencymanager/DependencyManagerTest.java
+++ b/dependency-manager/src/test/java/com/walmartlabs/concord/dependencymanager/DependencyManagerTest.java
@@ -98,4 +98,36 @@ public class DependencyManagerTest {
             m.resolveSingle(new URI("mvn://com.walmartlabs.concord:concord-sdk:1.54.0"));
         });
     }
+
+    @Test
+    @Disabled
+    public void testLatest() {
+        assertTimeout(Duration.ofMillis(30000), () -> {
+            Path tmpDir = Files.createTempDirectory("test");
+            URI uriA = new URI("mvn://com.walmartlabs.concord:concord-sdk:2.8.0");
+            URI uriB = new URI("mvn://com.walmartlabs.concord:concord-policy-engine:LATEST");
+            URI uriC = new URI("mvn://com.walmartlabs.concord:concord-agent:LATEST");
+            List<MavenRepository> repositories = Collections.singletonList(
+                    MavenRepository.builder()
+                            .id("test")
+                            .url("https://repo.maven.apache.org/maven2/")
+                            .build()
+            );
+
+            DependencyManager m = new DependencyManager(DependencyManagerConfiguration
+                    .builder()
+                    .repositories(repositories)
+                    .cacheDir(tmpDir)
+                    .build());
+            Collection<DependencyEntity> paths = m.resolve(Arrays.asList(uriA, uriB));
+
+            assertEquals("2.11.1", paths.stream()
+                    .filter(a -> a.getArtifact().getGroupId().equals("com.walmartlabs.concord")
+                            && a.getArtifact().getArtifactId().equals("concord-policy-engine"))
+                    .findFirst().get().getArtifact().getVersion());
+
+            DependencyEntity deps = m.resolveSingle(uriC);
+            assertEquals("2.11.1", deps.getArtifact().getVersion());
+        });
+    }
 }

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -101,7 +101,7 @@
         <maven.prj.version>2.2.1</maven.prj.version>
         <maven.resolver.provider.version>3.8.4</maven.resolver.provider.version>
         <maven.model.builder.version>3.8.4</maven.model.builder.version>
-        <maven.resolver.version>1.7.3</maven.resolver.version>
+        <maven.resolver.version>1.9.20</maven.resolver.version>
         <maven.resolver.version.concord>0.0.4</maven.resolver.version.concord>
         <metrics.version>4.2.25</metrics.version>
         <mockito.version>4.9.0</mockito.version>


### PR DESCRIPTION
Example:

`mvn://com.walmartlabs.concord:concord-sdk:LATEST`