### PR TITLE
runtime-v2: mask workDir value in logs by default

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/cfg/AgentConfiguration.java
@@ -53,6 +53,7 @@ public class AgentConfiguration {
 
     private final Path logDir;
     private final long logMaxDelay;
+    private final boolean workDirMasking;
 
     private final int workersCount;
     private final long pollInterval;
@@ -81,6 +82,7 @@ public class AgentConfiguration {
 
         this.logDir = getOrCreatePath(cfg, "logDir");
         this.logMaxDelay = cfg.getDuration("logMaxDelay", TimeUnit.MILLISECONDS);
+        this.workDirMasking = cfg.getBoolean("workDirMasking");
 
         this.workersCount = cfg.getInt("workersCount");
         this.maintenanceModeListenerHost = cfg.getString("maintenanceModeListenerHost");
@@ -134,6 +136,10 @@ public class AgentConfiguration {
 
     public long getLogMaxDelay() {
         return logMaxDelay;
+    }
+
+    public boolean isWorkDirMaskings() {
+        return workDirMasking;
     }
 
     public int getWorkersCount() {

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/JobExecutorFactory.java
@@ -124,6 +124,7 @@ public class JobExecutorFactory {
                     .exposeDockerDaemon(dockerCfg.exposeDockerDaemon())
                     .maxHeartbeatInterval(serverCfg.getMaxNoHeartbeatInterval())
                     .segmentedLogs(segmentedLogs)
+                    .workDirMasking(agentCfg.isWorkDirMaskings())
                     .persistentWorkDir(runnerCfg.getPersistentWorkDir())
                     .preforkEnabled(preForkCfg.isEnabled())
                     .cleanRunnerDescendants(runnerCfg.getCleanRunnerDescendants())

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJob.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJob.java
@@ -184,6 +184,7 @@ public class RunnerJob {
                 .logging(LoggingConfiguration.builder()
                         .sendSystemOutAndErrToSLF4J(true)
                         .segmentedLogs(execCfg.segmentedLogs())
+                        .workDirMasking(execCfg.workDirMasking())
                         .build())
                 .build();
     }

--- a/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/executors/runner/RunnerJobExecutor.java
@@ -759,6 +759,8 @@ public class RunnerJobExecutor implements JobExecutor {
 
         boolean segmentedLogs();
 
+        boolean workDirMasking();
+
         @Value.Default
         default List<String> extraDockerVolumes() {
             return Collections.emptyList();

--- a/agent/src/main/resources/concord-agent.conf
+++ b/agent/src/main/resources/concord-agent.conf
@@ -61,6 +61,9 @@ concord-agent {
     # determines how ofter the logs are send back to the server
     logMaxDelay = "2 seconds"
 
+    # replace the current process' workDir in logs with literal "$WORK_DIR"
+    workDirMasking = true
+
     # maximum number of concurrent processes
     workersCount = 3
     workersCount = ${?WORKERS_COUNT}

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/debug_logback.xml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/processMetadataSend/debug_logback.xml
@@ -3,7 +3,7 @@
         <filter class="com.walmartlabs.concord.runtime.v2.runner.logging.LogLevelFilter" />
 
         <encoder class="com.walmartlabs.concord.runtime.v2.runner.logging.ConcordLogEncoder">
-            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.MaskingSensitiveDataLayout">
+            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.CustomLayout">
                 <!-- the UI expects log timestamps in a specific format to be able to convert it to the local time -->
                 <pattern>%date{yyyy-MM-dd'T'HH:mm:ss.SSSZ, UTC} [%-5level] %msg%n%rEx{full, com.sun, sun}</pattern>
             </layout>

--- a/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/cfg/LoggingConfiguration.java
+++ b/runtime/common/src/main/java/com/walmartlabs/concord/runtime/common/cfg/LoggingConfiguration.java
@@ -53,6 +53,15 @@ public interface LoggingConfiguration {
         return true;
     }
 
+    /**
+     * If {@code true}, any ${workDir} value will be replaced with literal
+     * "$WORK_DIR" string. Reduces noise in the logs.
+     */
+    @Value.Default
+    default boolean workDirMasking() {
+        return true;
+    }
+
     static ImmutableLoggingConfiguration.Builder builder() {
         return ImmutableLoggingConfiguration.builder();
     }

--- a/runtime/v2/runner-test/src/main/java/com/walmartlabs/concord/runtime/v2/runner/TestRuntimeV2.java
+++ b/runtime/v2/runner-test/src/main/java/com/walmartlabs/concord/runtime/v2/runner/TestRuntimeV2.java
@@ -196,7 +196,10 @@ public class TestRuntimeV2 implements BeforeEachCallback, AfterEachCallback {
         }
 
         ImmutableRunnerConfiguration.Builder runnerCfg = RunnerConfiguration.builder()
-                .logging(LoggingConfiguration.builder().segmentedLogs(false).build());
+                .logging(LoggingConfiguration.builder()
+                        .segmentedLogs(false)
+                        .workDirMasking(false)
+                        .build());
 
         if (baseCfg != null) {
             runnerCfg.from(baseCfg);
@@ -205,9 +208,6 @@ public class TestRuntimeV2 implements BeforeEachCallback, AfterEachCallback {
         runnerCfg.agentId(UUID.randomUUID().toString())
                 .api(ApiConfiguration.builder()
                         .baseUrl("http://localhost:8001") // TODO make optional?
-                        .build())
-                .logging(LoggingConfiguration.builder()
-                        .workDirMasking(false)
                         .build());
 
         PrintStream oldOut = System.out;

--- a/runtime/v2/runner-test/src/main/java/com/walmartlabs/concord/runtime/v2/runner/TestRuntimeV2.java
+++ b/runtime/v2/runner-test/src/main/java/com/walmartlabs/concord/runtime/v2/runner/TestRuntimeV2.java
@@ -50,8 +50,8 @@ import com.walmartlabs.concord.runtime.v2.runner.vm.BlockCommand;
 import com.walmartlabs.concord.runtime.v2.runner.vm.ParallelCommand;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.sdk.Constants;
-import com.walmartlabs.concord.svm.*;
 import com.walmartlabs.concord.svm.Runtime;
+import com.walmartlabs.concord.svm.*;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -70,7 +70,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -205,6 +205,9 @@ public class TestRuntimeV2 implements BeforeEachCallback, AfterEachCallback {
         runnerCfg.agentId(UUID.randomUUID().toString())
                 .api(ApiConfiguration.builder()
                         .baseUrl("http://localhost:8001") // TODO make optional?
+                        .build())
+                .logging(LoggingConfiguration.builder()
+                        .workDirMasking(false)
                         .build());
 
         PrintStream oldOut = System.out;
@@ -377,7 +380,7 @@ public class TestRuntimeV2 implements BeforeEachCallback, AfterEachCallback {
                 taskCallListeners.addBinding().to(TaskResultListener.class);
 
                 Multibinder<ExecutionListener> executionListeners = Multibinder.newSetBinder(binder(), ExecutionListener.class);
-                executionListeners.addBinding().toInstance(new ExecutionListener(){
+                executionListeners.addBinding().toInstance(new ExecutionListener() {
                     @Override
                     public void beforeProcessStart(Runtime runtime, State state) {
                         SensitiveDataHolder.getInstance().get().clear();
@@ -390,7 +393,7 @@ public class TestRuntimeV2 implements BeforeEachCallback, AfterEachCallback {
                         @Override
                         public Result afterCommand(Runtime runtime, VM vm, State state, ThreadId threadId, Command cmd) {
                             if (cmd instanceof BlockCommand
-                                    || cmd instanceof ParallelCommand) {
+                                || cmd instanceof ParallelCommand) {
                                 return ExecutionListener.super.afterCommand(runtime, vm, state, threadId, cmd);
                             }
 

--- a/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -625,6 +625,7 @@ public class MainTest  {
         RunnerConfiguration runnerCfg = RunnerConfiguration.builder()
                 .logging(LoggingConfiguration.builder()
                         .sendSystemOutAndErrToSLF4J(false)
+                        .workDirMasking(false)
                         .build())
                 .build();
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/InjectorFactory.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/InjectorFactory.java
@@ -32,6 +32,7 @@ import com.walmartlabs.concord.runtime.common.injector.TaskHolder;
 import com.walmartlabs.concord.runtime.v2.runner.guice.CurrentClasspathModule;
 import com.walmartlabs.concord.runtime.v2.runner.guice.DefaultRunnerModule;
 import com.walmartlabs.concord.runtime.v2.runner.guice.ProcessDependenciesModule;
+import com.walmartlabs.concord.runtime.v2.runner.logging.CustomLayout;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.V2;
 import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
 import com.walmartlabs.concord.runtime.v2.sdk.Task;
@@ -123,6 +124,10 @@ public class InjectorFactory {
         @Override
         protected void configure() {
             bind(WorkingDirectory.class).toInstance(workDir);
+            if (runnerCfg.logging().workDirMasking()) {
+                CustomLayout.enableWorkingDirectoryMasking(workDir);
+            }
+
             bind(RunnerConfiguration.class).toInstance(runnerCfg);
             bind(ProcessConfiguration.class).toProvider(processCfgProvider);
             bind(InstanceId.class).toProvider(InstanceIdProvider.class);

--- a/runtime/v2/runner/src/main/resources/logback.xml
+++ b/runtime/v2/runner/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
         <filter class="com.walmartlabs.concord.runtime.v2.runner.logging.LogLevelFilter" />
 
         <encoder class="com.walmartlabs.concord.runtime.v2.runner.logging.ConcordLogEncoder">
-            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.MaskingSensitiveDataLayout">
+            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.CustomLayout">
                 <!-- the UI expects log timestamps in a specific format to be able to convert it to the local time -->
                 <pattern>%date{yyyy-MM-dd'T'HH:mm:ss.SSSZ, UTC} [%-5level] %msg%n%rEx{full, com.sun, sun}</pattern>
             </layout>
@@ -14,7 +14,7 @@
         <filter class="com.walmartlabs.concord.runtime.v2.runner.logging.LogLevelFilter" />
 
         <encoder class="com.walmartlabs.concord.runtime.v2.runner.logging.ConcordLogEncoder">
-            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.MaskingSensitiveDataLayout">
+            <layout class="com.walmartlabs.concord.runtime.v2.runner.logging.CustomLayout">
                 <!-- the UI expects log timestamps in a specific format to be able to convert it to the local time -->
                 <pattern>%date{yyyy-MM-dd'T'HH:mm:ss.SSSZ, UTC} %msg%n</pattern>
             </layout>


### PR DESCRIPTION
Add workDirMasking option to concord-agent.conf to enable masking of workDir values in logs. The actual path (which is usually some noise like `/tmp/concord-agent/xxxxxyyyyyzzzzz`) is replaced with a `$WORK_DIR` literal.