### PR TITLE
oidc: improve error handling

### DIFF
--- a/console2/src/components/pages/UnauthorizedPage/index.tsx
+++ b/console2/src/components/pages/UnauthorizedPage/index.tsx
@@ -23,17 +23,11 @@ import * as React from 'react';
 import { RedirectButton } from '../../organisms';
 
 import './styles.css';
-import { Card, CardContent, CardHeader, Divider, Image } from 'semantic-ui-react';
-import { useContext, useEffect } from 'react';
-import { UserSessionContext } from '../../../session';
+import {Card, CardContent, CardDescription, CardHeader, Divider, Image} from 'semantic-ui-react';
+import {withRouter} from "react-router";
 
-export default () => {
-    const session = useContext(UserSessionContext);
-
-    useEffect(() => {
-        session.setUserInfo(undefined);
-    }, [session]);
-
+export default withRouter((props) => {
+    const error = new URLSearchParams(props.location.search).get('error');
     return (
         <div className="flexbox-container">
             <Card centered={true}>
@@ -41,6 +35,8 @@ export default () => {
                     <Image id="concord-logo" src="/images/concord.svg" size="medium" />
 
                     <CardHeader>You are not authorized.</CardHeader>
+
+                    {error && <CardDescription>Error: {error}</CardDescription>}
 
                     <Divider />
 
@@ -51,4 +47,4 @@ export default () => {
             </Card>
         </div>
     );
-};
+});

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -589,6 +589,7 @@ concord-server {
         urlBase = "http://concord.example.com"
         afterLoginUrl = "http://concord.example.com"
         afterLogoutUrl = "http://concord.example.com/#/logout/done"
+        onErrorUrl = "http://concord.example.com/#/unauthorized"
 
         scopes = [ "openid", "profile", "email", "groups"]
 

--- a/server/plugins/oidc/README.md
+++ b/server/plugins/oidc/README.md
@@ -23,6 +23,23 @@ concord-server {
 }
 ```
 
+For running in development mode (i.e. on `localhost`), callback URLs must be
+in the form of
+
+```
+http://localhost:8001/api/service/oidc/callback?client_name=oidc
+```
+
+Note the `client_name=oidc` query parameter, it is required by the plugin and
+must be present in the provider's configuration.
+
+The plugin uses the following scopes: `openid`, `profile`, `email`, `groups`.
+Which may or may not be enabled by default in the provider's configuration.
+
+Okta, for example, does not provide the `groups` scope by default. You can
+add it in the "Security" -> "API" -> "Authorization Servers" -> your_server ->
+"Scope" section.
+
 ### Interactive Login
 
 Configure the Concord Console to use custom logout/login URLs:

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcCallbackFilter.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcCallbackFilter.java
@@ -72,6 +72,16 @@ public class OidcCallbackFilter implements Filter {
             postLoginUrl = cfg.getAfterLoginUrl();
         }
 
+        String error = req.getParameter("error");
+        if (error != null) {
+            String derivedError = "unknown";
+            if ("access_denied".equals(error)) {
+                derivedError = "oidc_access_denied";
+            }
+            resp.sendRedirect(resp.encodeRedirectURL(cfg.getOnErrorUrl() + "?from=" + postLoginUrl + "&error=" + derivedError));
+            return;
+        }
+
         try {
             CallbackLogic<?, JEEContext> callback = pac4jConfig.getCallbackLogic();
             callback.perform(context, pac4jConfig, pac4jConfig.getHttpActionAdapter(), postLoginUrl, true, false, true, OidcPluginModule.CLIENT_NAME);

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
@@ -59,6 +59,10 @@ public class PluginConfiguration {
     private String afterLogoutUrl;
 
     @Inject
+    @Config("oidc.onErrorUrl")
+    private String onErrorUrl;
+
+    @Inject
     @Nullable
     @Config("oidc.scopes")
     private List<String> scopes;
@@ -100,6 +104,10 @@ public class PluginConfiguration {
 
     public String getAfterLogoutUrl() {
         return afterLogoutUrl;
+    }
+
+    public String getOnErrorUrl() {
+        return onErrorUrl;
     }
 
     public List<String> getScopes() {


### PR DESCRIPTION
Handle `error` responses in OIDC callback code. Redirect to the unauthorized page and show the error:
![unauthorized](https://github.com/user-attachments/assets/2a033e93-8a91-46c0-af4e-52f486b1f7a8)
