### PR TITLE
cli: code coverage info

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -128,6 +128,9 @@ public class Run implements Callable<Integer> {
     @Parameters(arity = "0..1", description = "Directory with Concord files or a path to a single Concord YAML file.")
     Path sourceDir = Paths.get(System.getProperty("user.dir"));
 
+    @Option(names = {"--with-code-coverage"}, description = "Generate code coverage for process")
+    boolean withCodeCoverage = false;
+
     @Override
     public Integer call() throws Exception {
         Verbosity verbosity = new Verbosity(this.verbosity);
@@ -231,6 +234,7 @@ public class Run implements Callable<Integer> {
                     .configuration(ProcessDefinitionConfiguration.builder().from(processDefinition.configuration())
                             .arguments(args)
                             .dependencies(overlayDeps)
+                            .events(EventConfiguration.builder().from(processDefinition.configuration().events()).recordEvents(withCodeCoverage).build())
                             .build())
                     .flows(flows)
                     .imports(Imports.builder().build())
@@ -253,7 +257,8 @@ public class Run implements Callable<Integer> {
                 runnerCfg,
                 () -> cfg,
                 new ProcessDependenciesModule(targetDir, runnerCfg.dependencies(), cfg.debug()),
-                new CliServicesModule(secretStoreDir, targetDir, defaultTaskVars, new VaultProvider(vaultDir, vaultId), dependencyManager, verbosity))
+                new CliServicesModule(secretStoreDir, targetDir, defaultTaskVars, new VaultProvider(vaultDir, vaultId), dependencyManager, verbosity),
+                new CodeCoverageModule(withCodeCoverage))
                 .create();
 
         // Just to notify listeners

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliProcessEventsWriter.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliProcessEventsWriter.java
@@ -1,0 +1,135 @@
+package com.walmartlabs.concord.cli.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.client2.ProcessEventEntry;
+import com.walmartlabs.concord.client2.ProcessEventRequest;
+import com.walmartlabs.concord.runtime.common.injector.InstanceId;
+import com.walmartlabs.concord.runtime.v2.runner.ProcessEventWriter;
+import com.walmartlabs.concord.runtime.v2.sdk.WorkingDirectory;
+import com.walmartlabs.concord.svm.ExecutionListener;
+import com.walmartlabs.concord.svm.Frame;
+import com.walmartlabs.concord.svm.Runtime;
+import com.walmartlabs.concord.svm.State;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+public class CliProcessEventsWriter implements ProcessEventWriter, ExecutionListener {
+
+    private static final TypeReference<List<ProcessEventEntry>> EVENTS_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+    private final Path outputFile;
+    private volatile boolean isFirstEvent = true;
+
+    @Inject
+    public CliProcessEventsWriter(ObjectMapper objectMapper, InstanceId instanceId, WorkingDirectory workingDirectory) {
+        this.objectMapper = objectMapper;
+        this.outputFile = workingDirectory.getValue()
+                .resolve("events")
+                .resolve(instanceId.getValue() + ".events.json");
+
+        try {
+            Files.createDirectories(outputFile.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException("Can't create events directory", e);
+        }
+    }
+
+    public List<ProcessEventEntry> events() {
+        try {
+            return objectMapper.readValue(outputFile.toFile(), EVENTS_TYPE);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Can't read events from '%s'", outputFile), e);
+        }
+    }
+
+    @Override
+    public void write(ProcessEventRequest event) {
+        writeEvent(event);
+    }
+
+    @Override
+    public void write(List<ProcessEventRequest> events) {
+        events.forEach(this::write);
+    }
+
+    @Override
+    public void beforeProcessStart(Runtime runtime, State state) {
+        writeArrayStartIfNeeded(outputFile);
+    }
+
+    @Override
+    public void beforeProcessResume(Runtime runtime, State state) {
+        writeArrayStartIfNeeded(outputFile);
+    }
+
+    @Override
+    public void afterProcessEnds(Runtime runtime, State state, Frame lastFrame) {
+        writeArrayEnd(outputFile);
+    }
+
+    @Override
+    public void onProcessError(Runtime runtime, State state, Exception e) {
+        writeArrayEnd(outputFile);
+    }
+
+    private synchronized void writeEvent(ProcessEventRequest event) {
+        try (var out = Files.newOutputStream(outputFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+            if (!isFirstEvent) {
+                out.write(",".getBytes(StandardCharsets.UTF_8));
+            }
+
+            objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValue(out, event);
+
+            isFirstEvent = false;
+        } catch (IOException e) {
+            throw new RuntimeException("Error writing event", e);
+        }
+    }
+
+    private static void writeArrayEnd(Path outputFile) {
+        try (var out = Files.newOutputStream(outputFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+            out.write("]".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Error writing to events file '%s", outputFile), e);
+        }
+    }
+
+    private static void writeArrayStartIfNeeded(Path outputFile) {
+        try (var out = Files.newOutputStream(outputFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+            if (Files.size(outputFile) == 0) {
+                out.write("[".getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Error writing to events file '%s'", outputFile), e);
+        }
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CodeCoverageModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CodeCoverageModule.java
@@ -1,0 +1,61 @@
+package com.walmartlabs.concord.cli.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.walmartlabs.concord.cli.runner.codecoverage.CodeCoverage;
+import com.walmartlabs.concord.runtime.v2.runner.DefaultEventReportingService;
+import com.walmartlabs.concord.runtime.v2.runner.EventReportingService;
+import com.walmartlabs.concord.runtime.v2.runner.ProcessEventWriter;
+import com.walmartlabs.concord.runtime.v2.runner.remote.EventRecordingExecutionListener;
+import com.walmartlabs.concord.runtime.v2.runner.remote.TaskCallEventRecordingListener;
+import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallListener;
+import com.walmartlabs.concord.svm.ExecutionListener;
+
+import javax.inject.Singleton;
+
+public class CodeCoverageModule extends AbstractModule {
+
+    private final boolean enabled;
+
+    public CodeCoverageModule(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    protected void configure() {
+        if (!enabled) {
+            return;
+        }
+
+        bind(ProcessEventWriter.class).to(CliProcessEventsWriter.class).in(Singleton.class);
+        bind(EventReportingService.class).to(DefaultEventReportingService.class).in(Singleton.class);
+
+        Multibinder<ExecutionListener> executionListeners = Multibinder.newSetBinder(binder(), ExecutionListener.class);
+        executionListeners.addBinding().to(EventRecordingExecutionListener.class);
+        executionListeners.addBinding().to(CliProcessEventsWriter.class);
+        executionListeners.addBinding().to(CodeCoverage.class);
+
+        Multibinder<TaskCallListener> taskCallListeners = Multibinder.newSetBinder(binder(), TaskCallListener.class);
+        taskCallListeners.addBinding().to(TaskCallEventRecordingListener.class);
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/CodeCoverage.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/CodeCoverage.java
@@ -1,0 +1,79 @@
+package com.walmartlabs.concord.cli.runner.codecoverage;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.cli.runner.CliProcessEventsWriter;
+import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
+import com.walmartlabs.concord.runtime.v2.sdk.WorkingDirectory;
+import com.walmartlabs.concord.svm.ExecutionListener;
+import com.walmartlabs.concord.svm.Frame;
+import com.walmartlabs.concord.svm.Runtime;
+import com.walmartlabs.concord.svm.State;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+
+public class CodeCoverage implements ExecutionListener {
+
+    private final LcovReportProducer reportProducer;
+    private final Path workingDirectory;
+
+    @Inject
+    public CodeCoverage(WorkingDirectory workingDirectory) {
+        this.reportProducer = new LcovReportProducer();
+        this.workingDirectory = workingDirectory.getValue();
+    }
+
+    @Override
+    public void beforeProcessStart(Runtime runtime, State state) {
+        ProcessDefinition processDefinition = runtime.getService(ProcessDefinition.class);
+        reportProducer.init(processDefinition);
+    }
+
+    @Override
+    public void onProcessError(Runtime runtime, State state, Exception e) {
+        generateReport(runtime);
+    }
+
+    @Override
+    public void afterProcessEnds(Runtime runtime, State state, Frame lastFrame) {
+        generateReport(runtime);
+    }
+
+    private void generateReport(Runtime runtime) {
+        System.out.println("===");
+        System.out.println("Generating code coverage info...");
+
+        CliProcessEventsWriter eventsHolder = runtime.getService(CliProcessEventsWriter.class);
+
+        reportProducer.onEvents(eventsHolder.events());
+
+        try {
+            Path coverageInfo = reportProducer.produce(workingDirectory);
+            System.out.println("Coverage info file: " + coverageInfo);
+            System.out.println("To generate HTML report with lcov use:");
+            System.out.println("\tcd " + workingDirectory + " && genhtml coverage.info --output-directory out");
+            System.out.println("===");
+        } catch (Exception e) {
+            throw new RuntimeException("Can't generate code coverage report", e);
+        }
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/LcovReportProducer.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/LcovReportProducer.java
@@ -1,0 +1,224 @@
+package com.walmartlabs.concord.cli.runner.codecoverage;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.client2.ProcessEventEntry;
+import com.walmartlabs.concord.runtime.v2.model.Flow;
+import com.walmartlabs.concord.runtime.v2.model.ProcessDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LcovReportProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(LcovReportProducer.class);
+
+    private final Map<String, Stats> statsPerFile = new HashMap<>();
+
+    public void init(ProcessDefinition processDefinition) {
+        for (Map.Entry<String, Flow> fd : processDefinition.flows().entrySet()) {
+            String fileName = fd.getValue().location().fileName();
+
+            Stats stats = statsPerFile.computeIfAbsent(fileName, k -> new Stats());
+            stats.init(fd.getKey(), fd.getValue().location().lineNum());
+        }
+    }
+
+    public void onEvents(List<ProcessEventEntry> events) {
+        for (ProcessEventEntry event : events) {
+            if ("post".equals(ProcessEventData.phase(event))) {
+                continue;
+            }
+
+            String fileName = ProcessEventData.fileName(event);
+            Integer lineNum = ProcessEventData.line(event);
+            if (lineNum == null) {
+                continue;
+            }
+
+            Stats stats = statsPerFile.get(fileName);
+            if (stats == null) {
+                log.warn("Can't find definitions for {}. This is most likely a bug.", fileName);
+                continue;
+            }
+
+            stats.onLineExecuted(lineNum);
+
+            String flowCallName = ProcessEventData.flowCallName(event);
+            if (flowCallName != null) {
+                Stats statsForFlow = findStatsForFlow(flowCallName);
+                if (statsForFlow != null) {
+                    statsForFlow.onFlowCall(flowCallName);
+                }
+            }
+
+            String processDefinitionId = ProcessEventData.processDefinitionId(event);
+            if (processDefinitionId != null) {
+                // as we do not have call step for entry point
+                Stats statsForFlow = findStatsForFlow(processDefinitionId);
+                if (statsForFlow != null) {
+                    statsForFlow.markCalled(processDefinitionId);
+                }
+            }
+        }
+    }
+
+    public Path produce(Path baseDir) throws IOException {
+        Path reportName = baseDir.resolve("coverage.info");
+
+        try (BufferedWriter writer = Files.newBufferedWriter(reportName, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            for (Map.Entry<String, Stats> statsEntry : statsPerFile.entrySet()) {
+                // TN (Test Name):
+                // Optional. Can be left empty or used to specify the name of the test.
+                writer.write("TN:");
+                writer.newLine();
+
+                // SF (Source File Path):
+                // Specifies the path to the source file for which the coverage data is provided.
+                writer.write("SF:" + statsEntry.getKey());
+                writer.newLine();
+
+                Stats stats = statsEntry.getValue();
+                for (Map.Entry<String, Integer> flowEntry : stats.flowLocationByName.entrySet()) {
+                    // FN (Function):
+                    // The start line and name of the function in the source file.
+                    writer.write(String.format("FN:%d,%s", flowEntry.getValue(), flowEntry.getKey()));
+                    writer.newLine();
+                }
+
+                for (Map.Entry<String, Integer> execEntry : stats.flowExecCountByName.entrySet()) {
+                    // FNDA (Function Data):
+                    // The number of times the function was executed, followed by the function name.
+                    writer.write(String.format("FNDA:%d,%s", execEntry.getValue(), execEntry.getKey()));
+                    writer.newLine();
+                }
+
+                // Function summary
+                // FNF (Functions Found):
+                // The number of functions found in the file.
+                writer.write("FNF:" + stats.flowLocationByName.size());
+                writer.newLine();
+
+                // FNH (Functions Hit):
+                // The number of functions that were executed at least once.
+                writer.write("FNH:" + stats.flowExecCountByName.size());
+                writer.newLine();
+
+                // Line coverage data
+                // DA (Data Array):
+                // Line number and the execution count for that line.
+                for (Map.Entry<Integer, Integer> e : stats.stepExecCountByLineNumber.entrySet()) {
+                    writer.write(String.format("DA:%d,%d", e.getKey(), e.getValue()));
+                    writer.newLine();
+                }
+
+                // Branch coverage data
+                // BRDA (Branch Data Array):
+                // Line number, block number, branch number, and the execution count for branches.
+                //
+                // Branch summary
+                // BRF (Branches Found):
+                // The total number of branches found.
+                //
+                // BRH (Branches Hit):
+                // The number of branches that were taken.
+
+                // line summary
+                // LF (Lines Found):
+                // The total number of lines found in the source file.
+                writer.write("LF:7");
+                writer.newLine();
+                // LH (Lines Hit):
+                // The number of lines that were executed at least once.
+                writer.write("LH:6");
+                writer.newLine();
+
+                // End of record
+                writer.write("end_of_record");
+                writer.newLine();
+            }
+        }
+
+        return reportName;
+    }
+
+    private Stats findStatsForFlow(String flow) {
+        for (Map.Entry<String, Stats> stats : statsPerFile.entrySet()) {
+            if (stats.getValue().containsFlow(flow)) {
+                return stats.getValue();
+            }
+        }
+        log.warn("Can't find stats for {} flow. This is most likely a bug.", flow);
+        return null;
+    }
+
+    private static class Stats {
+
+        private final Map<String, Integer> flowLocationByName = new HashMap<>();
+
+        private final Map<String, Integer> flowExecCountByName = new HashMap<>();
+
+        private final Map<Integer, Integer> stepExecCountByLineNumber = new HashMap<>();
+
+        public void init(String flowName, int location) {
+            flowLocationByName.put(flowName, location);
+            stepExecCountByLineNumber.put(location, 0);
+        }
+
+        public void onLineExecuted(int lineNum) {
+            stepExecCountByLineNumber.compute(lineNum, (k, v) -> v == null ? 1 : v + 1);
+        }
+
+        public void onFlowCall(String flow) {
+            assertContainsFlow(flow);
+
+            flowExecCountByName.compute(flow, (k, v) -> v == null ? 1 : v + 1);
+            onLineExecuted(flowLocationByName.get(flow));
+        }
+
+        public void markCalled(String flow) {
+            assertContainsFlow(flow);
+
+            Integer prev = flowExecCountByName.putIfAbsent(flow, 1);
+            if (prev == null) {
+                onLineExecuted(flowLocationByName.get(flow));
+            }
+        }
+
+        public boolean containsFlow(String flow) {
+            return flowLocationByName.containsKey(flow);
+        }
+
+        private void assertContainsFlow(String flow) {
+            if (!flowLocationByName.containsKey(flow)) {
+                throw new IllegalArgumentException("Trying update stats for flow without flow definition " + flow);
+            }
+        }
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/ProcessEventData.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/codecoverage/ProcessEventData.java
@@ -1,0 +1,62 @@
+package com.walmartlabs.concord.cli.runner.codecoverage;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.client2.ProcessEventEntry;
+import com.walmartlabs.concord.sdk.MapUtils;
+
+public final class ProcessEventData {
+
+    public static String phase(ProcessEventEntry entry) {
+        return MapUtils.getString(entry.getData(), "phase");
+    }
+
+    public static String fileName(ProcessEventEntry event) {
+        return MapUtils.getString(event.getData(), "fileName");
+    }
+
+    public static Integer line(ProcessEventEntry event) {
+        Number lineNum = MapUtils.get(event.getData(), "line", null, Number.class);
+        if (lineNum == null) {
+            return null;
+        }
+        return lineNum.intValue();
+    }
+
+    public static String flowCallName(ProcessEventEntry event) {
+        String description = MapUtils.getString(event.getData(), "description");
+        if (description == null) {
+            return null;
+        }
+        if (description.startsWith("Flow call: ")) {
+            return description.substring("Flow call: ".length());
+        }
+
+        return null;
+    }
+
+    public static String processDefinitionId(ProcessEventEntry event) {
+        return MapUtils.getString(event.getData(), "processDefinitionId");
+    }
+
+    private ProcessEventData() {
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultProcessEventWriter.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultProcessEventWriter.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.runtime.v2.runner;
+
+import com.walmartlabs.concord.client2.ApiClient;
+import com.walmartlabs.concord.client2.ApiException;
+import com.walmartlabs.concord.client2.ProcessEventRequest;
+import com.walmartlabs.concord.client2.ProcessEventsApi;
+import com.walmartlabs.concord.runtime.common.injector.InstanceId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class DefaultProcessEventWriter implements ProcessEventWriter {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultProcessEventWriter.class);
+
+    private final ProcessEventsApi processEventsApi;
+
+    private final InstanceId instanceId;
+
+    @Inject
+    public DefaultProcessEventWriter(InstanceId instanceId, ApiClient apiClient) {
+        this.instanceId = instanceId;
+        this.processEventsApi = new ProcessEventsApi(apiClient);
+    }
+
+    @Override
+    public void write(List<ProcessEventRequest> eventBatch) {
+        try {
+            processEventsApi.batchEvent(instanceId.getValue(), eventBatch);
+        } catch (ApiException e) {
+            log.warn("Error while sending batch of {} event{} to the server: {}",
+                    eventBatch.size(), eventBatch.isEmpty() ? "" : "s", e.getMessage());
+        }
+    }
+
+    @Override
+    public void write(ProcessEventRequest req) {
+        try {
+            processEventsApi.event(instanceId.getValue(), req);
+        } catch (ApiException e) {
+            log.warn("error while sending an event to the server: {}", e.getMessage());
+        }
+    }
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultProcessEventWriter.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultProcessEventWriter.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.runtime.v2.runner;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.walmartlabs.concord.client2.ApiClient;
 import com.walmartlabs.concord.client2.ApiException;
 import com.walmartlabs.concord.client2.ProcessEventRequest;

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProcessEventWriter.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProcessEventWriter.java
@@ -1,12 +1,32 @@
 package com.walmartlabs.concord.runtime.v2.runner;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.walmartlabs.concord.client2.ProcessEventRequest;
 
 import java.util.List;
 
 public interface ProcessEventWriter {
 
-    void write(ProcessEventRequest processEventRequest);
+    void write(ProcessEventRequest event);
 
-    void write(List<ProcessEventRequest> eventBatch);
+    void write(List<ProcessEventRequest> events);
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProcessEventWriter.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/ProcessEventWriter.java
@@ -1,0 +1,12 @@
+package com.walmartlabs.concord.runtime.v2.runner;
+
+import com.walmartlabs.concord.client2.ProcessEventRequest;
+
+import java.util.List;
+
+public interface ProcessEventWriter {
+
+    void write(ProcessEventRequest processEventRequest);
+
+    void write(List<ProcessEventRequest> eventBatch);
+}

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/guice/DefaultRunnerModule.java
@@ -57,6 +57,7 @@ public class DefaultRunnerModule extends AbstractModule {
         bind(DependencyManager.class).to(DefaultDependencyManager.class).in(Singleton.class);
         bind(DockerService.class).to(DefaultDockerService.class).in(Singleton.class);
         bind(FileService.class).to(DefaultFileService.class).in(Singleton.class);
+        bind(ProcessEventWriter.class).to(DefaultProcessEventWriter.class).in(Singleton.class);
         bind(EventReportingService.class).to(DefaultEventReportingService.class).in(Singleton.class);
         bind(LockService.class).to(DefaultLockService.class).in(Singleton.class);
         bind(PersistenceService.class).to(DefaultPersistenceService.class).in(Singleton.class);

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/EventReportingServiceTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/EventReportingServiceTest.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,11 @@ package com.walmartlabs.concord.runtime.v2.runner;
  * =====
  */
 
-import com.walmartlabs.concord.client2.ApiClient;
 import com.walmartlabs.concord.client2.ProcessEventRequest;
-import com.walmartlabs.concord.client2.ProcessEventsApi;
-import com.walmartlabs.concord.runtime.common.injector.InstanceId;
 import com.walmartlabs.concord.runtime.v2.model.EventConfiguration;
 import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,12 +73,10 @@ class EventReportingServiceTest {
     }
 
     private static class MockedEventReportingService extends DefaultEventReportingService {
-        final ProcessEventsApi mockProcessEventsApi;
         private final AtomicInteger flushCounter;
 
         public MockedEventReportingService(ProcessConfiguration processConfiguration) {
-            super(new InstanceId(UUID.randomUUID()), processConfiguration, mock(ApiClient.class));
-            this.mockProcessEventsApi = mock(ProcessEventsApi.class);
+            super(processConfiguration, mock(ProcessEventWriter.class));
             this.flushCounter = new AtomicInteger();
         }
 
@@ -90,11 +84,6 @@ class EventReportingServiceTest {
         void flush() {
             super.flush();
             flushCounter.incrementAndGet();
-        }
-
-        @Override
-        ProcessEventsApi getProcessEventsApi() {
-            return mockProcessEventsApi;
         }
     }
 }


### PR DESCRIPTION
simple code coverage with Concord cli:

```
concord-cli run . --with-code-coverage
```

logs:
```
Starting...
13:39:12.073 [main] Hello, Concord!
===
Generating code coverage info...
Coverage info file: /Users/brig/prj/github/concord/examples/hello_world/target/coverage.info
To generate HTML report with lcov use:
	cd /Users/brig/prj/github/concord/examples/hello_world/target && genhtml coverage.info --output-directory out
===
...done!
```

<img width="1470" alt="Screenshot 2024-10-22 at 13 41 24" src="https://github.com/user-attachments/assets/d13270b0-25b1-47f1-a6b5-6e69b5093d86">
