### PR TITLE
project: build both x86 and aarch64 versions

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -4,9 +4,6 @@
     <profiles>
         <profile>
             <id>gha</id>
-            <properties>
-                <it.skipDocker>true</it.skipDocker>
-            </properties>
         </profile>
     </profiles>
 </settings>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,5 @@ jobs:
       - name: Build and test with Maven
         env:
           SKIP_DOCKER_TESTS: "true"
+          SKIP_OLD_AGENT_TESTS: "true"
         run: ./mvnw -s .github/settings.xml -B clean install -Pgha -Pdocker -Pit -P${{ matrix.profile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Build and test with Maven
         env:
           SKIP_DOCKER_TESTS: "true"
+          # re-enable old agent tests once we are several versions ahead
           SKIP_OLD_AGENT_TESTS: "true"
         run: ./mvnw -s .github/settings.xml -B clean install -Pgha -Pdocker -Pit -P${{ matrix.profile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,16 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk_version: [ '17' ]
+        profile: [ 'jdk17', 'jdk17-aarch64' ]
+        include:
+          - jdk_version: '17'
+          - profile: 'jdk17'
+            runs_on: ubuntu-latest
+          - profile: 'jdk17-aarch64'
+            runs_on: [ linux, ARM64 ]
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
 
     steps:
       - name: Set up Docker Buildx
@@ -43,4 +49,4 @@ jobs:
       - name: Build and test with Maven
         env:
           SKIP_DOCKER_TESTS: "true"
-        run: ./mvnw -s .github/settings.xml -B clean install -Pgha -Pdocker -Pit -Pjdk${{ matrix.jdk_version }}
+        run: ./mvnw -s .github/settings.xml -B clean install -Pgha -Pdocker -Pit -P${{ matrix.profile }}

--- a/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
+++ b/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
@@ -26,6 +26,7 @@ import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
 import com.walmartlabs.concord.client2.ProcessEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.images.PullPolicy;
 
@@ -37,6 +38,7 @@ import static com.walmartlabs.concord.it.compat.ITConstants.DEFAULT_TEST_TIMEOUT
  * Runs an older version of the Agent with the current version of the Server.
  */
 @Timeout(value = DEFAULT_TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
+@DisabledIfEnvironmentVariable(named = "SKIP_OLD_AGENT_TESTS", matches = "true", disabledReason = "Requires a published agent image of the old version.")
 public class OldAgentIT {
 
     @RegisterExtension
@@ -50,8 +52,8 @@ public class OldAgentIT {
     @Test
     public void test() throws Exception {
         String concordYml = "flows:\n" +
-                "  default:\n" +
-                "    - log: \"Hello!\"\n";
+                            "  default:\n" +
+                            "    - log: \"Hello!\"\n";
 
         ConcordProcess proc = concord.processes().start(new Payload()
                 .concordYml(concordYml));

--- a/it/runtime-v2/pom.xml
+++ b/it/runtime-v2/pom.xml
@@ -19,7 +19,7 @@
         <server.image>walmartlabs/concord-server</server.image>
         <agent.image>walmartlabs/concord-agent</agent.image>
         <ryuk.image>testcontainers/ryuk:0.6.0</ryuk.image>
-        <sshd.image>testcontainers/sshd:latest</sshd.image>
+        <sshd.image>testcontainers/sshd:1.2.0</sshd.image>
     </properties>
 
     <dependencies>

--- a/it/server/pom.xml
+++ b/it/server/pom.xml
@@ -29,7 +29,6 @@
         <it.ldap.addr>ldap-node:389</it.ldap.addr>
         <it.server.network.mode>custom</it.server.network.mode>
         <it.server.port>8001</it.server.port>
-        <it.skipDocker>false</it.skipDocker>
         <local.repository.src.mount>${settings.localRepository}</local.repository.src.mount>
         <network>net-server-it</network>
         <oldap.image>osixia/openldap</oldap.image>
@@ -252,7 +251,6 @@
                         <IT_LDAP_URL>ldap://localhost:${it.ldap.port}</IT_LDAP_URL>
                         <IT_PROJECT_VERSION>${project.version}</IT_PROJECT_VERSION>
                         <IT_SERVER_PORT>${it.server.port}</IT_SERVER_PORT>
-                        <IT_SKIP_DOCKER_TESTS>${it.skipDocker}</IT_SKIP_DOCKER_TESTS>
                     </environmentVariables>
                     <systemProperties>
                         <java.io.tmpdir>${tmp.dir}</java.io.tmpdir>

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/AbstractServerIT.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -213,10 +215,6 @@ public abstract class AbstractServerIT {
             return def;
         }
         return v;
-    }
-
-    public static boolean shouldSkipDockerTests() {
-        return Boolean.parseBoolean(System.getenv("IT_SKIP_DOCKER_TESTS"));
     }
 
     protected void withOrg(Consumer<String> consumer) throws Exception {

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -125,7 +125,7 @@
         <sshd.version>2.8.0</sshd.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
         <testcontainers.concord.version>2.0.1</testcontainers.concord.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <wiremock.version>3.5.2</wiremock.version>
     </properties>


### PR DESCRIPTION
`runs-on: [ linux, ARM64 ]` is currently handled by a RPi5 in my basement. :-)

Next step will be moving the release process to GHA flows.