### PR TITLE
runtime-v2: limit depth of MultiException stack trace

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -51,7 +51,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.runtime.v2.runner.vm.LoggedException;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
-import com.walmartlabs.concord.svm.MultiException;
+import com.walmartlabs.concord.svm.ParallelExecutionException;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -274,7 +274,7 @@ public class Run implements Callable<Integer> {
             runner.start(cfg, processDefinition, args);
         } catch (LoggedException e) {
             return -1;
-        } catch (MultiException e) {
+        } catch (ParallelExecutionException e) {
             System.err.println(e.getMessage());
             return -1;
         } catch (Exception e) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/Main.java
@@ -42,7 +42,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.UserDefinedException;
 import com.walmartlabs.concord.runtime.v2.sdk.WorkingDirectory;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.svm.Frame;
-import com.walmartlabs.concord.svm.MultiException;
+import com.walmartlabs.concord.svm.ParallelExecutionException;
 import com.walmartlabs.concord.svm.State;
 import com.walmartlabs.concord.svm.ThreadStatus;
 import org.slf4j.Logger;
@@ -111,7 +111,7 @@ public class Main {
         } catch (UserDefinedException e) {
             log.error(e.getMessage());
             System.exit(1);
-        } catch (MultiException e) {
+        } catch (ParallelExecutionException e) {
             log.error("{}", e.getMessage());
             System.exit(1);
         } catch (Throwable t) {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
@@ -83,7 +83,7 @@ public class JoinCommand<T extends Step> extends StepCommand<T> {
 
             // nothing left to run and we got some unhandled exceptions
             if (!failed.isEmpty() && !anyReady) {
-                throw new MultiException(failed.stream()
+                throw new ParallelExecutionException(failed.stream()
                         .map(state::clearThreadError)
                         .toList());
             }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -25,7 +25,7 @@ import com.walmartlabs.concord.forms.Form;
 import com.walmartlabs.concord.runtime.common.cfg.LoggingConfiguration;
 import com.walmartlabs.concord.runtime.common.cfg.RunnerConfiguration;
 import com.walmartlabs.concord.runtime.v2.runner.vm.LoggedException;
-import com.walmartlabs.concord.runtime.v2.sdk.*;
+import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
@@ -662,6 +662,17 @@ public class MainTest extends AbstractTest {
         byte[] log = run();
         assertLog(log, ".*result: \\[10, 20, 30\\].*");
         assertLog(log, ".*threadIds: \\[1, 2, 3].*");
+    }
+
+    @Test
+    public void testParallelWithError() throws Exception {
+        deploy("parallelWithError");
+
+        save(ProcessConfiguration.builder()
+                .build());
+
+        LoggedException exception = assertThrows(LoggedException.class, this::run);
+        assertTrue(exception.getMessage().matches("(?s)Parallel execution errors:.*faultyTask.*\n.*faultyTask.*"));
     }
 
     @Test

--- a/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/parallelWithError/concord.yml
+++ b/runtime/v2/runner/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/parallelWithError/concord.yml
@@ -1,0 +1,9 @@
+flows:
+  default:
+    - task: faultyTask
+      loop:
+        mode: parallel
+        parallelism: 2
+        items:
+          - "foo"
+          - "bar"

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/ParallelExecutionException.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/ParallelExecutionException.java
@@ -26,18 +26,22 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-public class MultiException extends RuntimeException {
+/**
+ * An exception that is thrown when multiple exceptions are thrown
+ * in {@code parallel} blocks.
+ */
+public class ParallelExecutionException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
     private static final int MAX_STACK_TRACE_ELEMENTS = 3;
 
-    public MultiException(Collection<Exception> causes) {
+    public ParallelExecutionException(Collection<Exception> causes) {
         super("Parallel execution errors: \n" + toMessage(causes));
     }
 
     private static String toMessage(Collection<Exception> causes) {
         return causes.stream()
-                .map(MultiException::stacktraceToString)
+                .map(ParallelExecutionException::stacktraceToString)
                 .collect(Collectors.joining("\n"));
     }
 


### PR DESCRIPTION
Cut off the bottom of the trace, it's not particularly useful anyway.
Should make parallel execution errors sligtly more readable.

Before:

```
2024-06-18T14:18:16.989+0000 [INFO ] will fail with error
2024-06-18T14:18:16.989+0000 [INFO ] will fail with error
2024-06-18T14:18:16.995+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Error during execution of 'faultyTask' task: boom!
2024-06-18T14:18:16.995+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Error during execution of 'faultyTask' task: boom!
2024-06-18T14:18:17.965+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Errors: 
java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:100)
	at com.walmartlabs.concord.runtime.v2.runner.tasks.ContextProvider.withContext(ContextProvider.java:49)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.executeWithContext(StepCommand.java:95)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.eval(StepCommand.java:83)
	at com.walmartlabs.concord.svm.VM.eval(VM.java:173)
	at com.walmartlabs.concord.runtime.v2.runner.DefaultRuntime.lambda$spawn$0(DefaultRuntime.java:54)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallUtils.toException(TaskCallUtils.java:77)
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallUtils.processTaskResult(TaskCallUtils.java:56)
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallCommand.execute(TaskCallCommand.java:94)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:97)
	... 10 more

java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:100)
	at com.walmartlabs.concord.runtime.v2.runner.tasks.ContextProvider.withContext(ContextProvider.java:49)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.executeWithContext(StepCommand.java:95)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.eval(StepCommand.java:83)
	at com.walmartlabs.concord.svm.VM.eval(VM.java:173)
	at com.walmartlabs.concord.runtime.v2.runner.DefaultRuntime.lambda$spawn$0(DefaultRuntime.java:54)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallUtils.toException(TaskCallUtils.java:77)
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallUtils.processTaskResult(TaskCallUtils.java:56)
	at com.walmartlabs.concord.runtime.v2.runner.vm.TaskCallCommand.execute(TaskCallCommand.java:94)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:97)
	... 10 more
```

After:

```
2024-06-18T14:19:03.370+0000 [INFO ] will fail with error
2024-06-18T14:19:03.370+0000 [INFO ] will fail with error
2024-06-18T14:19:03.375+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Error during execution of 'faultyTask' task: boom!
2024-06-18T14:19:03.375+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Error during execution of 'faultyTask' task: boom!
2024-06-18T14:19:04.354+0000 [ERROR] (concord.yml): Error @ line: 3, col: 7. Parallel execution errors: 
java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:100)
	at com.walmartlabs.concord.runtime.v2.runner.tasks.ContextProvider.withContext(ContextProvider.java:49)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.executeWithContext(StepCommand.java:95)
	...8 more

java.lang.RuntimeException: Error during execution of 'faultyTask' task: boom!
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.lambda$executeWithContext$1(StepCommand.java:100)
	at com.walmartlabs.concord.runtime.v2.runner.tasks.ContextProvider.withContext(ContextProvider.java:49)
	at com.walmartlabs.concord.runtime.v2.runner.vm.StepCommand.executeWithContext(StepCommand.java:95)
	...8 more
```