### PR TITLE
runtime-v1: update bpm library to fix saving variables before suspend

### DIFF
--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -287,6 +287,19 @@ public class ProcessIT {
     }
 
     @Test
+    public void testGetProcessForChildIdAfterSuspendWithoutOut() throws Exception {
+        byte[] archive = archive(ProcessIT.class.getResource("processWithChildSuspendWithoutOut").toURI());
+
+        ConcordProcess proc = concord.processes().start(new Payload().archive(archive));
+
+        // ---
+
+        proc.expectStatus(StatusEnum.FINISHED);
+
+        proc.assertLog(".*Got 1 ids.*");
+    }
+
+    @Test
     public void testKillCascade() throws Exception {
         byte[] archive = archive(ProcessIT.class.getResource("killCascade").toURI());
 

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -261,6 +261,32 @@ public class ProcessIT {
     }
 
     @Test
+    public void testGetProcessForChildIdsAfterSuspend() throws Exception {
+        byte[] archive = archive(ProcessIT.class.getResource("processWithChildrenSuspend").toURI());
+
+        ConcordProcess proc = concord.processes().start(new Payload().archive(archive));
+
+        // ---
+
+        proc.expectStatus(StatusEnum.FINISHED);
+
+        assertEquals(3, proc.getEntry("childrenIds").getChildrenIds().size());
+    }
+
+    @Test
+    public void testGetProcessForChildIdAfterSuspend() throws Exception {
+        byte[] archive = archive(ProcessIT.class.getResource("processWithChildSuspend").toURI());
+
+        ConcordProcess proc = concord.processes().start(new Payload().archive(archive));
+
+        // ---
+
+        proc.expectStatus(StatusEnum.FINISHED);
+
+        proc.assertLog(".*Got 1 ids.*");
+    }
+
+    @Test
     public void testKillCascade() throws Exception {
         byte[] archive = archive(ProcessIT.class.getResource("killCascade").toURI());
 

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/concord.yml
@@ -1,0 +1,20 @@
+flows:
+  default:
+    - task: concord
+      in:
+        action: start
+        payload: myPayload
+        sync: true
+        suspend: true
+        # disable the `onCancel` handler, because it's going to handle
+        # the parent's cancellation only
+        disableOnCancel: true
+        entryPoint: aJob
+        arguments:
+          color: "red"
+
+      # out variable "myJobs" will contain a list of process IDs
+      out:
+        myJobs: ${jobs}
+
+    - log: "Got ${jobs.size()} ids"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/concord.yml
@@ -17,4 +17,4 @@ flows:
       out:
         myJobs: ${jobs}
 
-    - log: "Got ${jobs.size()} ids"
+    - log: "Got ${myJobs.size()} ids"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/myPayload/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspend/myPayload/concord.yml
@@ -1,0 +1,4 @@
+flows:
+  aJob:
+    - log: "FORK (${color}) starting..."
+    - log: "...done!"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspendWithoutOut/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspendWithoutOut/concord.yml
@@ -1,0 +1,16 @@
+flows:
+  default:
+    - task: concord
+      in:
+        action: start
+        payload: myPayload
+        sync: true
+        suspend: true
+        # disable the `onCancel` handler, because it's going to handle
+        # the parent's cancellation only
+        disableOnCancel: true
+        entryPoint: aJob
+        arguments:
+          color: "red"
+
+    - log: "Got ${jobs.size()} ids"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspendWithoutOut/myPayload/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildSuspendWithoutOut/myPayload/concord.yml
@@ -1,0 +1,4 @@
+flows:
+  aJob:
+    - log: "FORK (${color}) starting..."
+    - log: "...done!"

--- a/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildrenSuspend/concord.yml
+++ b/it/runtime-v1/src/test/resources/com/walmartlabs/concord/it/runtime/v1/processWithChildrenSuspend/concord.yml
@@ -1,0 +1,35 @@
+flows:
+  default:
+
+
+  - task: concord
+    in:
+      action: fork
+      tags: forkJoinChild
+      sync: true
+      suspend: true
+      # disable the `onCancel` handler, because it's going to handle
+      # the parent's cancellation only
+      disableOnCancel: true
+      forks:
+      # spawn multiple jobs with different parameters
+      - entryPoint: aJob
+        arguments:
+          color: "red"
+      - entryPoint: aJob
+        arguments:
+          color: "green"
+      - entryPoint: aJob
+        arguments:
+            color: "blue"
+
+
+    # out variable "myJobs" will contain a list of process IDs
+    out:
+      myJobs: ${jobs}
+
+  - log: "Done! Status of the jobs: ${concord.waitForCompletion(myJobs)}"
+
+  aJob:
+  - log: "FORK (${color}) starting..."
+  - log: "...done!"

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -39,7 +39,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <aws.version>1.11.475</aws.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <bpm.version>1.0.2</bpm.version>
+        <bpm.version>1.0.3</bpm.version>
         <bytebuddy.version>1.14.9</bytebuddy.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>


### PR DESCRIPTION
re: https://github.com/concord-workflow/bpm/pull/19