### PR TITLE
docker-images: update ansible galaxy community.docker version

### DIFF
--- a/docker-images/ansible/galaxy_requirements.yml
+++ b/docker-images/ansible/galaxy_requirements.yml
@@ -19,7 +19,7 @@ collections:
   - name: community.postgresql
     version: "2.4.1"
   - name: community.docker
-    version: "3.4.6"
+    version: "3.12.1"
   - name: "ansible.netcommon"
     version: "5.1.1"
   - name: "google.cloud"


### PR DESCRIPTION
Newer versions of `requests` python module are [not compatible](https://github.com/ansible-collections/community.docker/issues/868) with the pinned older version of `community.docker`.