### PR TITLE
runtime-v2: add github exclusive trigger to schema

### DIFF
--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/DefaultExclusiveMode.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/DefaultExclusiveMode.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.runtime.v2.model;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2024 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,48 +20,25 @@ package com.walmartlabs.concord.runtime.v2.model;
  * =====
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.io.Serial;
-import java.io.Serializable;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonSerialize(as = ImmutableGithubTriggerExclusiveMode.class)
-@JsonDeserialize(as = ImmutableGithubTriggerExclusiveMode.class)
-public interface GithubTriggerExclusiveMode extends ExclusiveMode, Serializable {
+@JsonSerialize(as = ImmutableDefaultExclusiveMode.class)
+@JsonDeserialize(as = ImmutableDefaultExclusiveMode.class)
+public interface DefaultExclusiveMode extends ExclusiveMode {
 
     @Serial
     long serialVersionUID = 1L;
 
-    @Nullable
-    @Value.Parameter
-    @JsonProperty(value = "group")
-    String group();
-
-    // Unused, just for backward compatibility
-    @Nullable
-    @JsonIgnore
-    GroupBy groupBy();
-    enum GroupBy {
-        branch
+    static ExclusiveMode of(String group, Mode mode) {
+        return ImmutableDefaultExclusiveMode.of(group, mode);
     }
 
-    @Value.Parameter
-    @JsonProperty(value = "groupBy")
-    @Nullable
-    String groupByProperty();
-
-    @Value.Parameter
-    @Value.Default
-    default ExclusiveMode.Mode mode() {
-        return ExclusiveMode.Mode.wait;
-    }
 }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ExclusiveMode.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/ExclusiveMode.java
@@ -20,22 +20,12 @@ package com.walmartlabs.concord.runtime.v2.model;
  * =====
  */
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 import java.io.Serializable;
 
-@Value.Immutable
-@Value.Style(jdkOnly = true)
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonSerialize(as = ImmutableExclusiveMode.class)
-@JsonDeserialize(as = ImmutableExclusiveMode.class)
 public interface ExclusiveMode extends Serializable {
-
-    long serialVersionUID = 1L;
 
     @Value.Parameter
     @JsonProperty(value = "group", required = true)
@@ -64,7 +54,4 @@ public interface ExclusiveMode extends Serializable {
         wait
     }
 
-    static ExclusiveMode of(String group, Mode mode) {
-        return ImmutableExclusiveMode.of(group, mode);
-    }
 }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ConfigurationGrammar.java
@@ -35,11 +35,11 @@ public final class ConfigurationGrammar {
 
     private static final Parser<Atom, ExclusiveMode> exclusive =
             betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
-                    with(ImmutableExclusiveMode::builder,
+                    with(ImmutableDefaultExclusiveMode::builder,
                             o -> options(
                                     mandatory("group", stringNotEmptyVal.map(o::group)),
                                     optional("mode", enumVal(ExclusiveMode.Mode.class).map(o::mode))))
-                            .map(ImmutableExclusiveMode.Builder::build));
+                            .map(ImmutableDefaultExclusiveMode.Builder::build));
 
     public static final Parser<Atom, ExclusiveMode> exclusiveVal =
             orError(exclusive, YamlValueType.EXCLUSIVE_MODE);

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/schema/TriggerMixIn.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/schema/TriggerMixIn.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
 import com.walmartlabs.concord.runtime.v2.model.ExclusiveMode;
+import com.walmartlabs.concord.runtime.v2.model.GithubTriggerExclusiveMode;
 import com.walmartlabs.concord.runtime.v2.model.Trigger;
 
 import java.util.List;
@@ -111,7 +112,7 @@ public interface TriggerMixIn extends Trigger {
             GithubTriggerConditions conditions();
 
             @JsonProperty("exclusive")
-            ExclusiveMode exclusive();
+            GithubTriggerExclusiveMode exclusive();
 
             interface GithubTriggerConditions {
                 @JsonProperty(value = "type", required = true)

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -351,7 +351,7 @@ public class YamlOkParserTest extends AbstractParserTest {
         assertEquals(Collections.singletonMap("k", "v"), cfg.arguments());
         assertEquals(Collections.singletonMap("k", "v1"), cfg.requirements());
         assertEquals(Duration.parse("PT1H"), cfg.processTimeout());
-        assertEquals(ExclusiveMode.of("X", ExclusiveMode.Mode.cancel), cfg.exclusive());
+        assertEquals(DefaultExclusiveMode.of("X", ExclusiveMode.Mode.cancel), cfg.exclusive());
         assertEquals(EventConfiguration.builder()
                 .recordTaskInVars(true)
                 .inVarsBlacklist(Collections.singletonList("pass"))

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/PayloadUtils.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.server.process;
 
 import com.walmartlabs.concord.common.DateTimeUtils;
 import com.walmartlabs.concord.repository.Snapshot;
+import com.walmartlabs.concord.runtime.v2.model.DefaultExclusiveMode;
 import com.walmartlabs.concord.runtime.v2.model.ExclusiveMode;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
@@ -44,7 +45,7 @@ public final class PayloadUtils {
             throw new ProcessException(p.getProcessKey(), "Invalid exclusive mode: exclusive group not specified or empty");
         }
         ExclusiveMode.Mode mode = MapUtils.getEnum(exclusive, "mode", ExclusiveMode.Mode.class, ExclusiveMode.Mode.cancel);
-        return ExclusiveMode.of(group, mode);
+        return DefaultExclusiveMode.of(group, mode);
     }
 
     @SuppressWarnings("unchecked")
@@ -65,10 +66,10 @@ public final class PayloadUtils {
             return null;
         }
 
-        if (v instanceof String) {
+        if (v instanceof String iso) {
             OffsetDateTime t;
             try {
-                t = DateTimeUtils.fromIsoString((String) v);
+                t = DateTimeUtils.fromIsoString(iso);
             } catch (DateTimeParseException e) {
                 throw new ProcessException(p.getProcessKey(), "Invalid '" + k + "' format, expected an ISO-8601 value, got: " + v);
             }


### PR DESCRIPTION
`groupBy` currently isn't represented in the [runtime-v2 json schema](https://repo1.maven.org/maven2/com/walmartlabs/concord/runtime/v2/concord-runtime-model-v2/2.14.0/concord-runtime-model-v2-2.14.0-schema.json). 