### PR TITLE
runtime-v2: flush events on process error

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultEventReportingService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultEventReportingService.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import com.walmartlabs.concord.client2.ProcessEventRequest;
 import com.walmartlabs.concord.client2.ProcessEventsApi;
 import com.walmartlabs.concord.runtime.common.injector.InstanceId;
 import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
+import com.walmartlabs.concord.svm.ExecutionListener;
 import com.walmartlabs.concord.svm.Frame;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.State;
@@ -42,7 +43,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class DefaultEventReportingService implements EventReportingService {
+public class DefaultEventReportingService implements EventReportingService, ExecutionListener {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultEventReportingService.class);
 
@@ -96,6 +97,12 @@ public class DefaultEventReportingService implements EventReportingService {
 
     @Override
     public void afterProcessEnds(Runtime runtime, State state, Frame lastFrame) {
+        flushScheduler.shutdown();
+        flush();
+    }
+
+    @Override
+    public void onProcessError(Runtime runtime, State state, Exception e) {
         flushScheduler.shutdown();
         flush();
     }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/EventReportingService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/EventReportingService.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,11 +23,10 @@ package com.walmartlabs.concord.runtime.v2.runner;
 import com.walmartlabs.concord.client2.ProcessEventRequest;
 import com.walmartlabs.concord.svm.ExecutionListener;
 
-public interface EventReportingService extends ExecutionListener {
+public interface EventReportingService {
 
     /**
      * Report a process event to the server.
      */
     void report(ProcessEventRequest req);
-
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
@@ -73,7 +73,7 @@ public class DefaultRunnerModule extends AbstractModule {
 
         Multibinder<ExecutionListener> executionListeners = Multibinder.newSetBinder(binder(), ExecutionListener.class);
         executionListeners.addBinding().to(EventRecordingExecutionListener.class);
-        executionListeners.addBinding().to(EventReportingService.class);
+        executionListeners.addBinding().to(DefaultEventReportingService.class);
         executionListeners.addBinding().to(MetadataProcessor.class);
         executionListeners.addBinding().to(OutVariablesProcessor.class);
         executionListeners.addBinding().to(SensitiveDataPersistenceService.class);


### PR DESCRIPTION
and `EventReportingService` does not implement the `ExecutionListener` interface, as it's not supposed to :)