### PR TITLE
concord-server: expose websocket channels

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/websocket/WebSocketChannel.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/websocket/WebSocketChannel.java
@@ -62,6 +62,10 @@ public class WebSocketChannel {
         return userAgent;
     }
 
+    public Session getSession() {
+        return session;
+    }
+
     public void onRequest(Message request) {
         Message old = requests.put(request.getCorrelationId(), request);
         if (old != null) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/websocket/WebSocketChannelManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/websocket/WebSocketChannelManager.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -116,5 +117,9 @@ public class WebSocketChannelManager {
 
     public int connectedClientsCount() {
         return channels.size();
+    }
+
+    public Map<UUID, WebSocketChannel> getChannels() {
+        return Collections.unmodifiableMap(channels);
     }
 }


### PR DESCRIPTION
Allow server plugins to access currently connected websockets.