### PR TITLE
concord-server: allow non-standard runtimes

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.cli.lint.LintResult.Type;
 import com.walmartlabs.concord.cli.runner.CliImportsListener;
 import com.walmartlabs.concord.imports.NoopImportManager;
 import com.walmartlabs.concord.process.loader.ProjectLoader;
+import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.process.loader.model.SourceMap;
 import picocli.CommandLine.Command;
@@ -65,7 +66,7 @@ public class Lint implements Callable<Integer> {
             throw new IllegalArgumentException("Not a directory: " + targetDir);
         }
 
-        ProjectLoader loader = new ProjectLoader(new NoopImportManager());
+        ProjectLoader loader = new ProjectLoader(ProjectLoaderConfiguration.defaultConfiguration(), new NoopImportManager());
         ProcessDefinition pd = loader.loadProject(targetDir, new DummyImportsNormalizer(), verbose ? new CliImportsListener() : null).projectDefinition();
 
         List<LintResult> lintResults = new ArrayList<>();

--- a/console2/src/api/process/index.ts
+++ b/console2/src/api/process/index.ts
@@ -170,7 +170,7 @@ export enum ProcessKind {
     TIMEOUT_HANDLER = 'TIMEOUT_HANDLER'
 }
 
-export type ProcessRuntime = 'concord-v1' | 'concord-v2';
+export type ProcessRuntime = 'concord-v1' | 'concord-v2' | string;
 
 export interface TriggeredByEntry {
     externalEventId?: string;

--- a/console2/src/components/organisms/ProcessActivity/index.tsx
+++ b/console2/src/components/organisms/ProcessActivity/index.tsx
@@ -251,7 +251,7 @@ const ProcessActivity = (props: ExternalProps) => {
                 </Route>
                 <Route path={`${baseUrl}/log`} exact={true}>
                     {process &&
-                        (process.runtime === 'concord-v1' || process.runtime === undefined) && (
+                        (process.runtime === 'concord-v1') && (
                             <ProcessLogActivity
                                 instanceId={instanceId}
                                 processStatus={process ? process.status : undefined}
@@ -260,7 +260,7 @@ const ProcessActivity = (props: ExternalProps) => {
                                 dataFetchInterval={dataFetchInterval}
                             />
                         )}
-                    {process && process.runtime === 'concord-v2' && (
+                    {process && (process.runtime === 'concord-v2' || process.runtime === undefined) && (
                         <ProcessLogActivityV2
                             instanceId={instanceId}
                             processStatus={process ? process.status : undefined}

--- a/policy-engine/src/test/java/com/walmartlabs/concord/policyengine/DependencyRewritePolicyTest.java
+++ b/policy-engine/src/test/java/com/walmartlabs/concord/policyengine/DependencyRewritePolicyTest.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.policyengine;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;

--- a/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/UnsupportedRuntimeTypeException.java
+++ b/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/UnsupportedRuntimeTypeException.java
@@ -1,0 +1,28 @@
+package com.walmartlabs.concord.process.loader;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public class UnsupportedRuntimeTypeException extends Exception {
+
+    public UnsupportedRuntimeTypeException(String runtime) {
+        super("Unsupported runtime type: " + runtime);
+    }
+}

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -184,7 +184,7 @@ concord-server {
         maxStartFailureAge = "10 minutes"
 
         # list of process state files that must be encrypted before storing
-        secureFiles: ["_main.json"]
+        secureFiles = ["_main.json"]
 
         signingKeyAlgorithm = "RSA"
         signingAlgorithm = "SHA256withRSA"

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -204,6 +204,9 @@ concord-server {
         # if true then the /api/v1/process/{id}/log endpoint performs additional permission checks
         # if false all logs are readable by any authenticated user
         checkLogPermissions = false
+
+        # (optional) list of allowed runtimes (configuration.runtime values)
+        extraRuntimes = []
     }
 
     # process queue configuration

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ProcessConfiguration.java
@@ -87,6 +87,10 @@ public class ProcessConfiguration implements Serializable {
     private boolean checkLogPermissions;
 
     @Inject
+    @Config("process.extraRuntimes")
+    private List<String> extraRuntimes;
+
+    @Inject
     public ProcessConfiguration(@Config("process.signingKeyPath") @Nullable String signingKeyPath) {
         this.signingKeyPath = signingKeyPath != null ? Paths.get(signingKeyPath) : null;
     }
@@ -146,5 +150,9 @@ public class ProcessConfiguration implements Serializable {
 
     public boolean isCheckLogPermissions() {
         return checkLogPermissions;
+    }
+
+    public List<String> getExtraRuntimes() {
+        return extraRuntimes;
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProjectLoaderConfigurationProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProjectLoaderConfigurationProvider.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.server.process;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
+import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.Optional;
+import java.util.Set;
+
+@Named
+public class ProjectLoaderConfigurationProvider implements Provider<ProjectLoaderConfiguration> {
+
+    private final Set<String> extraRuntimes;
+
+    @Inject
+    public ProjectLoaderConfigurationProvider(ProcessConfiguration cfg) {
+        this.extraRuntimes = Optional.ofNullable(cfg.getExtraRuntimes()).map(Set::copyOf).orElse(Set.of());
+    }
+
+    @Override
+    public ProjectLoaderConfiguration get() {
+        return new ProjectLoaderConfiguration(Set.copyOf(extraRuntimes));
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ProcessDefinitionProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ProcessDefinitionProcessor.java
@@ -46,6 +46,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
+import static com.walmartlabs.concord.process.loader.ProjectLoader.CONCORD_V1_RUNTIME_TYPE;
+
 /**
  * Loads the process definition using the working directory and configured {@code imports}.
  */
@@ -125,14 +127,14 @@ public class ProcessDefinitionProcessor implements PayloadProcessor {
     private static String getRuntimeType(Payload payload) throws IOException {
         Map<String, Object> cfg = payload.getHeader(Payload.CONFIGURATION);
         if (cfg != null) {
-            String s = MapUtils.getString(cfg, Constants.Request.RUNTIME_KEY); // TODO constants
+            String s = MapUtils.getString(cfg, Constants.Request.RUNTIME_KEY);
             if (s != null) {
                 return s;
             }
         }
 
         Path workDir = payload.getHeader(Payload.WORKSPACE_DIR);
-        return ProjectLoader.getRuntimeType(workDir, "concord-v1"); // TODO constants or configuration
+        return ProjectLoader.getRuntimeType(workDir, CONCORD_V1_RUNTIME_TYPE);
     }
 
     class ProcessImportsListener implements ImportsListener {


### PR DESCRIPTION
Add `process.extraRuntimes` configuration parameter to concord-server.conf. Only the default v1, v2 and `extraRuntimes` will be allowed as `configuration.runtime` values.

> what's the result if someone misspells the runtime? e.g. runtime: runtime-v@

The process will transition NEW -> FAILED with the exception printed in the "system" log segment.