### PR TITLE
runtime-v2: use shorter delay while polling status of threads

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
@@ -26,13 +26,17 @@ import com.walmartlabs.concord.svm.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.Map;
 
 public class JoinCommand<T extends Step> extends StepCommand<T> {
 
-    private static final Logger log = LoggerFactory.getLogger(JoinCommand.class);
+    @Serial
     private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggerFactory.getLogger(JoinCommand.class);
+    private static final long BUSY_WAIT_SLEEP = 100; // how often poll status of threads, milliseconds
 
     private final Collection<ThreadId> ids;
 
@@ -90,7 +94,7 @@ public class JoinCommand<T extends Step> extends StepCommand<T> {
 
             // some children are still running, wait for a bit and then check again
             try {
-                Thread.sleep(1000); // a "good enough™" value
+                Thread.sleep(BUSY_WAIT_SLEEP);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
The current "good enough™" value is not particularly good for short forks. Tighten the loop by reducing the delay from 1 second to 100 milliseconds.

Test flow:

```yaml
flows:
  default:
    - call: foo
      loop:
        items: ["A", "B", "C"]
        parallelism: 2
        mode: parallel

  foo:
    - log: "Hi, ${item}!"
    - "${sleep.ms(1000)}"
    - log: "Bye, ${item}!"
```

Before:

![Screenshot_20241029_200357](https://github.com/user-attachments/assets/1d9a96b3-ff8e-418c-8d95-709b1aacd582)


After:

![Screenshot_20241029_200413](https://github.com/user-attachments/assets/c64e35b8-c18e-4735-b5bd-5ee1b0f21cc9)
