### PR TITLE
schema: add json schema for concord YAML syntax

### DIFF
--- a/.schema/concord.json
+++ b/.schema/concord.json
@@ -1,0 +1,705 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Schema for Concord",
+  "description": "",
+  "type":"object",
+  "properties": {
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "runtime": {
+          "type":"string",
+          "enum": ["concord-v2"]
+        },
+        "entryPoint": {
+          "type":"string"
+        },
+        "arguments": {
+          "type":"object",
+          "additionalProperties": {"type":["object", "array","boolean","integer","number","string"]}
+        },
+        "dependencies": {
+          "type":"array",
+          "items": {"type":"string"}
+        },
+        "requirements": {
+          "type":"object",
+          "properties": {
+            "agent": {"type": "object"}
+          }
+        },
+        "processTimeout": {
+          "type":"string",
+          "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+        },
+        "suspendTimeout": {
+          "type": "string",
+          "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+        },
+        "exclusive": {
+          "type":"object",
+          "properties": {
+            "group": {
+              "type":"string",
+              "minLength":1
+            },
+            "mode": {
+              "type":"string",
+              "enum": ["cancel","cancelOld","wait"]
+            }
+          },
+          "required": ["group"],
+          "additionalProperties": false
+        },
+        "meta": {
+          "type":"object"
+        },
+        "events": {
+          "type":"object",
+          "properties": {
+            "recordEvents": {"type":"boolean"},
+            "recordTaskMeta": {"type":"boolean"},
+            "recordTaskInVars":{"type":"boolean"},
+            "recordTaskOutVars":{"type":"boolean"},
+            "truncateInVars" :{"type":"boolean"},
+            "truncateOutVars" :{"type":"boolean"},
+            "inVarsBlacklist" :{"type": "array", "items": {"type":"string"}},
+            "metaBlacklist" :{"type": "array", "items": {"type":"string"}},
+            "outVarsBlacklist" :{"type":"array", "items": {"type":"string"}},
+            "truncateMaxStringLength": {"type":"integer"},
+            "truncateMaxArrayLength" :{"type":"integer"},
+            "truncateMaxDepth" :{"type":"integer"},
+            "truncateMeta": {"type":"boolean"}
+          },
+          "additionalProperties": false
+        },
+        "debug": {
+          "type":"boolean"
+        },
+        "out": {
+          "type": "array",
+          "items": {"type":"string"},
+          "minItems":1
+        },
+        "parallelLoopParallelism": {
+          "type":"integer"
+        },
+        "template": {
+          "type":"string"
+        }
+      },
+      "uniqueItems": true,
+      "additionalProperties": false
+    },
+    "flows": {
+      "type":"object",
+      "properties": {
+        "default": {"$ref": "#/$defs/flow"}
+      },
+      "additionalProperties": {"$ref": "#/$defs/flow"}
+    },
+    "imports": {
+      "type":"array",
+      "items": {
+        "type":"object",
+        "properties": {
+          "git": {
+            "type":"object",
+            "properties": {
+              "dest": {"type": "string"},
+              "exclude": {"type": "array", "items": {"type":"string"} },
+              "name":{"type":"string"},
+              "path":{"type":"string"},
+              "secret":{
+                "type":"object",
+                "properties": {
+                  "name":{"type":"string"},
+                  "org":{"type":"string"},
+                  "password":{"type":"string"}
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              },
+              "url":{"type":"string"},
+              "version":{"type":"string"}
+            }
+          },
+          "dir": {
+            "type":"object",
+            "properties": {
+              "dest": {"type":"string"},
+              "src": {"type":"string"}
+            },
+            "required": ["src"],
+            "additionalProperties": false
+          },
+          "mvn": {
+            "type":"object",
+            "properties": {
+              "dest": {"type":"string"},
+              "url": {"type":"string"}
+            },
+            "required": ["url"],
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "profiles": {
+      "type":"object",
+      "additionalProperties": {
+        "type":"object",
+        "properties": {
+          "configuration": {"$ref":"#/properties/configuration"},
+          "flows": {"$ref": "#/properties/flows"},
+          "forms": {"$ref": "#/properties/forms"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "publicFlows":{"type":"array", "items": {"type":"string"}},
+    "resources":{
+      "type":"object",
+      "properties": {
+        "concord": {"type":"array", "items": {"type":"string"}}
+      },
+      "additionalProperties": false
+    },
+    "triggers": {
+      "type":"array",
+      "items": {
+        "type":"object",
+        "properties": {
+          "cron": {
+            "type":"object",
+            "properties": {
+              "activeProfiles": {"type":"array", "items": {"type": "string"}},
+              "arguments": {"type":"object"},
+              "entryPoint": {"type":"string"},
+              "exclusive": {
+                "type":"object",
+                "properties": {
+                  "group": {"type":"string", "minLength":1},
+                  "groupBy": {"type": "string"},
+                  "mode": {"type":"string", "enum": ["cancel", "cancelOld", "wait"]}
+                },
+                "uniqueItems": true,
+                "additionalProperties": false
+              },
+              "runAs": {
+                "type":"object",
+                "properties": {
+                  "withSecret": {"type":"string"}
+                },
+                "additionalProperties": false
+              },
+              "spec":{"type":"string"},
+              "timezone":{"type":"string"}
+            },
+            "required": ["entryPoint","spec"],
+            "additionalProperties": false
+          },
+          "github": {
+            "type":"object",
+            "properties": {
+              "activeProfiles":{"type":"array", "items": {"type":"string"}},
+              "arguments":{"type":"object"},
+              "conditions":{
+                "type":"object",
+                "properties": {
+                  "branch": {"type":"string"},
+                  "files": {
+                    "type":"object",
+                    "properties": {
+                      "added":{"type":["string", "array"], "items": {"type":"string"}},
+                      "any":{"type":["string", "array"], "items": {"type":"string"}},
+                      "modified":{"type":["string", "array"], "items": {"type":"string"}},
+                      "removed":{"type":["string", "array"], "items": {"type":"string"}}
+                    },
+                    "additionalProperties": false
+                  },
+                  "githubHost": {"type":"string"},
+                  "githubOrg": {"type":"string"},
+                  "githubRepo": {"type":"string"},
+                  "payload": {"type": "object"},
+                  "repositoryInfo": {
+                    "type":"array",
+                    "items": {
+                      "type":"object",
+                      "properties": {
+                        "branch": {"type":"string"},
+                        "enabled": {"type":"boolean"},
+                        "projectId": {"type":"string"},
+                        "repository": {"type":"string"},
+                        "repositoryId": {"type":"string"}
+                      },
+                      "uniqueItems": true,
+                      "additionalProperties": false
+                    }
+                  },
+                  "sender": {"type":"string"},
+                  "status": {"type":"string"},
+                  "type": {"type":"string"}
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              },
+              "entryPoint":{"type":"string"},
+              "exclusive": {
+                "type":"object",
+                "properties": {
+                  "group": {"type":"string", "minLength":1},
+                  "groupBy": {"type": "string"},
+                  "mode": {"type":"string", "enum": ["cancel", "cancelOld", "wait"]}
+                },
+                "uniqueItems": true,
+                "additionalProperties": false
+              },
+              "ignoreEmptyPush":{"type":"boolean"},
+              "useEventCommitId":{"type":"boolean"},
+              "useInitiator":{"type":"boolean"},
+              "version":{"type":"integer"}
+            },
+            "required": ["conditions","entryPoint","version"],
+            "additionalProperties": false
+          },
+          "manual": {
+            "type":"object",
+            "properties": {
+              "activeProfiles": {"type":"array", "items": {"type":"string"}},
+              "arguments": {"type": "object"},
+              "entryPoint": {"type":"string"},
+              "name": {"type":"string"}
+            },
+            "additionalProperties": false,
+            "uniqueItems": true,
+            "required": ["entryPoint"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "forms":{
+      "type":"object",
+      "properties": {
+        "myForm": {
+          "type":"array",
+          "items": {
+            "type":"object",
+            "properties": {
+              "myField": {
+                "type":["string","object"],
+                "properties": {
+                  "allow": {"type":["string","boolean","integer","null","number","object","array"]},
+                  "label": {"type":"string"},
+                  "type": {"type":"string", "enum": ["boolean", "date", "dateTime","decimal", "file", "int", "string", "boolean*", "date*", "dateTime*","decimal*", "file*", "int*", "string*", "boolean+", "date+", "dateTime+","decimal+", "file+", "int+", "string+", "boolean?", "date?", "dateTime?","decimal?", "file?", "int?", "string?"]},
+                  "pattern": {"type": "string"},
+                  "readonly": {"type": "boolean"},
+                  "placeholder": {"type": "string"},
+                  "value" :{"type":["string","boolean","integer","null","number","object","array"]}
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": {
+              "type":["object","string"],
+              "properties": {
+                "allow": {"type":["string","boolean","integer","null","number","object","array"]},
+                "label": {"type":"string"},
+                "type": {"type":"string", "enum": ["boolean", "date", "dateTime","decimal", "file", "int", "string", "boolean*", "date*", "dateTime*","decimal*", "file*", "int*", "string*", "boolean+", "date+", "dateTime+","decimal+", "file+", "int+", "string+", "boolean?", "date?", "dateTime?","decimal?", "file?", "int?", "string?"]},
+                "pattern": {"type": "string"},
+                "readonly": {"type": "boolean"},
+                "placeholder": {"type": "string"},
+                "value" :{"type":["string","boolean","integer","null","number","object","array"]}
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "type":"array",
+        "items": {
+          "type":"object",
+          "properties": {
+            "myField": {
+              "type":["object","string"],
+              "properties": {
+                "allow": {"type":["string","boolean","integer","null","number","object","array"]},
+                "label": {"type":"string"},
+                "type": {"type":"string", "enum": ["boolean", "date", "dateTime","decimal", "file", "int", "string", "boolean*", "date*", "dateTime*","decimal*", "file*", "int*", "string*", "boolean+", "date+", "dateTime+","decimal+", "file+", "int+", "string+", "boolean?", "date?", "dateTime?","decimal?", "file?", "int?", "string?"]},
+                "pattern": {"type": "string"},
+                "readonly": {"type": "boolean"},
+                "placeholder": {"type": "string"},
+                "value" :{"type":["string","boolean","integer","null","number","object","array"]}
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": {
+            "type":["object", "string"],
+            "properties": {
+              "allow": {"type":["string","boolean","integer","null","number","object","array"]},
+              "label": {"type":"string"},
+              "type": {"type":"string", "enum": ["boolean", "date", "dateTime","decimal", "file", "int", "string", "boolean*", "date*", "dateTime*","decimal*", "file*", "int*", "string*", "boolean+", "date+", "dateTime+","decimal+", "file+", "int+", "string+", "boolean?", "date?", "dateTime?","decimal?", "file?", "int?", "string?"]},
+              "pattern": {"type": "string"},
+              "readonly": {"type": "boolean"},
+              "placeholder": {"type": "string"},
+              "value" :{"type":["string","boolean","integer","null","number","object","array"]}
+            },
+            "required": ["type"],
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  },
+  "$defs":{
+    "flow": {
+      "type":"array",
+      "items": {"$ref": "#/$defs/flowItem"}
+    },
+    "flowItem": {
+      "type":["object","string"],
+      "pattern": "^return$|^exit$",
+      "properties": {
+        "call" :{"type":"string"},
+        "log": {"type": "string"},
+        "block": {"$ref": "#/$defs/flow"},
+        "checkpoint": {"type": "string"},
+        "expr": {
+          "type": "string",
+          "pattern": "^\\$\\{[^}]*\\}$"
+
+        },
+        "form": {"type": "string"},
+        "if": {
+          "type": "string",
+          "pattern": "^\\$\\{[^}]*\\}$"
+        },
+        "parallel": {"$ref": "#/$defs/flow"},
+        "script": {"type": "string"},
+        "set":{"type":"object"},
+        "suspend": {"type": "string"},
+        "switch": {
+          "type": "string",
+          "pattern": "^\\$\\{[^}]*\\}$"
+        },
+        "task": {"type": "string"},
+        "throw": {"type": "string"},
+        "try": {"$ref":"#/$defs/flow"}
+      },
+      "dependencies": {
+        "switch": {
+          "minProperties":2,
+          "properties": {
+            "switch": {
+              "type": "string",
+              "pattern": "^\\$\\{[^}]*\\}$"
+            }
+          },
+          "additionalProperties": {"$ref":"#/$defs/flow"}
+        },
+        "block": {
+          "properties": {
+            "block": {"$ref": "#/$defs/flow"},
+            "error": {"$ref":"#/$defs/flow"},
+            "loop": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": ["parallel", "serial"]
+                },
+                "items": {
+                  "type": ["string", "array", "object"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                },
+                "parallelism": {
+                  "type": "string",
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                }
+              }
+            },
+            "meta": {
+              "type": "object"
+            },
+            "name": {"type":"string"},
+            "out": {
+              "type": ["string", "array"],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "call": {
+          "properties": {
+            "call" :{"type": "string"},
+            "error": {"$ref": "#/$defs/flow"},
+            "in": {
+              "type": ["string", "object"],
+              "pattern": "^\\$\\{[^}]*\\}$"
+            },
+            "loop": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": ["parallel", "serial"]
+                },
+                "items": {
+                  "type": ["string", "array", "object"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                },
+                "parallelism": {
+                  "type": "string",
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                }
+              },
+              "required": ["items"],
+              "additionalProperties": false
+            },
+            "meta": {"type": "object"},
+            "name": {"type": "string"},
+            "out":{
+              "type": ["array", "string", "object"],
+              "items": {"type": "string"}
+            },
+            "retry": {
+              "type": "object",
+              "properties": {
+                "in": {"type": "object"},
+                "delay": {
+                  "type": ["integer", "string"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                },
+                "times": {
+                  "type": ["integer", "string"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "checkpoint": {
+          "properties": {
+            "checkpoint": {"type": "string"},
+            "meta": {"type": "object"}
+          },
+          "additionalProperties": false
+        },
+        "expr": {
+          "properties": {
+            "expr": {
+              "type": "string",
+              "pattern": "^\\$\\{[^}]*\\}$"
+
+            },
+            "error": {"$ref": "#/$defs/flow"},
+            "meta": {
+              "type": "object"
+            },
+            "name": {"type": "string"},
+            "out": {
+              "type":["object", "string"],
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "form": {
+          "properties": {
+            "form": {"type": "string"},
+            "fields": {
+              "type": ["string","array"],
+              "pattern": "^\\$\\{[^}]*\\}$",
+              "items": {
+                "type":"object",
+                "additionalProperties": {
+                  "type":["object", "string", "boolean", "number"],
+                  "properties": {
+                    "allow": {"type":["string","boolean","integer","null","number","object","array"]},
+                    "label": {"type":"string"},
+                    "type": {"type":"string", "enum": ["boolean", "date", "dateTime","decimal", "file", "int", "string", "boolean*", "date*", "dateTime*","decimal*", "file*", "int*", "string*", "boolean+", "date+", "dateTime+","decimal+", "file+", "int+", "string+", "boolean?", "date?", "dateTime?","decimal?", "file?", "int?", "string?"]},
+                    "pattern": {"type": "string"},
+                    "readonly": {"type": "boolean"},
+                    "placeholder": {"type": "string"},
+                    "value" :{"type":["string","boolean","integer","null","number","object","array"]}
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "runAs": {
+              "type": "object"
+            },
+            "saveSubmittedBy": {
+              "type": "boolean"
+            },
+            "values": {
+              "type": "object"
+            },
+            "yield": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "if": {
+          "properties": {
+            "if": {
+              "type": "string",
+              "pattern": "^\\$\\{[^}]*\\}$"
+            },
+            "else": {"$ref": "#/$defs/flow"},
+            "meta": {"type": "object"},
+            "then": {"$ref": "#/$defs/flow"}
+          },
+          "required": ["then"],
+          "additionalProperties": false
+        },
+        "log": {
+          "properties": {
+            "log": {"type": "string"},
+            "meta": {"type": "object"},
+            "name": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "parallel": {
+          "properties": {
+            "parallel": {"$ref": "#/$defs/flow"},
+            "meta": {"type": "object"},
+            "out":{
+              "type": ["array", "string", "object"],
+              "items": {"type": "string"}
+            }
+          },
+          "additionalProperties": false
+        },
+        "script": {
+          "properties": {
+            "script": {"type": "string"},
+            "body": {"type": "string"},
+            "error": {"$ref": "#/$defs/flow"},
+            "in": {
+              "type":["object", "string"],
+              "pattern": "^\\$\\{[^}]*\\}$"
+            },
+            "loop": {"$ref":"#/$defs/flowItem/dependencies/call/properties/loop"},
+            "meta": {"type": "object"},
+            "name": {"type": "string"},
+            "out": {
+              "type":["object", "string"],
+              "minLength": 1
+            },
+            "retry": {"$ref": "#/$defs/flowItem/dependencies/call/properties/retry"}
+
+          },
+          "additionalProperties": false
+        },
+        "set": {
+          "properties": {
+            "set":{"type":"object"}
+          },
+          "additionalProperties": false
+        },
+        "suspend": {
+          "properties": {
+            "suspend": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+
+        "task": {
+          "properties":{
+            "task": {"type": "string"},
+            "in": {
+              "type":["object", "string"],
+              "pattern": "^\\$\\{[^}]*\\}$"
+            },
+            "out": {
+              "type":["object", "string"],
+              "minLength": 1
+            },
+            "meta": {"type": "object"},
+            "error": {"$ref": "#/$defs/flow"},
+            "ignoreErrors": {"type": "boolean"},
+            "loop": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": ["parallel", "serial"]
+                },
+                "items": {
+                  "type": ["string", "array", "object"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                },
+                "parallelism": {
+                  "type": "string",
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                }
+              },
+              "required": ["items"],
+              "additionalProperties": false
+            },
+            "name": {
+              "type":"string"
+            },
+            "retry": {
+              "type": "object",
+              "properties": {
+                "in": {"type": "object"},
+                "delay": {
+                  "type": ["integer", "string"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                },
+                "times": {
+                  "type": ["integer", "string"],
+                  "pattern":"^\\$\\{[^}]*\\}$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "throw": {
+          "properties":{
+            "throw": {"type": "string"},
+            "name":{"type":"string"}
+          },
+          "additionalProperties": false
+        },
+        "try": {
+          "properties":{
+            "try": {"$ref":"#/$defs/flow"},
+            "error": {"$ref": "#/$defs/flow"},
+            "loop": {"$ref":"#/$defs/flowItem/dependencies/call/properties/loop"},
+            "meta": {"type": "object"},
+            "name":{"type":"string"},
+            "out": {
+              "type": ["string", "array"],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
Publish concord JSON schema (syntax) to Schema store - https://www.schemastore.org/json/

Repo - https://github.com/schemastore/schemastore/

Provides autocompletion and validation features for editors