### PR TITLE
server: exception mapper for InvalidProcessStateException

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/InvalidProcessStateExceptionMapper.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/InvalidProcessStateExceptionMapper.java
@@ -1,0 +1,39 @@
+package com.walmartlabs.concord.server.process.pipelines.processors;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.boot.resteasy.ExceptionMapperSupport;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+@Named
+@Singleton
+@Provider
+public class InvalidProcessStateExceptionMapper extends ExceptionMapperSupport<InvalidProcessStateException> {
+
+    @Override
+    protected Response convert(InvalidProcessStateException e) {
+        return Response.status(Response.Status.CONFLICT).entity(e.getMessage()).build();
+    }
+}


### PR DESCRIPTION
simply to avoid logging the stack trace of this exception and return a proper status code