### PR TITLE
server: add authorization check to User lookup endpoint in API

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResourceV2.java
@@ -91,8 +91,8 @@ public class UserResourceV2 implements Resource {
 
         UUID authenticatedId = loggedIn.getId();
 
-        if(!authenticatedId.equals(id)) {
-            assertAdmin();
+        if(!authenticatedId.equals(id) && !Roles.isAdmin()) {
+            throw new UnauthorizedException("Users can only view their own information or must have admin privileges.");
         }
 
         return userDao.get(id);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/user/UserResourceV2.java
@@ -69,17 +69,6 @@ public class UserResourceV2 implements Resource {
         return userDao.list(filter, offset, limit);
     }
 
-
-    /*
-        throws unauthorized exception if user is not an admin,
-        copied from UserResource.java
-    */
-    private static void assertAdmin() {
-        if (!Roles.isAdmin()) {
-            throw new UnauthorizedException("Only admins can do that");
-        }
-    }
-
     @GET
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
restricts UserResourceV2 to only allow a user to look up their own information or requires admin permissions.