### PR TITLE
project: use concord-maven-plugin

### DIFF
--- a/plugins/tasks/ansible/pom.xml
+++ b/plugins/tasks/ansible/pom.xml
@@ -121,8 +121,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/asserts/pom.xml
+++ b/plugins/tasks/asserts/pom.xml
@@ -42,8 +42,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/concord/pom.xml
+++ b/plugins/tasks/concord/pom.xml
@@ -99,8 +99,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/crypto/pom.xml
+++ b/plugins/tasks/crypto/pom.xml
@@ -38,8 +38,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/docker/pom.xml
+++ b/plugins/tasks/docker/pom.xml
@@ -38,8 +38,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/dynamic-tasks/pom.xml
+++ b/plugins/tasks/dynamic-tasks/pom.xml
@@ -48,8 +48,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/example/pom.xml
+++ b/plugins/tasks/example/pom.xml
@@ -40,8 +40,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/files/pom.xml
+++ b/plugins/tasks/files/pom.xml
@@ -28,8 +28,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/http/pom.xml
+++ b/plugins/tasks/http/pom.xml
@@ -108,8 +108,15 @@
 
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/kv/pom.xml
+++ b/plugins/tasks/kv/pom.xml
@@ -38,8 +38,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/locale/pom.xml
+++ b/plugins/tasks/locale/pom.xml
@@ -33,8 +33,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/lock/pom.xml
+++ b/plugins/tasks/lock/pom.xml
@@ -43,8 +43,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/log/pom.xml
+++ b/plugins/tasks/log/pom.xml
@@ -65,8 +65,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/misc/pom.xml
+++ b/plugins/tasks/misc/pom.xml
@@ -38,8 +38,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/mock/pom.xml
+++ b/plugins/tasks/mock/pom.xml
@@ -99,8 +99,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/noderoster/pom.xml
+++ b/plugins/tasks/noderoster/pom.xml
@@ -54,8 +54,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/resource/pom.xml
+++ b/plugins/tasks/resource/pom.xml
@@ -85,8 +85,12 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/slack/pom.xml
+++ b/plugins/tasks/slack/pom.xml
@@ -70,8 +70,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/sleep/pom.xml
+++ b/plugins/tasks/sleep/pom.xml
@@ -44,8 +44,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/smtp/pom.xml
+++ b/plugins/tasks/smtp/pom.xml
@@ -94,8 +94,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/plugins/tasks/throw/pom.xml
+++ b/plugins/tasks/throw/pom.xml
@@ -33,8 +33,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <configuration>
+                    <!-- no verify, as this plugin depends on runtime-v2 -->
+                    <skipVerify>true</skipVerify>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins/tasks/variables/pom.xml
+++ b/plugins/tasks/variables/pom.xml
@@ -38,8 +38,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+                        <artifactId>concord-runner-v2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,22 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>dev.ybrig.concord</groupId>
+                    <artifactId>concord-maven-plugin</artifactId>
+                    <version>0.0.31</version>
+                    <configuration>
+                        <concordVersion>${project.version}</concordVersion>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sisu-index</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>


### PR DESCRIPTION
Some plugins depend on the runner, so we can't verify it because it creates a circular dependency: 
task A -> concord-maven-plugin -> runner -> task A

so we just create an sisu-index for them.