### PR TITLE
oidc: support "from" when logging out

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
@@ -23,6 +23,8 @@ package com.walmartlabs.concord.server.process;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.walmartlabs.concord.imports.ImportManager;
+import com.walmartlabs.concord.process.loader.ProjectLoader;
+import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointResource;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV2Resource;
 import com.walmartlabs.concord.server.process.event.ProcessEventDao;
@@ -73,6 +75,8 @@ public class ProcessModule implements Module {
         binder.bind(ProcessCheckpointManager.class).in(SINGLETON);
         binder.bind(ProcessStateManager.class).in(SINGLETON);
         binder.bind(ProcessWaitManager.class).in(SINGLETON);
+
+        binder.bind(ProjectLoaderConfiguration.class).toProvider(ProjectLoaderConfigurationProvider.class);
 
         bindSingletonScheduledTask(binder, ProcessCleaner.class);
         bindSingletonScheduledTask(binder, ProcessLocksWatchdog.class);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProjectLoaderConfigurationProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProjectLoaderConfigurationProvider.java
@@ -24,12 +24,10 @@ import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfigu
 import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Optional;
 import java.util.Set;
 
-@Named
 public class ProjectLoaderConfigurationProvider implements Provider<ProjectLoaderConfiguration> {
 
     private final Set<String> extraRuntimes;

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcLogoutFilter.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcLogoutFilter.java
@@ -30,6 +30,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 
 public class OidcLogoutFilter implements Filter {
 
@@ -55,7 +56,8 @@ public class OidcLogoutFilter implements Filter {
         JEEContext context = new JEEContext(req, resp, pac4jConfig.getSessionStore());
 
         LogoutLogic<?, JEEContext> logout = pac4jConfig.getLogoutLogic();
-        logout.perform(context, pac4jConfig, pac4jConfig.getHttpActionAdapter(), cfg.getAfterLogoutUrl(), null, true, true, true);
+        String afterLogoutUrl = Optional.ofNullable(req.getParameter("from")).orElse(cfg.getAfterLogoutUrl());
+        logout.perform(context, pac4jConfig, pac4jConfig.getHttpActionAdapter(), afterLogoutUrl, null, true, true, true);
     }
 
     @Override


### PR DESCRIPTION
plus a small fix for a missing binding for ProjectLoaderConfigurationProvider when using concord-server modules without autowiring