### PR TITLE
project: update Maven plugin versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ yarn.lock
 .mvn/wrapper/maven-wrapper.jar
 .java-version
 .attach_pid*
+dependency-reduced-pom.xml

--- a/docker-images/agent/oss/debian/Dockerfile
+++ b/docker-images/agent/oss/debian/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM ${docker_namespace}/concord-ansible:${container_version}
 LABEL maintainer="amith.k.b@walmartlabs.com"
 
-ENV DOCKER_HOST tcp://dind:2375
+ENV DOCKER_HOST=tcp://dind:2375
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 USER root

--- a/docker-images/base/oss/debian/Dockerfile
+++ b/docker-images/base/oss/debian/Dockerfile
@@ -24,10 +24,10 @@ RUN export DEFAULT_TARGETARCH=$(/tmp/get_arch.sh); \
     tar xpf /tmp/jdk.tar.gz --strip 1 -C /opt/jdk && \
     rm /tmp/jdk.tar.gz
 
-ENV JAVA_HOME /opt/jdk
+ENV JAVA_HOME=/opt/jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-ENV LC_CTYPE en_US.UTF-8
-ENV LANG en_US.UTF-8
+ENV LC_CTYPE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 RUN virtualenv /usr/local/bin/concord_venv && \
     /usr/local/bin/concord_venv/bin/pip3 --no-cache-dir install dumb-init

--- a/docker-images/server/oss/Dockerfile
+++ b/docker-images/server/oss/Dockerfile
@@ -14,5 +14,5 @@ RUN mkdir -p /opt/concord/server/logs && \
 
 USER concord
 
-ENV BASE_RESOURCE_PATH /opt/concord/console/
+ENV BASE_RESOURCE_PATH=/opt/concord/console/
 CMD ["bash", "/opt/concord/server/start.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord.git</scm.connection>
 
-        <docker.plugin.version>0.38.1</docker.plugin.version>
+        <docker.plugin.version>0.45.1</docker.plugin.version>
         <jooq.version>3.14.0</jooq.version>
         <junit.version>5.9.1</junit.version>
         <liquibase.version>4.29.2</liquibase.version>
@@ -106,13 +106,12 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.14.0</version>
             </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>1.14</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>first</id>
@@ -143,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.6.0</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
@@ -161,8 +160,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -374,37 +374,37 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.15.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
-                    <version>7.0.1</version>
+                    <version>7.12.0</version>
                 </plugin>
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.6</version>
+                    <version>4.9.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.revapi</groupId>
@@ -428,12 +428,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.11.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/runtime/v1/impl/pom.xml
+++ b/runtime/v1/impl/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>25.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.takari.bpm</groupId>


### PR DESCRIPTION
And other minor changes.

The updated maven-enforcer-plugin complained about runtime-v1 pulling in Guava 25.x while Jackson was pulling in the common version (33.x). Now runtime-v1 will be using the common Guava version as well.
