### PR TITLE
docker: configure safe.directory for git 2.35+

### DIFF
--- a/docker-images/base/oss/debian/Dockerfile
+++ b/docker-images/base/oss/debian/Dockerfile
@@ -32,7 +32,10 @@ ENV LANG en_US.UTF-8
 RUN virtualenv /usr/local/bin/concord_venv && \
     /usr/local/bin/concord_venv/bin/pip3 --no-cache-dir install dumb-init
 
-RUN groupadd -g 456 concord && useradd --no-log-init -u 456 -g concord -m -s /sbin/nologin concord
+RUN groupadd -g 456 concord && \
+    useradd --no-log-init -u 456 -g concord -m -s /sbin/nologin concord && \
+    echo "[safe]\n\tdirectory = *\n" > ~concord/.gitconfig && \
+    chown concord:concord ~concord/.gitconfig
 
 # Point /bin/sh to bash from dash
 RUN echo "dash dash/sh boolean false" | debconf-set-selections && \


### PR DESCRIPTION
Git 2.35+ introduced `safe.directory` feature, i.e. fail if .git belongs to a user different that the current.
It is an issue for our integration tests where we share .git between the host and the containers.
This change effectively disables the `safe.directory` feature by configuring `safe.directory=*` at user-level in the base Docker image.