### PR TITLE
http-tasks: refactor tests, support for parallel tests

### DIFF
--- a/plugins/tasks/http/pom.xml
+++ b/plugins/tasks/http/pom.xml
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/HttpTask.java
+++ b/plugins/tasks/http/src/main/java/com/walmartlabs/concord/plugins/http/HttpTask.java
@@ -70,7 +70,7 @@ public class HttpTask implements Task {
      * @return Map
      * @throws Exception exception
      */
-    private Map<String, Object> executeRequest(Configuration config) throws Exception {
+    Map<String, Object> executeRequest(Configuration config) throws Exception {
         log.info("Request method: {}", config.getMethodType());
 
         Map<String, Object> response = SimpleHttpClient.create(config, false).execute().getResponse();

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskTest.java
@@ -20,391 +20,51 @@ package com.walmartlabs.concord.plugins.http;
  * =====
  */
 
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.walmartlabs.concord.plugins.http.exception.RequestTimeoutException;
-import com.walmartlabs.concord.sdk.Context;
+import com.walmartlabs.concord.sdk.MockContext;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-public class HttpTaskTest extends AbstractHttpTaskTest {
-
-    private final Context mockContext = mock(Context.class);
+class HttpTaskTest {
 
     @Test
-    public void testForAsStringMethod(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        String response = task.asString("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json");
-        verify(getRequestedFor(urlEqualTo("/json")));
-        assertNotNull(response);
+    void testExecute() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("url", "https://mock.local");
+
+        var ctx = new MockContext(input);
+        assertDoesNotThrow(() -> new MockHttpTask().execute(ctx));
+
+        assertNotNull(ctx.getVariable("response"));
     }
 
     @Test
-    public void testExecuteGetRequestForJson(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-        task.execute(mockContext);
-        verify(getRequestedFor(urlEqualTo("/json")));
-        assertEquals(200, response.get("statusCode"));
-        assertNull(response.get("errorString"));
+    void testExecuteCustomOutVar() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("url", "https://mock.local");
+        input.put("out", "myOut");
+
+        var ctx = new MockContext(input);
+        assertDoesNotThrow(() -> new MockHttpTask().execute(ctx));
+
+        assertNotNull(ctx.getVariable("myOut"));
     }
 
     @Test
-    public void testExecuteGetRequestForString(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/string", false, 0, true);
-        task.execute(mockContext);
-        verify(getRequestedFor(urlEqualTo("/string")));
+    void testAsString() {
+        var out = assertDoesNotThrow(() -> new MockHttpTask().asString("https://mock.local"));
+        assertEquals("ok", out);
     }
 
-    @Test
-    public void testExecuteGetRequestWithQueryParams(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        Map<String, Object> queryParams = new HashMap<>();
-        queryParams.put("key", "value with space");
+    private static class MockHttpTask extends HttpTask {
 
-        initCxtForRequest(mockContext, "GET", queryParams, null, "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/query", false, 0, true);
-        task.execute(mockContext);
-        verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("key", equalTo("value with space")));
-    }
-
-    @Test
-    public void testExecutePostRequestWithFormUrlEncoded(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "form", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-        when(mockContext.getVariable("body")).thenReturn(Collections.singletonMap("message", "Hello Concord!"));
-        task.execute(mockContext);
-    }
-
-    @Test
-    public void testExecutePostRequestForJson(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-        when(mockContext.getVariable("body")).thenReturn("{ \"request\": \"PostTest\" }");
-        task.execute(mockContext);
-        verify(postRequestedFor(urlEqualTo("/post"))
-                .withHeader("Content-Type", equalTo("application/json")));
-    }
-
-    @Test
-    public void testExecutePostRequestForComplexObject(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-        HashMap<String, Object> complexObject = new HashMap<>();
-        HashMap<String, Object> nestedObject = new HashMap<>();
-        nestedObject.put("nestedVar", 123);
-        complexObject.put("myObject", nestedObject);
-        when(mockContext.getVariable("body")).thenReturn(complexObject);
-        task.execute(mockContext);
-        verify(postRequestedFor(urlEqualTo("/post"))
-                .withHeader("Content-Type", equalTo("application/json")));
-    }
-
-    @Test
-    public void testExecutePostRequestForMultipart(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "formData", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-
-        HashMap<String, Object> formInput = new HashMap<>();
-        HashMap<String, Object> field = new HashMap<>();
-        field.put("type", "text/plain");
-        field.put("data", "\"string value\"");
-
-        formInput.put("field1", "string value");
-        formInput.put("field2", "src/test/resources/__files/file.bin");
-        formInput.put("field3", field);
-        when(mockContext.getVariable("body")).thenReturn(formInput);
-        task.execute(mockContext);
-
-        assertNotNull(response);
-        assertTrue((Boolean) response.get("success"));
-    }
-
-    @Test
-    public void testExecuteForException(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        assertThrows(Exception.class, () -> {
-            initCxtForRequest(mockContext, "GET", "string", "string",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/fault", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testExecuteWithIgnoreError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/fault", true, 0, true);
-        task.execute(mockContext);
-    }
-
-    @Test
-    public void testExecuteGetRequestWithoutFollowRedirect(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/followRedirects", false, 0, false);
-        task.execute(mockContext);
-        assertEquals(301, response.get("statusCode"));
-    }
-
-    @Test
-    public void testExecuteGetRequestWithFollowRedirect(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "string", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/followRedirects", false, 0, true);
-        task.execute(mockContext);
-        assertEquals(200, response.get("statusCode"));
-    }
-
-    @Test
-    public void testExecutePostRequestWithoutFollowRedirect(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/followRedirectsPost", false, 0, false);
-        when(mockContext.getVariable("body")).thenReturn("{}");
-        task.execute(mockContext);
-        assertEquals(301, response.get("statusCode"));
-    }
-
-    @Test
-    public void testExecutePostRequestWithFollowRedirect(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "json", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/followRedirectsPost", false, 0, true);
-        when(mockContext.getVariable("body")).thenReturn("{}");
-        task.execute(mockContext);
-        assertEquals(200, response.get("statusCode"));
-    }
-
-    @Test
-    public void testIllegalArgumentExceptionForRequest() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testGetAsDefaultRequestMethod(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, null, "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertNotNull(response.get("content"));
-    }
-
-    @Test
-    public void testGetRequestForResponseContent(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertNotNull(response.get("content"));
-    }
-
-    @Test
-    public void testUnsuccessfulResponse(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/unsuccessful", false, 0, true);
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertFalse((Boolean) response.get("success"));
-        assertTrue(((String) response.get("errorString")).length() > 0);
-    }
-
-    @Test
-    public void testFilePostRequest(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "POST", "file", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/file", false, 0, true);
-        when(mockContext.getVariable("body")).thenReturn("src/test/resources/__files/file.bin");
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertTrue((Boolean) response.get("success"));
-    }
-
-    @Test
-    public void testForMissingWorkDirForFileGetRequest(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            // Working directory is mandatory for response type file
-            initCxtForRequest(mockContext, "GET", "json", "file",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/stringFile", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testFileGetRequestWithWorkDir(WireMockRuntimeInfo wmRuntimeInfo, @TempDir Path tempDir) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "file",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/stringFile", false, 0, true);
-        when(mockContext.getVariable("workDir")).thenReturn(tempDir.toString());
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertTrue((Boolean) response.get("success"));
-        assertEquals("stringFile", (new File((String) response.get("content"))).getName());
-    }
-
-    @Test
-    public void testFileGetRequestWithNoFilename(WireMockRuntimeInfo wmRuntimeInfo, @TempDir Path tempDir) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "file",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/fileUrlWithoutName/", false, 0, true);
-        when(mockContext.getVariable("workDir")).thenReturn(tempDir.toString());
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertTrue((Boolean) response.get("success"));
-        assertTrue(((String) response.get("content")).matches(".*/tmpfile_.*\\.tmp$"));
-    }
-
-    @Test
-    public void testFileGetWithResponseTypeString(WireMockRuntimeInfo wmRuntimeInfo, @TempDir Path tempDir) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "string",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/stringFile", false, 0, true);
-        when(mockContext.getVariable("workDir")).thenReturn(tempDir.toString());
-        task.execute(mockContext);
-        assertNotNull(response);
-    }
-
-    @Test
-    public void testFileGetWithResponseTypeJSON(WireMockRuntimeInfo wmRuntimeInfo, @TempDir Path tempDir) throws Exception {
-        initCxtForRequest(mockContext, "GET", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/JSONFile", false, 0, true);
-        when(mockContext.getVariable("workDir")).thenReturn(tempDir.toString());
-        task.execute(mockContext);
-        assertNotNull(response);
-        assertTrue((Boolean) response.get("success"));
-    }
-
-    @Test
-    public void testPostJsonRequestForIncompatibleBody(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "POST", "json", "string",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-            when(mockContext.getVariable("body")).thenReturn("src/test/resources/__files/file.bin");
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testPostStringRequestForIncompatibleComplexBody(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "POST", "string", "string",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-            when(mockContext.getVariable("body")).thenReturn(new HashMap<>());
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testPostFileRequestForIncompatibleComplexBody(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "POST", "file", "string",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/post", false, 0, true);
-            when(mockContext.getVariable("body")).thenReturn(new HashMap<>());
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidRequestMethodType(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "GET1", "json", "file",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/file", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidRequestType(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "GET", "json1", "file",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/file", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidResponseType(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "GET", "json", "file1",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/file", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testOptionalResponseType(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "GET", "string", null, "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/string", false, 0, true);
-        task.execute(mockContext);
-        assertTrue((Boolean) response.get("success"));
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testDelete(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "DELETE", "string", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/delete", false, 0, true);
-        task.execute(mockContext);
-        verify(deleteRequestedFor(urlEqualTo("/delete")));
-        assertNotNull(response);
-        assertEquals("Success", ((Map<String, Object>) response.get("content")).get("message"));
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testPatch(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        initCxtForRequest(mockContext, "PATCH", "json", "json",
-                "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/patch", false, 0, true);
-        when(mockContext.getVariable("body")).thenReturn("{ \"request\": \"PatchTest\" }");
-        task.execute(mockContext);
-        verify(patchRequestedFor(urlEqualTo("/patch")));
-        assertNotNull(response);
-        assertEquals("Success", ((Map<String, Object>) response.get("content")).get("message"));
-    }
-
-    @Test
-    public void testRequestTimeoutException(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(RequestTimeoutException.class, () -> {
-            initCxtForRequest(mockContext, "GET", "string", "string",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/requestTimeout", false, 5000, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidJsonResponse(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(RuntimeException.class, () -> {
-            initCxtForRequest(mockContext, "GET", "json", "json",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/invalid/json", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidRequestMethod(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, 123, "json", "json",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidRequest(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "GET", 123, "json",
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-            task.execute(mockContext);
-        });
-    }
-
-    @Test
-    public void testInvalidResponse(WireMockRuntimeInfo wmRuntimeInfo) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            initCxtForRequest(mockContext, "GET", "json", 123,
-                    "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/json", false, 0, true);
-            task.execute(mockContext);
-        });
+        @Override
+        Map<String, Object> executeRequest(Configuration config) {
+            return Map.of("success", true, "content", "ok");
+        }
     }
 
 }

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskV2Test.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/HttpTaskV2Test.java
@@ -1,0 +1,86 @@
+package com.walmartlabs.concord.plugins.http;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.Context;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HttpTaskV2Test {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    Context ctx;
+
+    HttpTaskV2 task;
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.processConfiguration().dryRun()).thenReturn(true);
+        when(ctx.workingDirectory()).thenReturn(tempDir);
+        task = new HttpTaskV2(ctx);
+    }
+
+    @Test
+    void testExecute() {
+        var input = defaultInput();
+
+        var result = execute(input);
+
+        assertTrue(result.ok());
+        assertEquals(200, result.values().get("statusCode"));
+    }
+
+    private static Map<String, Object> defaultInput() {
+        Map<String, Object> defaultInput = new HashMap<>();
+        defaultInput.put("url", "https://mock.local");
+        defaultInput.put("method", "POST");
+        defaultInput.put("request", "json");
+        defaultInput.put("body", "{}");
+
+        return defaultInput;
+    }
+
+    private TaskResult.SimpleResult execute(Map<String, Object> input) {
+        var result = assertDoesNotThrow(() -> task.execute(new MapBackedVariables(input)));
+        return assertInstanceOf(TaskResult.SimpleResult.class, result);
+    }
+}

--- a/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/SimpleHttpClientTest.java
+++ b/plugins/tasks/http/src/test/java/com/walmartlabs/concord/plugins/http/SimpleHttpClientTest.java
@@ -1,0 +1,482 @@
+package com.walmartlabs.concord.plugins.http;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2018 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.walmartlabs.concord.plugins.http.exception.RequestTimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleHttpClientTest extends WiremockTest {
+
+    @Test
+    void testExecuteGetRequestForJson() throws Exception {
+        var config = initCfgForRequest("GET", "JSON", "JSON",
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true);
+
+        var response = SimpleHttpClient.create(config, false)
+                .execute()
+                .getResponse();
+
+        wireMockServer().verify(getRequestedFor(urlEqualTo("/json")));
+        assertEquals(200, response.get("statusCode"));
+        assertNull(response.get("errorString"));
+    }
+
+    @Test
+    void testExecuteGetRequestForString() throws Exception {
+        var config = initCfgForRequest("GET", "STRING", "STRING",
+                "http://localhost:" + wireMockServer().port() + "/string", false, 0, true);
+        SimpleHttpClient.create(config, false)
+                .execute();
+        wireMockServer().verify(getRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testExecuteGetRequestWithQueryParams() throws Exception {
+        Map<String, Object> queryParams = new HashMap<>();
+        queryParams.put("key", "value with space");
+
+        var config = initCfgForRequest("GET", null, "STRING",
+                "http://localhost:" + wireMockServer().port() + "/query", false, 0, true,
+                Map.of("query", queryParams ));
+        SimpleHttpClient.create(config, false)
+                .execute();
+        wireMockServer().verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("key", equalTo("value with space")));
+    }
+
+    @Test
+    void testExecutePostRequestWithFormUrlEncoded() throws Exception {
+        var config = initCfgForRequest("POST", "form", "json",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", Map.of("message", "Hello Concord!")));
+        SimpleHttpClient.create(config, false)
+                        .execute();
+
+        var req = wireMockServer().getAllServeEvents().get(0).getRequest();
+        assertEquals(RequestMethod.POST, req.getMethod());
+        assertEquals("message=" + URLEncoder.encode("Hello Concord!", StandardCharsets.UTF_8), req.getBodyAsString());
+    }
+
+    @Test
+    void testExecutePostRequestForJson() throws Exception {
+        var cfg = initCfgForRequest("POST", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", "{ \"request\": \"PostTest\" }"));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        wireMockServer().verify(postRequestedFor(urlEqualTo("/post"))
+                .withHeader("Content-Type", equalTo("application/json")));
+    }
+
+    @Test
+    void testExecutePostRequestForComplexObject() throws Exception {
+        HashMap<String, Object> complexObject = new HashMap<>();
+        HashMap<String, Object> nestedObject = new HashMap<>();
+        nestedObject.put("nestedVar", 123);
+        complexObject.put("myObject", nestedObject);
+
+        var cfg = initCfgForRequest("POST", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", complexObject));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        wireMockServer().verify(postRequestedFor(urlEqualTo("/post"))
+                .withHeader("Content-Type", equalTo("application/json")));
+    }
+
+    @Test
+    void testExecutePostRequestForMultipart() throws Exception {
+        HashMap<String, Object> formInput = new HashMap<>();
+        HashMap<String, Object> field = new HashMap<>();
+        field.put("type", "text/plain");
+        field.put("data", "\"string value\"");
+
+        formInput.put("field1", "string value");
+        formInput.put("field2", "src/test/resources/__files/file.bin");
+        formInput.put("field3", field);
+
+        var cfg = initCfgForRequest("POST", "formData", "json",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", formInput));
+
+        var out = SimpleHttpClient.create(cfg, false).execute();
+
+        assertNotNull(out.getResponse());
+        assertTrue((Boolean) out.getResponse().get("success"));
+    }
+
+    @Test
+    void testExecuteForException() throws Exception {
+        var cfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/fault", false, 0, true);
+        var client = SimpleHttpClient.create(cfg, false);
+        var ex = assertThrows(Exception.class, client::execute);
+
+        assertTrue(ex.getMessage().contains("failed to respond"));
+    }
+
+    @Test
+    void testExecuteWithIgnoreError() throws Exception {
+        var throwingCfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/fault", false, 0, true);
+        var throwingClient = SimpleHttpClient.create(throwingCfg, false);
+        assertThrows(Exception.class, throwingClient::execute);
+
+        var ignoringCfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/fault", true, 0, true);
+        var ignoringClient = SimpleHttpClient.create(ignoringCfg, false);
+        assertDoesNotThrow(ignoringClient::execute);
+        wireMockServer().verify(8, getRequestedFor(urlEqualTo("/fault")));
+    }
+
+    @Test
+    void testExecuteGetRequestWithoutFollowRedirect() throws Exception {
+        var cfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/followRedirects", false, 0, false);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertEquals(301, out.getResponse().get("statusCode"));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/followRedirects")));
+        wireMockServer().verify(0, getRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testExecuteGetRequestWithFollowRedirect() throws Exception {
+        var cfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/followRedirects", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertEquals(200, out.getResponse().get("statusCode"));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/followRedirects")));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testExecutePostRequestWithoutFollowRedirect() throws Exception {
+        var cfg = initCfgForRequest("POST", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/followRedirectsPost", false, 0, false,
+                Map.of("body", "{}"));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertEquals(301, out.getResponse().get("statusCode"));
+        wireMockServer().verify(1, postRequestedFor(urlEqualTo("/followRedirectsPost")));
+        wireMockServer().verify(0, postRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testExecutePostRequestWithFollowRedirect() throws Exception {
+        var cfg = initCfgForRequest("POST", "json", "string",
+                "http://localhost:" + wireMockServer().port() + "/followRedirectsPost", false, 0, true,
+                Map.of("body", "{}"));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertEquals(200, out.getResponse().get("statusCode"));
+        wireMockServer().verify(1, postRequestedFor(urlEqualTo("/followRedirectsPost")));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testIllegalArgumentExceptionForRequest() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", null, "json",
+                null, false, 0, true));
+
+        assertTrue(ex.getMessage().contains("('url') argument is missing"));
+    }
+
+    @Test
+    void testGetAsDefaultRequestMethod() throws Exception {
+        var cfg = initCfgForRequest(null, "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true);
+        SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertEquals(HttpTask.RequestMethodType.GET, cfg.getMethodType());
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/json")));
+    }
+
+    @Test
+    void testGetRequestForResponseContent() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertNotNull(out.getResponse().get("content"));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/json")));
+    }
+
+    @Test
+    void testUnsuccessfulResponse() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/unsuccessful", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertFalse((Boolean) out.getResponse().get("success"));
+        String errorString = assertInstanceOf(String.class, out.getResponse().get("errorString"));
+        assertFalse(errorString.isEmpty());
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/unsuccessful")));
+    }
+
+    @Test
+    void testFilePostRequest() throws Exception {
+        var cfg = initCfgForRequest("POST", "file", "json",
+                "http://localhost:" + wireMockServer().port() + "/file", false, 0, true,
+                Map.of("body", "src/test/resources/__files/file.bin"));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertTrue((Boolean) out.getResponse().get("success"));
+        wireMockServer().verify(1, postRequestedFor(urlEqualTo("/file")));
+    }
+
+    @Test
+    void testForMissingWorkDirForFileGetRequest() throws Exception {
+        // Working directory is mandatory for response type file
+        workDir = Paths.get("");
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", "json", "file",
+                "http://localhost:" + wireMockServer().port() + "/stringFile", false, 0, true));
+
+        assertTrue(ex.getMessage().contains("Working directory is mandatory for ResponseType FILE"));
+    }
+
+    @Test
+    void testFileGetRequestWithWorkDir() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "file",
+                "http://localhost:" + wireMockServer().port() + "/stringFile", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertTrue((Boolean) out.getResponse().get("success"));
+        assertEquals("stringFile", (new File((String) out.getResponse().get("content"))).getName());
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/stringFile")));
+    }
+
+    @Test
+    void testFileGetRequestWithNoFilename() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "file",
+                "http://localhost:" + wireMockServer().port() + "/fileUrlWithoutName/", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertTrue((Boolean) out.getResponse().get("success"));
+        assertTrue(((String) out.getResponse().get("content")).matches(".*/tmpfile_.*\\.tmp$"));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/fileUrlWithoutName/")));
+    }
+
+    @Test
+    void testFileGetWithResponseTypeString() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "string",
+                "http://localhost:" + wireMockServer().port() + "/stringFile", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/stringFile")));
+    }
+
+    @Test
+    void testFileGetWithResponseTypeJSON() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/JSONFile", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertNotNull(out.getResponse());
+        assertTrue((Boolean) out.getResponse().get("success"));
+        wireMockServer().verify(1, getRequestedFor(urlEqualTo("/JSONFile")));
+    }
+
+    @Test
+    void testPostJsonRequestForIncompatibleBody() throws Exception {
+        var cfg = initCfgForRequest("POST", "json", "string",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", "src/test/resources/__files/file.bin"));
+        var ex = assertThrows(IllegalArgumentException.class, () -> SimpleHttpClient.create(cfg, false));
+
+        assertTrue(ex.getMessage().contains("'request: json' is not compatible with 'body'"));
+    }
+
+    @Test
+    void testPostStringRequestForIncompatibleComplexBody() throws Exception {
+        var cfg = initCfgForRequest("POST", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", Map.of()));
+        var ex = assertThrows(IllegalArgumentException.class, () -> SimpleHttpClient.create(cfg, false));
+
+        assertTrue(ex.getMessage().contains("'request: string' is not compatible with 'body'"));
+    }
+
+    @Test
+    void testPostFileRequestForIncompatibleComplexBody() throws Exception {
+        var cfg = initCfgForRequest("POST", "file", "string",
+                "http://localhost:" + wireMockServer().port() + "/post", false, 0, true,
+                Map.of("body", Map.of()));
+        var ex = assertThrows(IllegalArgumentException.class, () -> SimpleHttpClient.create(cfg, false));
+
+        assertTrue(ex.getMessage().contains("'request: file' is not compatible with 'body'"));
+    }
+
+    @Test
+    void testInvalidRequestMethodType() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET1", "json", "file",
+                "http://localhost:" + wireMockServer().port() + "/file", false, 0, true));
+
+        assertTrue(ex.getMessage().contains("'method: GET1' is not a supported HTTP method"));
+    }
+
+    @Test
+    void testInvalidRequestType() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", "json1", "file",
+                "http://localhost:" + wireMockServer().port() + "/file", false, 0, true));
+
+        assertTrue(ex.getMessage().contains("'request: json1' is not a supported request type"));
+    }
+
+    @Test
+    void testInvalidResponseType() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", "json", "file1",
+                "http://localhost:" + wireMockServer().port() + "/file", false, 0, true));
+
+        assertTrue(ex.getMessage().contains("'response: file1' is not a supported response type"));
+    }
+
+    @Test
+    void testOptionalResponseType() throws Exception {
+        var cfg = initCfgForRequest("GET", "string", null,
+                "http://localhost:" + wireMockServer().port() + "/string", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        assertTrue((Boolean) out.getResponse().get("success"));
+        wireMockServer().verify(getRequestedFor(urlEqualTo("/string")));
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        var cfg = initCfgForRequest("DELETE", "string", "json",
+                "http://localhost:" + wireMockServer().port() + "/delete", false, 0, true);
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        wireMockServer().verify(deleteRequestedFor(urlEqualTo("/delete")));
+        assertNotNull(out.getResponse());
+        Map<?, ?> content = assertInstanceOf(Map.class, out.getResponse().get("content"));
+        assertEquals("Success", content.get("message"));
+    }
+
+    @Test
+    void testPatch() throws Exception {
+        var cfg = initCfgForRequest("PATCH", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/patch", false, 0, true,
+                Map.of("body", "{ \"request\": \"PatchTest\" }"));
+        var out = SimpleHttpClient.create(cfg, false)
+                .execute();
+
+        wireMockServer().verify(patchRequestedFor(urlEqualTo("/patch")));
+        assertNotNull(out.getResponse());
+        Map<?, ?> content = assertInstanceOf(Map.class, out.getResponse().get("content"));
+        assertEquals("Success", content.get("message"));
+    }
+
+    @Test
+    void testRequestTimeoutException() throws Exception {
+        var cfg = initCfgForRequest("GET", "string", "string",
+                "http://localhost:" + wireMockServer().port() + "/requestTimeout", false, 250, true);
+
+        assertThrows(RequestTimeoutException.class, () -> SimpleHttpClient.create(cfg, false)
+                .execute());
+    }
+
+    @Test
+    void testInvalidJsonResponse() throws Exception {
+        var cfg = initCfgForRequest("GET", "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/invalid/json", false, 0, true);
+        var client =  SimpleHttpClient.create(cfg, false);
+        var ex = assertThrows(RuntimeException.class, client::execute);
+
+        assertTrue(ex.getMessage().contains("Invalid JSON response"));
+    }
+
+    @Test
+    void testInvalidRequestMethod() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest(null, "json", "json",
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true,
+                Map.of("method", 123)));
+
+        assertTrue(ex.getMessage().contains("Invalid variable 'method' type"));
+    }
+
+    @Test
+    void testInvalidRequest() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", null, "json",
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true,
+                Map.of("request", 123)));
+
+        assertTrue(ex.getMessage().contains("Invalid variable 'request' type"));
+    }
+
+    @Test
+    void testInvalidResponse() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> initCfgForRequest("GET", "json", null,
+                "http://localhost:" + wireMockServer().port() + "/json", false, 0, true,
+                Map.of("response", 123)));
+
+        assertTrue(ex.getMessage().contains("Invalid variable 'response' type"));
+    }
+
+}

--- a/plugins/tasks/http/src/test/resources/logback.xml
+++ b/plugins/tasks/http/src/test/resources/logback.xml
@@ -5,6 +5,9 @@
         </encoder>
     </appender>
 
+    <logger name="org.eclipse.jetty" level="ERROR"/>
+    <logger name="com.walmartlabs.concord" level="INFO"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -883,6 +883,12 @@
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>


### PR DESCRIPTION
* No main code changes (except for method visibility `private` -> package private)
* Refactor to test only the intended bits (i.e. don't run through task when test is only for client or config)
* Compatibility for [parallel tests](https://github.com/walmartlabs/concord/pull/1117)