### PR TITLE
runtime-v2: option to update meta only on termination or suspend

### DIFF
--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/concord.yml
@@ -1,0 +1,44 @@
+configuration:
+  runtime: concord-v2
+  requirements:
+    jvm:
+      extraArgs: # enable debug to capture metadata send log message
+        - "-Dlogback.configurationFile=debug_logback.xml"
+  meta:
+    var: default_value
+    tmpVar: default_value
+  arguments:
+    doSuspend: false # for ensuring meta is updated on SUSPENDED as well as FINISHED
+
+profiles:
+  disableMetaUpdates:
+    configuration:
+      events:
+        updateMetaOnAllEvents: false
+
+flows:
+  default:
+    - call: anotherFlow
+      out: tmpVar
+      loop:
+        items:
+          - a
+          - b
+          - c
+
+    - set:
+        var: "${tmpVar[1]}"
+
+    - if: "${doSuspend}"
+      then:
+        - task: sleep
+          in:
+            suspend: true
+            duration: 1
+
+    - set:
+        var: "${tmpVar[2]}"
+
+  anotherFlow:
+    - set:
+        tmpVar: ${item}

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/debug_logback.xml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/debug_logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="com.walmartlabs.concord.runtime.v2.runner.logging.LogLevelFilter" />
+
+        <encoder class="com.walmartlabs.concord.runtime.v2.runner.logging.ConcordLogEncoder">
+            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.MaskingSensitiveDataLayout">
+                <!-- the UI expects log timestamps in a specific format to be able to convert it to the local time -->
+                <pattern>%date{yyyy-MM-dd'T'HH:mm:ss.SSSZ, UTC} [%-5level] %msg%n%rEx{full, com.sun, sun}</pattern>
+            </layout>
+        </encoder>
+    </appender>
+
+    <logger name="com.walmartlabs.concord.runtime.v2.runner.MetadataProcessor" level="DEBUG"/>
+    <logger name="com.walmartlabs.concord" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/EngineFactory.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/EngineFactory.java
@@ -169,7 +169,7 @@ public class EngineFactory {
                 .build();
 
         ProcessMetadataProcessor metadataProcessor = new ProcessMetadataProcessor(apiClientFactory, metaVariables, eventCfg.isUpdateMetaOnAllEvents());
-        engine.addInterceptor(new ProcessElementInterceptor(eventProcessor,metadataProcessor));
+        engine.addInterceptor(new ProcessElementInterceptor(eventProcessor, metadataProcessor));
 
         return engine;
     }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/EventConfiguration.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/EventConfiguration.java
@@ -122,6 +122,11 @@ public interface EventConfiguration extends Serializable {
         return true;
     }
 
+    @Value.Default
+    default boolean updateMetaOnAllEvents() {
+        return true;
+    }
+
     /**
      * IN variables in the blacklist won't be recorded.
      */

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
@@ -56,6 +56,7 @@ public final class ConfigurationGrammar {
                                     optional("truncateMaxDepth", intVal.map(o::truncateMaxDepth)),
                                     optional("recordTaskOutVars", booleanVal.map(o::recordTaskOutVars)),
                                     optional("truncateOutVars", booleanVal.map(o::truncateOutVars)),
+                                    optional("updateMetaOnAllEvents", booleanVal.map(o::updateMetaOnAllEvents)),
                                     optional("inVarsBlacklist", stringArrayVal.map(o::inVarsBlacklist)),
                                     optional("outVarsBlacklist", stringArrayVal.map(o::outVarsBlacklist)),
                                     optional("recordTaskMeta", booleanVal.map(o::recordTaskMeta)),

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -2044,7 +2044,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
     @Test
     public void test1318() throws Exception {
         String msg =
-                "(018.yml): Error @ line: 26, col: 11. Unknown options: ['trash' [NULL] @ line: 26, col: 11], expected: [inVarsBlacklist, metaBlacklist, outVarsBlacklist, recordEvents, recordTaskInVars, recordTaskMeta, recordTaskOutVars, truncateInVars, truncateMaxArrayLength, truncateMaxDepth, truncateMaxStringLength, truncateMeta, truncateOutVars]. Remove invalid options and/or fix indentation\n" +
+                "(018.yml): Error @ line: 26, col: 11. Unknown options: ['trash' [NULL] @ line: 26, col: 11], expected: [inVarsBlacklist, metaBlacklist, outVarsBlacklist, recordEvents, recordTaskInVars, recordTaskMeta, recordTaskOutVars, truncateInVars, truncateMaxArrayLength, truncateMaxDepth, truncateMaxStringLength, truncateMeta, truncateOutVars, updateMetaOnAllEvents]. Remove invalid options and/or fix indentation\n" +
                         "\twhile processing steps:\n" +
                         "\t'events' @ line: 14, col: 3\n" +
                         "\t\t'configuration' @ line: 1, col: 1";

--- a/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
+++ b/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
@@ -11,6 +11,7 @@ configuration:
     truncateMaxDepth: 10
     recordTaskOutVars: false
     truncateOutVars: true
+    updateMetaOnAllEvents: true
     inVarsBlacklist:
     - "apiKey"
     - "apiToken"


### PR DESCRIPTION
Similar to https://github.com/walmartlabs/concord/pull/938 but for runtime-v2.