### PR TITLE
concord-server: fix session token handling

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/StandardAuthenticationHandlersIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/StandardAuthenticationHandlersIT.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.it.server;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,24 +20,47 @@ package com.walmartlabs.concord.it.server;
  * =====
  */
 
-import com.walmartlabs.concord.it.common.ServerClient;
+import com.walmartlabs.concord.client2.ProcessEntry;
+import com.walmartlabs.concord.client2.StartProcessResponse;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
+import java.util.Map;
 
+import static com.walmartlabs.concord.it.common.ITUtils.archive;
+import static com.walmartlabs.concord.it.common.ServerClient.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BearerTokenIT {
+public class StandardAuthenticationHandlersIT extends AbstractServerIT {
 
     @Test
-    public void test() throws Exception {
+    public void testBearerToken() throws Exception {
         URL urlObj = new URL(ITConstants.SERVER_URL + "/api/v1/org?limit=1");
         HttpURLConnection httpCon = (HttpURLConnection) urlObj.openConnection();
 
-        httpCon.setRequestProperty("Authorization", "Bearer " + ServerClient.DEFAULT_API_KEY);
+        httpCon.setRequestProperty("Authorization", "Bearer " + DEFAULT_API_KEY);
 
         int responseCode = httpCon.getResponseCode();
         assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+    }
+
+    @Test
+    public void testSessionTokenAsUsername() throws Exception {
+        URI dir = SuspendIT.class.getResource("sessionTokenAsUsername").toURI();
+        byte[] payload = archive(dir);
+
+        // ---
+
+        String targetUrl = getApiClient().getBaseUri() + "/api/v1/org?limit=1";
+        StartProcessResponse spr = start(Map.of(
+                "archive", payload,
+                "arguments.targetUrl", targetUrl));
+
+        // ---
+
+        ProcessEntry pir = waitForStatus(getApiClient(), spr.getInstanceId(), ProcessEntry.StatusEnum.FINISHED);
+        assertLog(".*statusCode=200.*", getLog(pir.getInstanceId()));
     }
 }

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/sessionTokenAsUsername/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/sessionTokenAsUsername/concord.yml
@@ -1,0 +1,23 @@
+configuration:
+  runtime: "concord-v2"
+flows:
+  default:
+    - script: js
+      body: |
+        const Base64 = Java.type('java.util.Base64');
+        const auth = processInfo.sessionToken + ":";
+        result.set('auth', Base64.getEncoder().withoutPadding().encodeToString(auth.getBytes()));
+      out:
+        auth: ${result.auth}
+
+    - task: http
+      in:
+        method: GET
+        headers:
+          Authorization: "Basic ${auth}"
+        url: ${targetUrl}
+        ignoreErrors: false
+        response: json
+      out: response
+
+    - log: "statusCode=${response.statusCode}"

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/BasicAuthenticationHandler.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/BasicAuthenticationHandler.java
@@ -35,6 +35,8 @@ import static com.walmartlabs.concord.sdk.Constants.Headers.REMEMBER_ME_HEADER;
 
 /**
  * Handles basic authentication (username/password).
+ *
+ * @see SessionTokenAuthenticationHandler for a special case of session tokens passed as usernames.
  */
 public class BasicAuthenticationHandler implements AuthenticationHandler {
 
@@ -64,12 +66,16 @@ public class BasicAuthenticationHandler implements AuthenticationHandler {
         auth = new String(Base64.getDecoder().decode(auth));
 
         var idx = auth.indexOf(":");
-        if (idx + 1 == auth.length()) {
-            throw new IllegalArgumentException("Invalid basic auth header");
+        if (idx < 0) {
+            // invalid auth header
+            return null;
         }
 
-        if (idx < 0 || idx + 1 >= auth.length()) {
-            throw new IllegalArgumentException("Invalid basic auth header");
+        if (idx + 1 == auth.length()) {
+            // no password
+            // it might be a session token that is passed as a username
+            // we let the SessionTokenAuthenticationHandler to handle it
+            return null;
         }
 
         var username = auth.substring(0, idx).trim();


### PR DESCRIPTION
Bring back the handling of the "session tokens as usernames" special case.