### PR TITLE
process-state: filter out additional contents from state downloads

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/StateManagerUtils.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/StateManagerUtils.java
@@ -1,0 +1,77 @@
+package com.walmartlabs.concord.server.process;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.walmartlabs.concord.server.security.Roles;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.walmartlabs.concord.sdk.Constants.Files.CONFIGURATION_FILE_NAME;
+
+public final class StateManagerUtils {
+
+    private static final Map<String, List<String>> STATE_FILTER = Map.of(CONFIGURATION_FILE_NAME, List.of("arguments"));
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("json", "yaml", "yml");
+
+    public static InputStream stateFilter(String file, InputStream in) {
+        // do not apply filter for admins
+        if (Roles.isAdmin()) {
+            return in;
+        }
+
+        return filter(file, in);
+    }
+
+    public static InputStream filter(String file, InputStream in) {
+        try {
+            String extension = getFileExtension(file);
+            if (!ALLOWED_EXTENSIONS.contains(extension) || STATE_FILTER.get(file) == null) {
+                // only filter for allowed extension files
+                return in;
+            }
+
+            byte[] inputBytes = in.readAllBytes();
+            if (inputBytes.length == 0) {
+                return new ByteArrayInputStream(inputBytes);
+            }
+
+            Map<String, Object> map = switch (extension) {
+                case "json" -> new ObjectMapper().readValue(inputBytes, Map.class);
+                case "yaml", "yml" -> new ObjectMapper(new YAMLFactory()).readValue(inputBytes, Map.class);
+                default -> null;
+            };
+
+            if (map == null) {
+                return new ByteArrayInputStream(inputBytes);
+            }
+
+            Map<String, Object> filteredMap = STATE_FILTER.get(file).stream()
+                    .filter(map::containsKey)
+                    .collect(HashMap::new, (m, key) -> m.put(key, map.get(key)), HashMap::putAll);
+
+            byte[] data = switch (extension) {
+                case "json" -> new ObjectMapper().writeValueAsBytes(filteredMap);
+                case "yaml", "yml" -> new ObjectMapper(new YAMLFactory()).writeValueAsBytes(filteredMap);
+                default -> throw new IllegalArgumentException("Unsupported file extension: " + extension);
+            };
+
+            return new ByteArrayInputStream(data);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getFileExtension(String fileName) {
+        if (fileName.lastIndexOf(".") != -1 && fileName.lastIndexOf(".") != 0)
+            return fileName.substring(fileName.lastIndexOf(".") + 1);
+        else return "";
+    }
+
+    private StateManagerUtils() {
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessStateManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessStateManager.java
@@ -34,6 +34,7 @@ import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
 import com.walmartlabs.concord.server.cfg.SecretStoreConfiguration;
 import com.walmartlabs.concord.server.policy.PolicyException;
 import com.walmartlabs.concord.server.policy.PolicyManager;
+import com.walmartlabs.concord.server.process.StateManagerUtils;
 import com.walmartlabs.concord.server.process.logs.ProcessLogManager;
 import com.walmartlabs.concord.server.sdk.PartialProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
@@ -423,8 +424,9 @@ public class ProcessStateManager extends AbstractDao {
                         int unixMode = rs.getInt(2);
                         boolean encrypted = rs.getBoolean(3);
                         try (InputStream in = rs.getBinaryStream(4);
-                             InputStream processed = encrypted ? decrypt(in) : in) {
-                            consumer.accept(n, unixMode, processed);
+                             InputStream processed = encrypted ? decrypt(in) : in;
+                             InputStream filtered = StateManagerUtils.stateFilter(n, processed)) {
+                            consumer.accept(n, unixMode, filtered);
                         }
                     }
                 }

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/StateManagerUtilsTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/StateManagerUtilsTest.java
@@ -1,0 +1,90 @@
+package com.walmartlabs.concord.server.process;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StateManagerUtilsTest {
+
+    @Test
+    void testFilterWithJsonFile() throws Exception {
+        String jsonInput = "{\"arguments\": \"value\", \"otherKey\": \"otherValue\"}";
+        InputStream inputStream = new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
+
+        InputStream result = StateManagerUtils.filter("_main.json", inputStream);
+        String text = new String(result.readAllBytes(), StandardCharsets.UTF_8);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> resultMap = mapper.readValue(text, Map.class);
+
+        assertEquals(1, resultMap.size());
+        assertEquals("value", resultMap.get("arguments"));
+    }
+
+    @Test
+    void testFilterWithYamlFile() throws Exception {
+        String yamlInput = "arguments: value\notherKey: otherValue";
+        InputStream inputStream = new ByteArrayInputStream(yamlInput.getBytes(StandardCharsets.UTF_8));
+
+        InputStream result = StateManagerUtils.filter("test.yaml", inputStream);
+
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        Map<String, Object> resultMap = mapper.readValue(result, Map.class);
+
+        // return the same if to filter items not present
+        assertEquals(2, resultMap.size());
+        assertEquals("otherValue", resultMap.get("otherKey"));
+    }
+
+    @Test
+    void testFilterWithUnsupportedExtension() throws Exception {
+        String input = "key: value";
+        InputStream inputStream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+
+        InputStream result = StateManagerUtils.filter("file.txt", inputStream);
+        String text = new String(result.readAllBytes(), StandardCharsets.UTF_8);
+
+        assertEquals(input, text);
+    }
+
+    // Test case for empty input
+    @Test
+    void testFilterWithEmptyInput() throws Exception {
+        String input = "";
+        InputStream inputStream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+
+        InputStream result = StateManagerUtils.filter("_main.json", inputStream);
+        String text = new String(result.readAllBytes(), StandardCharsets.UTF_8);
+
+        assertEquals(input, text);
+    }
+
+    // Test case for null filtering rules
+    @Test
+    void testFilterWithNullRules() throws Exception {
+        String jsonInput = "{\"key\": \"value\"}";
+        InputStream inputStream = new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
+
+        InputStream result = StateManagerUtils.filter("unknown.json", inputStream);
+        String text = new String(result.readAllBytes(), StandardCharsets.UTF_8);
+
+        assertEquals(jsonInput, text);
+    }
+
+    // Test case for null input
+    @Test
+    void testFilterWithNullInput() throws Exception {
+        String jsonInput = "{\"key\": \"value\"}";
+        InputStream inputStream = null;
+        InputStream result = StateManagerUtils.filter("unknown.json", inputStream);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
- Currently _main.json has additional data like `defaultTaskVariables` which might contain sensitive data which will be open to access for all when download state of the process. 
- Soln: add filters to restrict only non sensitive fields to such state downloads