### PR TITLE
runtime-v2: allow throw payload with exception

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ProcessIT.java
@@ -24,6 +24,7 @@ import ca.ibodrov.concord.testcontainers.ConcordProcess;
 import ca.ibodrov.concord.testcontainers.Payload;
 import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
 import com.walmartlabs.concord.client2.*;
+import com.walmartlabs.concord.common.ConfigurationUtils;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
 import org.junit.jupiter.api.Test;
@@ -193,6 +194,23 @@ public class ProcessIT extends AbstractTest {
         assertEquals(123, data.get("x"));
         assertEquals(true, data.get("y.some.boolean"));
         assertFalse(data.containsKey("z"));
+    }
+
+    @Test
+    public void testThrowWithPayload() throws Exception {
+        Payload payload = new Payload()
+                .archive(resource("throwWithPayload"));
+
+        ConcordProcess proc = concord.processes().start(payload);
+        expectStatus(proc, ProcessEntry.StatusEnum.FAILED);
+
+        // ---
+
+        Map<String, Object> data = proc.getOutVariables();
+        assertNotNull(data);
+
+        assertEquals("BOOM", ConfigurationUtils.get(data, "lastError", "message"));
+        assertEquals(Map.of("key", "value", "key2", "value2"), ConfigurationUtils.get(data, "lastError", "payload"));
     }
 
     @Test

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/throwWithPayload/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/throwWithPayload/concord.yml
@@ -1,0 +1,11 @@
+configuration:
+  runtime: "concord-v2"
+
+flows:
+  default:
+  - task: "throw"
+    in:
+      exception: "BOOM"
+      payload:
+        key: "value"
+        key2: "value2"

--- a/plugins/tasks/throw/src/main/java/com/walmartlabs/concord/plugins/throwex/ThrowExceptionTaskV2.java
+++ b/plugins/tasks/throw/src/main/java/com/walmartlabs/concord/plugins/throwex/ThrowExceptionTaskV2.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.*;
 
 import javax.inject.Named;
 import java.io.Serializable;
+import java.util.Map;
 
 @Named("throw")
 @DryRunReady
@@ -31,12 +32,12 @@ public class ThrowExceptionTaskV2 implements Task {
 
     @Override
     public TaskResult execute(Variables input) throws Exception {
-        Object exception = input.get("exception");
+        var exception = input.get("exception");
 
         if (exception instanceof Exception) {
             throw (Exception) exception;
-        } else if (exception instanceof String) {
-            throw new UserDefinedException(exception.toString());
+        } else if (exception instanceof String s) {
+            throw new UserDefinedException(s, input.getMap("payload", Map.of()));
         } else if (exception instanceof Serializable) {
             throw new ConcordException("Process Error", (Serializable) exception);
         } else {

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/SaveLastErrorCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/SaveLastErrorCommand.java
@@ -68,6 +68,10 @@ public class SaveLastErrorCommand implements Command {
 
     private static Map<String, Object> serialize(Exception e) {
         try {
+            if (e instanceof LoggedException le) {
+                e = le.getCause();
+            }
+
             return createMapper().convertValue(e, MAP_TYPE);
         } catch (Exception ex) {
             // ignore ex
@@ -83,7 +87,7 @@ public class SaveLastErrorCommand implements Command {
     }
 
     @SuppressWarnings("unused")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonIdentityInfo(generator= ObjectIdGenerators.IntSequenceGenerator.class)
     abstract static class ExceptionMixIn {
         @JsonIgnore

--- a/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/UserDefinedException.java
+++ b/runtime/v2/sdk/src/main/java/com/walmartlabs/concord/runtime/v2/sdk/UserDefinedException.java
@@ -9,9 +9,9 @@ package com.walmartlabs.concord.runtime.v2.sdk;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.runtime.v2.sdk;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Map;
 
 /**
  * Doesn't produce a stack trace in process logs.
@@ -31,8 +32,15 @@ public class UserDefinedException extends RuntimeException {
     // for backward compatibility (java8 concord 1.92.0 version)
     private static final long serialVersionUID = 8152584338845805365L;
 
+    private final Map<String, Object> payload;
+
     public UserDefinedException(String message) {
+        this(message, null);
+    }
+
+    public UserDefinedException(String message, Map<String, Object> payload) {
         super(message);
+        this.payload = payload;
     }
 
     @Override
@@ -43,5 +51,9 @@ public class UserDefinedException extends RuntimeException {
     @Override
     public void printStackTrace(PrintWriter s) {
         s.println(getMessage());
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
     }
 }


### PR DESCRIPTION
```
  - task: "throw"
    in:
      exception: "message"
      payload:
        key: "value"
```

<img width="757" alt="Screenshot 2024-12-17 at 17 42 06" src="https://github.com/user-attachments/assets/a0f202ea-3f5e-44e2-8f67-24a56d7d65a4" />

Everything seems like it shouldn't break, but it might be useful :)