### PR TITLE
project: use GitHub-hosted ARM64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           - profile: 'jdk17'
             runs_on: ubuntu-latest
           - profile: 'jdk17-aarch64'
-            runs_on: [ linux, ARM64 ]
+            runs_on: ubuntu-24.04-arm
       fail-fast: false
 
     runs-on: ${{ matrix.runs_on }}


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/