### PR TITLE
project: do not log into Docker in check runs started in forks (another attempt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
-        if: github.repository_owner == 'walmartlabs'
+        if: github.event.pull_request.head.repo.full_name == 'walmartlabs/concord'
         with:
           username: ${{ secrets.OSS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.OSS_DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Checking github.repository_owner is not enough. IIUC, it always points at the repository in the context of which the current GHA check is running.

Let's try `github.event.pull_request.head.repo.full_name` instead.