### PR TITLE
misc-tasks: add base64 task, shortcut for current ISO timestamp

### DIFF
--- a/plugins/tasks/misc/src/main/java/com/walmartlabs/concord/plugins/misc/Base64TaskV2.java
+++ b/plugins/tasks/misc/src/main/java/com/walmartlabs/concord/plugins/misc/Base64TaskV2.java
@@ -1,0 +1,46 @@
+package com.walmartlabs.concord.plugins.misc;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.Task;
+
+import javax.inject.Named;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Named("base64")
+public class Base64TaskV2 implements Task {
+
+    /**
+     * Encodes bytes of a UTF-8 string as a base64 string.
+     */
+    public String encode(String raw) {
+        return Base64.getEncoder().encodeToString(raw.getBytes(UTF_8));
+    }
+
+    /**
+     * Decodes a base64-encoded string.
+     */
+    public String decode(String base64) {
+        return new String(Base64.getDecoder().decode(base64), UTF_8);
+    }
+}

--- a/plugins/tasks/misc/src/main/java/com/walmartlabs/concord/plugins/misc/DateTimeTaskV2.java
+++ b/plugins/tasks/misc/src/main/java/com/walmartlabs/concord/plugins/misc/DateTimeTaskV2.java
@@ -43,6 +43,10 @@ public class DateTimeTaskV2 implements Task {
         return DateTimeFormatter.ofPattern(pattern).format(ZonedDateTime.now());
     }
 
+    public String currentISO() {
+        return current("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    }
+
     public String currentWithZone(String zone, String pattern) {
         return DateTimeFormatter.ofPattern(pattern).format(ZonedDateTime.now(ZoneId.of(zone)));
     }


### PR DESCRIPTION
runtime-v2 only:

- add `base64.encode` and `decode` methods
- add `datetime.currentISO()` shortcut