### PR TITLE
server: fix updateWaitConditions when wait condition without processes

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -1028,6 +1028,9 @@ public class ProcessResource implements Resource {
     public Response setWaitCondition(@PathParam("id") UUID instanceId, Map<String, Object> waitCondition) {
         ProcessKey processKey = assertProcessKey(instanceId);
         AbstractWaitCondition condition = objectMapper.convertValue(waitCondition, AbstractWaitCondition.class);
+        if (condition == null) {
+            throw new ConcordApplicationException("Wait condition is required", Status.BAD_REQUEST);
+        }
         processWaitManager.addWait(processKey, condition);
         return Response.ok().build();
     }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java
@@ -158,7 +158,10 @@ public class ProcessWaitWatchdog implements ScheduledTask {
 
             try {
                 boolean updated = processWaitManager.txResult(tx -> {
-                    boolean isWaiting = !resultWaits.isEmpty() && resumeEvents.isEmpty();
+                    // TODO: better way
+                    // Right now, we have only one result action, and it moves the process to enqueued status. 
+                    // If the process moves to enqueued, it means it's no longer waiting for anything, so isWaiting should be false
+                    boolean isWaiting = !resultWaits.isEmpty() && resumeEvents.isEmpty() && resultActions.isEmpty();
                     boolean up = processWaitManager.setWait(tx, p.processKey(), resultWaits, isWaiting, p.version());
                     if (up) {
                         resultActions.forEach(a -> a.execute(tx));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitConditionUpdater.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/WaitConditionUpdater.java
@@ -48,9 +48,9 @@ public class WaitConditionUpdater implements ProcessStatusListener {
             SET wait_conditions =
                     (SELECT jsonb_agg(
                         CASE
-                            WHEN obj->>'type' = 'PROCESS_COMPLETION' and obj->>'completeCondition' = 'ALL'
+                            WHEN obj->>'type' = 'PROCESS_COMPLETION' and obj->>'completeCondition' = 'ALL' and obj->>'processes' is not null
                                 THEN jsonb_set(obj, '{processes}', (obj->'processes') - ?)
-                            WHEN obj->>'type' = 'PROCESS_COMPLETION' and obj->>'completeCondition' = 'ONE_OF' and obj->'processes' ?? ?
+                            WHEN obj->>'type' = 'PROCESS_COMPLETION' and obj->>'completeCondition' = 'ONE_OF' and obj->>'processes' is not null and obj->'processes' ?? ?
                                 THEN jsonb_set(obj, '{processes}', '[]')
                             ELSE obj
                         END


### PR DESCRIPTION
[ConcurrentProcessFilter](https://github.com/walmartlabs/concord/blob/brig-patch-1/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/dispatcher/ConcurrentProcessFilter.java#L43) adds an `exclusive` wait condition to the process, 
transitions the process from `ENQUEUED -> WAITING`, and marks it with `PROCESS_WAIT_CONDITIONS.IS_WAITING=true`.

[ProcessWaitWatchdog](https://github.com/walmartlabs/concord/blob/brig-patch-1/server/impl/src/main/java/com/walmartlabs/concord/server/process/waits/ProcessWaitWatchdog.java#L221) processes the `exclusive` wait condition first, transitions the process from `WAITING -> ENQUEUED`, 
and marks it with `PROCESS_WAIT_CONDITIONS.IS_WAITING=false`.

This is a symmetric action. As a result, the process will return to the state it was in.

If the process has `PROCESS_WAIT_CONDITIONS.IS_WAITING=true` and does not have an exclusive wait condition, 
for example, if the process is waiting for a child to finish, 
then the process will be in the `SUSPENDED` state. 
When the wait condition is met, the process will be resumed and transition from `SUSPENDED -> RESUMING -> ENQUEUED`
with `PROCESS_WAIT_CONDITIONS.IS_WAITING=false`