### PR TITLE
runtime-v2: use log segment statuses

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/LogSegmentStats.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/LogSegmentStats.java
@@ -23,7 +23,7 @@ package com.walmartlabs.concord.agent.logging;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.walmartlabs.concord.client2.LogSegmentUpdateRequest;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 public interface LogSegmentStats {
 
     @Nullable
-    LogSegmentUpdateRequest.StatusEnum status();
+    LogSegmentStatus status();
 
     @Nullable
     Integer errors();

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/RemoteLogAppender.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/RemoteLogAppender.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.agent.logging;
 
 import com.walmartlabs.concord.agent.AgentConstants;
 import com.walmartlabs.concord.client2.*;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +74,7 @@ public class RemoteLogAppender implements LogAppender {
     @Override
     public boolean updateSegment(UUID instanceId, long segmentId, LogSegmentStats stats) {
         LogSegmentUpdateRequest request = new LogSegmentUpdateRequest()
-                .status(stats.status())
+                .status(convertStatus(stats.status()))
                 .warnings(stats.warnings())
                 .errors(stats.errors());
 
@@ -85,5 +86,17 @@ public class RemoteLogAppender implements LogAppender {
             log.warn("updateSegment ['{}', '{}', '{}'] -> error: {}", instanceId, segmentId, stats, e.getMessage());
         }
         return false;
+    }
+
+    private static LogSegmentUpdateRequest.StatusEnum convertStatus(LogSegmentStatus status) {
+        if (status == null) {
+            return null;
+        }
+        return switch (status) {
+            case ERROR -> LogSegmentUpdateRequest.StatusEnum.FAILED;
+            case OK -> LogSegmentUpdateRequest.StatusEnum.OK;
+            case RUNNING -> LogSegmentUpdateRequest.StatusEnum.RUNNING;
+            case SUSPENDED -> LogSegmentUpdateRequest.StatusEnum.SUSPENDED;
+        };
     }
 }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentHeaderParser.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentHeaderParser.java
@@ -139,33 +139,6 @@ public class SegmentHeaderParser {
 
         return result;
     }
-//
-//    public static byte[] serialize(Header header) {
-//        return String.format("|%d|%d|%d|%d|%d|",
-//                header.length(),
-//                header.segmentId(),
-//                serializeStatus(header.status()),
-//                header.warnCount(), header.errorCount()).getBytes();
-//    }
-//
-//    public static int serializeStatus(LogSegmentUpdateRequest.StatusEnum status) {
-//        return switch (status) {
-//            case RUNNING -> 0;
-//            case OK -> 1;
-//            case SUSPENDED -> 2;
-//            case FAILED -> 3;
-//        };
-//    }
-//
-//    public static LogSegmentUpdateRequest.StatusEnum deserializeStatus(String status) {
-//        return switch (status) {
-//            case "0" -> LogSegmentUpdateRequest.StatusEnum.RUNNING;
-//            case "1" -> LogSegmentUpdateRequest.StatusEnum.OK;
-//            case "2" -> LogSegmentUpdateRequest.StatusEnum.SUSPENDED;
-//            case "3" -> LogSegmentUpdateRequest.StatusEnum.FAILED;
-//            default -> throw new IllegalStateException("Unexpected value: " + status);
-//        };
-//    }
 
     @Value.Immutable
     @Value.Style(jdkOnly = true)

--- a/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentedLogsConsumer.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/logging/SegmentedLogsConsumer.java
@@ -93,6 +93,7 @@ public class SegmentedLogsConsumer implements Consumer<RedirectedProcessLog.Chun
     private void invalidSegmentsToSystemSegments(List<Position> invalidSegments, List<Segment> segments) {
         for (Position s : invalidSegments) {
             LogSegmentHeader header = LogSegmentHeader.builder()
+                    .status(LogSegmentStatus.RUNNING)
                     .segmentId(0)
                     .errorCount(0)
                     .warnCount(0)

--- a/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
+++ b/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
@@ -22,7 +22,6 @@ package com.walmartlabs.concord.agent.executors.runner;
 
 import com.google.common.primitives.Bytes;
 import com.walmartlabs.concord.agent.logging.SegmentHeaderParser;
-import com.walmartlabs.concord.client2.LogSegmentUpdateRequest;
 import com.walmartlabs.concord.runtime.common.logger.LogSegmentHeader;
 import com.walmartlabs.concord.runtime.common.logger.LogSegmentSerializer;
 import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
@@ -205,7 +204,7 @@ public class SegmentHeaderParserTest {
         assertEquals(1, segments.size());
         Segment s = segments.get(0);
         assertEquals(0, s.header().length());
-        assertEquals(LogSegmentUpdateRequest.StatusEnum.OK, s.header().status());
+        assertEquals(LogSegmentStatus.OK, s.header().status());
     }
 
     private static String msg(byte[] ab, Segment segment) {

--- a/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
+++ b/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentHeaderParserTest.java
@@ -22,6 +22,10 @@ package com.walmartlabs.concord.agent.executors.runner;
 
 import com.google.common.primitives.Bytes;
 import com.walmartlabs.concord.agent.logging.SegmentHeaderParser;
+import com.walmartlabs.concord.client2.LogSegmentUpdateRequest;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentHeader;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentSerializer;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -29,11 +33,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Header;
 import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Position;
 import static com.walmartlabs.concord.agent.logging.SegmentHeaderParser.Segment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SegmentHeaderParserTest {
 
@@ -203,7 +205,7 @@ public class SegmentHeaderParserTest {
         assertEquals(1, segments.size());
         Segment s = segments.get(0);
         assertEquals(0, s.header().length());
-        assertTrue(s.header().done());
+        assertEquals(LogSegmentUpdateRequest.StatusEnum.OK, s.header().status());
     }
 
     private static String msg(byte[] ab, Segment segment) {
@@ -214,12 +216,12 @@ public class SegmentHeaderParserTest {
     private static byte[] bb(int segmentId, String msg) {
         byte[] ab = msg.getBytes();
 
-        byte[] header = SegmentHeaderParser.serialize(Header.builder()
+        byte[] header = LogSegmentSerializer.serializeHeader(LogSegmentHeader.builder()
                 .segmentId(segmentId)
                 .length(ab.length)
                 .warnCount(1)
                 .errorCount(2)
-                .done(false)
+                .status(LogSegmentStatus.RUNNING)
                 .build());
 
         return Bytes.concat(header, ab);

--- a/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentedLogsConsumerTest.java
+++ b/agent/src/test/java/com/walmartlabs/concord/agent/executors/runner/SegmentedLogsConsumerTest.java
@@ -23,8 +23,10 @@ package com.walmartlabs.concord.agent.executors.runner;
 import com.google.common.primitives.Bytes;
 import com.walmartlabs.concord.agent.logging.LogAppender;
 import com.walmartlabs.concord.agent.logging.LogSegmentStats;
-import com.walmartlabs.concord.agent.logging.SegmentHeaderParser;
 import com.walmartlabs.concord.agent.logging.SegmentedLogsConsumer;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentHeader;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentSerializer;
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -156,12 +158,12 @@ public class SegmentedLogsConsumerTest {
     private static byte[] bb(int segmentId, String msg, int errorCount, int warnCount) {
         byte[] ab = msg.getBytes();
 
-        byte[] header = SegmentHeaderParser.serialize(SegmentHeaderParser.Header.builder()
+        byte[] header = LogSegmentSerializer.serializeHeader(LogSegmentHeader.builder()
                 .segmentId(segmentId)
                 .length(ab.length)
                 .warnCount(warnCount)
                 .errorCount(errorCount)
-                .done(false)
+                .status(LogSegmentStatus.RUNNING)
                 .build());
 
         return Bytes.concat(header, ab);

--- a/console2/src/api/process/log/index.ts
+++ b/console2/src/api/process/log/index.ts
@@ -81,7 +81,8 @@ export const getLog = async (instanceId: ConcordId, range: LogRange): Promise<Lo
 export enum SegmentStatus {
     OK = 'OK',
     FAILED = 'FAILED',
-    RUNNING = 'RUNNING'
+    RUNNING = 'RUNNING',
+    SUSPENDED = 'SUSPENDED'
 }
 
 export interface LogSegmentEntry {

--- a/console2/src/components/molecules/LogSegment/index.tsx
+++ b/console2/src/components/molecules/LogSegment/index.tsx
@@ -310,6 +310,9 @@ const StatusIcon = ({ status, processStatus, warnings = 0, errors = 0 }: StatusI
         color = 'teal';
         icon = 'spinner';
         spinning = true;
+    } else if (status === SegmentStatus.SUSPENDED) {
+        color = 'blue';
+        icon = 'hourglass half';
     } else if (status === SegmentStatus.FAILED) {
         color = 'red';
         icon = 'close';

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentDeserializer.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentDeserializer.java
@@ -23,7 +23,7 @@ package com.walmartlabs.concord.runtime.common.logger;
 public final class LogSegmentDeserializer {
 
     public static LogSegmentStatus deserializeStatus(String status) {
-        return LogSegmentStatus.fromString(status);
+        return LogSegmentStatus.fromId(Integer.parseInt(status));
     }
 
     private LogSegmentDeserializer() {

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentDeserializer.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentDeserializer.java
@@ -1,10 +1,10 @@
-package com.walmartlabs.concord.runtime.v2.runner.logging;
+package com.walmartlabs.concord.runtime.common.logger;
 
 /*-
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2024 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,12 @@ package com.walmartlabs.concord.runtime.v2.runner.logging;
  * =====
  */
 
-import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
+public final class LogSegmentDeserializer {
 
-import javax.annotation.Nullable;
-import java.util.UUID;
+    public static LogSegmentStatus deserializeStatus(String status) {
+        return LogSegmentStatus.fromString(status);
+    }
 
-public interface RunnerLogger {
-
-    void withContext(LogContext context, Runnable runnable);
-
-    @Nullable
-    Long createSegment(String segmentName, UUID correlationId);
-
-    void setSegmentStatus(long segmentId, LogSegmentStatus segmentStatus);
+    private LogSegmentDeserializer() {
+    }
 }

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentHeader.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentHeader.java
@@ -1,10 +1,10 @@
-package com.walmartlabs.concord.runtime.v2.runner.logging;
+package com.walmartlabs.concord.runtime.common.logger;
 
 /*-
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2024 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,23 @@ package com.walmartlabs.concord.runtime.v2.runner.logging;
  * =====
  */
 
-import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
+import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
-import java.util.UUID;
+@Value.Immutable
+@Value.Style(jdkOnly = true)
+public interface LogSegmentHeader {
 
-public interface RunnerLogger {
+    int length();
 
-    void withContext(LogContext context, Runnable runnable);
+    long segmentId();
 
-    @Nullable
-    Long createSegment(String segmentName, UUID correlationId);
+    int warnCount();
 
-    void setSegmentStatus(long segmentId, LogSegmentStatus segmentStatus);
+    int errorCount();
+
+    LogSegmentStatus status();
+
+    static ImmutableLogSegmentHeader.Builder builder() {
+        return ImmutableLogSegmentHeader.builder();
+    }
 }

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentSerializer.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentSerializer.java
@@ -40,10 +40,10 @@ public final class LogSegmentSerializer {
     public static byte[] serializeHeader(LogSegmentHeader header, int messageLength) {
         return String.format("|%d|%d|%d|%d|%d|",
                         messageLength,
-                header.segmentId(),
-                header.status().id(),
-                header.warnCount(),
-                header.errorCount())
+                        header.segmentId(),
+                        header.status().id(),
+                        header.warnCount(),
+                        header.errorCount())
                 .getBytes();
     }
 

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentSerializer.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentSerializer.java
@@ -1,0 +1,59 @@
+package com.walmartlabs.concord.runtime.common.logger;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public final class LogSegmentSerializer {
+
+    private static final byte[] EMPTY_AB = new byte[0];
+
+    public static byte[] serialize(LogSegmentHeader header, String message) {
+        byte[] msgBytes = EMPTY_AB;
+        if (message != null) {
+            msgBytes = message.getBytes();
+        }
+        byte[] headerBytes = serializeHeader(header, msgBytes.length);
+        return concat(headerBytes, msgBytes);
+    }
+
+    public static byte[] serializeHeader(LogSegmentHeader header) {
+        return serializeHeader(header, header.length());
+    }
+
+    public static byte[] serializeHeader(LogSegmentHeader header, int messageLength) {
+        return String.format("|%d|%d|%d|%d|%d|",
+                        messageLength,
+                header.segmentId(),
+                header.status().id(),
+                header.warnCount(),
+                header.errorCount())
+                .getBytes();
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] c = new byte[a.length + b.length];
+        System.arraycopy(a, 0, c, 0, a.length);
+        System.arraycopy(b, 0, c, a.length, b.length);
+        return c;
+    }
+
+    private LogSegmentSerializer() {
+    }
+}

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
@@ -1,0 +1,48 @@
+package com.walmartlabs.concord.runtime.common.logger;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public enum LogSegmentStatus {
+
+    RUNNING (0),
+    OK (1),
+    SUSPENDED (2),
+    ERROR (3);
+
+    private final int id;
+
+    LogSegmentStatus(int id) {
+        this.id = id;
+    }
+
+    public int id() {
+        return id;
+    }
+
+    public static LogSegmentStatus fromString(String status) {
+        for (LogSegmentStatus s : LogSegmentStatus.values()) {
+            if (s.name().equals(status)) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("Unknown log segment status: " + status);
+    }
+}

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
@@ -24,7 +24,7 @@ public enum LogSegmentStatus {
 
     RUNNING (0),
     OK (1),
-    SUSPENDED (2),
+    SUSPENDED (2), // unused now...
     ERROR (3);
 
     private final int id;

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/logger/LogSegmentStatus.java
@@ -37,9 +37,9 @@ public enum LogSegmentStatus {
         return id;
     }
 
-    public static LogSegmentStatus fromString(String status) {
+    public static LogSegmentStatus fromId(int status) {
         for (LogSegmentStatus s : LogSegmentStatus.values()) {
-            if (s.name().equals(status)) {
+            if (s.id() == status) {
                 return s;
             }
         }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogLevelFilter.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/LogLevelFilter.java
@@ -28,7 +28,7 @@ public class LogLevelFilter extends Filter<ILoggingEvent> {
 
     @Override
     public FilterReply decide(ILoggingEvent event) {
-        if (event.getMarker() == ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER) {
+        if (ConcordLogEncoder.segmentMarker(event) != null) {
             return FilterReply.NEUTRAL;
         }
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/SegmentStatusMarker.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/SegmentStatusMarker.java
@@ -1,0 +1,84 @@
+package com.walmartlabs.concord.runtime.v2.runner.logging;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
+import org.slf4j.Marker;
+
+import java.util.Iterator;
+
+public class SegmentStatusMarker implements Marker {
+
+    private final long segmentId;
+    private final LogSegmentStatus status;
+
+    public SegmentStatusMarker(long segmentId, LogSegmentStatus status) {
+        this.segmentId = segmentId;
+        this.status = status;
+    }
+
+    public long getSegmentId() {
+        return segmentId;
+    }
+
+    public LogSegmentStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getName() {
+        return "close-segment-marker";
+    }
+
+    @Override
+    public void add(Marker reference) {
+    }
+
+    @Override
+    public boolean remove(Marker reference) {
+        return false;
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return false;
+    }
+
+    @Override
+    public boolean hasReferences() {
+        return false;
+    }
+
+    @Override
+    public Iterator<Marker> iterator() {
+        return null;
+    }
+
+    @Override
+    public boolean contains(Marker other) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(String name) {
+        return false;
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/SimpleLogger.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/logging/SimpleLogger.java
@@ -20,6 +20,8 @@ package com.walmartlabs.concord.runtime.v2.runner.logging;
  * =====
  */
 
+import com.walmartlabs.concord.runtime.common.logger.LogSegmentStatus;
+
 import java.util.UUID;
 
 public class SimpleLogger implements RunnerLogger {
@@ -27,6 +29,11 @@ public class SimpleLogger implements RunnerLogger {
     @Override
     public Long createSegment(String segmentName, UUID correlationId) {
         return null;
+    }
+
+    @Override
+    public void setSegmentStatus(long segmentId, LogSegmentStatus segmentStatus) {
+        // do nothing
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/LogSegment.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/LogSegment.java
@@ -62,7 +62,8 @@ public interface LogSegment {
     enum Status {
         OK,
         FAILED,
-        RUNNING
+        RUNNING,
+        SUSPENDED
     }
 
     static ImmutableLogSegment.Builder builder() {


### PR DESCRIPTION
before this, the segment had two statuses: RUNNING and OK.
now the segment will have the correct status in case of an error.
the SUSPENDED status is not used yet, I just reserved id=2 for it))