### PR TITLE
it: tighten up polling intervals

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -58,7 +58,16 @@ public final class ConcordConfiguration {
                 .streamAgentLogs(true)
                 .sharedContainerDir(sharedDir)
                 .useLocalMavenRepository(true)
-                .extraConfigurationSupplier(() -> "concord-agent { prefork { enabled = true } }");
+                .extraConfigurationSupplier(() -> """
+                    concord-agent {
+                        dependencyResolveTimeout = "5 seconds"
+                        logMaxDelay = "250 milliseconds"
+                        pollInterval = "250 milliseconds"
+                        prefork {
+                            enabled = true
+                        }
+                    }
+                    """);
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/CryptoIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/CryptoIT.java
@@ -36,7 +36,7 @@ import static com.walmartlabs.concord.it.common.ITUtils.randomString;
 public class CryptoIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure();
+    public static final ConcordRule concord = ConcordConfiguration.configure();
 
     /**
      * Tests various methods of the 'crypto' plugin.

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/FormIT.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class FormIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure();
+    public static final ConcordRule concord = ConcordConfiguration.configure();
 
     /**
      * A straightforward single form process.

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
@@ -40,7 +40,7 @@ import static com.walmartlabs.concord.it.common.ITUtils.randomString;
 public class ImportsIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure()
+    public static final ConcordRule concord = ConcordConfiguration.configure()
             .extraConfigurationSupplier(() -> "concord-server { imports { disabledProcessors = [] } }\n" +
                     "concord-agent { imports { disabledProcessors = [] } }");
 

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/JsonStoreIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/JsonStoreIT.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JsonStoreIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure();
+    public static final ConcordRule concord = ConcordConfiguration.configure();
 
     /**
      * Tests various methods of the 'jsonStore' plugin.

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/KvTaskIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/KvTaskIT.java
@@ -32,7 +32,7 @@ import static com.walmartlabs.concord.it.common.ITUtils.randomString;
 public class KvTaskIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure();
+    public static final ConcordRule concord = ConcordConfiguration.configure();
 
     /**
      * Tests various methods of the 'kv' plugin.

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/NodeRosterIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/NodeRosterIT.java
@@ -36,7 +36,7 @@ import static com.walmartlabs.concord.it.runtime.v2.Utils.resourceToString;
 public class NodeRosterIT extends AbstractTest {
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure();
+    public static final ConcordRule concord = ConcordConfiguration.configure();
 
     /**
      * Tests various methods of the 'noderoster' plugin.

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SmtpIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/SmtpIT.java
@@ -40,10 +40,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SmtpIT extends AbstractTest {
 
     @RegisterExtension
-    GreenMailExtension mailServer = new GreenMailExtension(new ServerSetup(0, "0.0.0.0", ServerSetup.PROTOCOL_SMTP));
+    public static final GreenMailExtension mailServer = new GreenMailExtension(new ServerSetup(0, "0.0.0.0", ServerSetup.PROTOCOL_SMTP))
+            .withPerMethodLifecycle(false);
 
     @RegisterExtension
-    public final ConcordRule concord = ConcordConfiguration.configure()
+    public static final ConcordRule concord = ConcordConfiguration.configure()
             .containerListener(new ContainerListener() {
                 @Override
                 public void beforeStart(ContainerType type) {

--- a/it/server/src/test/resources/agent.conf
+++ b/it/server/src/test/resources/agent.conf
@@ -1,5 +1,9 @@
 concord-agent {
 
+    dependencyResolveTimeout = "5 seconds"
+    logMaxDelay = "250 milliseconds"
+    pollInterval = "250 milliseconds"
+
     prefork {
         enabled = true
     }


### PR DESCRIPTION
Use shorter polling intervals on the agent during ITs.

Last few runs, "Build and test with Maven" time:

| Platform      | Before | After |
|--------------|---------|-------|
| jdk17        | 1h 9m 14s<br>1h 11m 23s<br>1h 10m 22s | 1h 3m 59s<br>1h 4m 46s<br>1h 4m 57s |
| jdk17-aarch64| 1h 36m 24s<br>1h 30m 7s<br>1h 28m 25s | 1h 22m 6s<br>1h 22m 6s<br>1h 22m 15s |