### PR TITLE
server: handle invalid regex in dispatcher requirements

### DIFF
--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/processRequirements/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/processRequirements/concord.yml
@@ -1,0 +1,15 @@
+configuration:
+  requirements:
+    agent:
+      type: "t.*t"
+
+profiles:
+  invalidRegex:
+    configuration:
+      requirements:
+        agent:
+          type: "*test*"
+
+flows:
+  default:
+    - log: "Hello from a process with requirements!"

--- a/server/impl/pom.xml
+++ b/server/impl/pom.xml
@@ -322,6 +322,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
@@ -1,0 +1,68 @@
+package com.walmartlabs.concord.server.process.queue.dispatcher;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.process.queue.ProcessQueueEntry;
+import com.walmartlabs.concord.server.queueclient.message.ProcessRequest;
+import com.walmartlabs.concord.server.sdk.ProcessKey;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DispatcherTest {
+
+    private static List<Dispatcher.Request> requests;
+
+    @BeforeAll
+    static void setup() {
+        var request = new ProcessRequest(Map.of("flavor", "default"));
+        requests = List.of(new Dispatcher.Request(null, request));
+    }
+
+    @Test
+    void testInvalidInvalidRegex() {
+        var candidate = generateCandidate("*invalidRegex*");
+        assertNull(Dispatcher.findRequest(candidate, requests));
+    }
+
+    @Test
+    void testValid() {
+        var candidate = generateCandidate(".*default.*");
+        assertNotNull(Dispatcher.findRequest(candidate, requests));
+    }
+
+    private static ProcessQueueEntry generateCandidate(String flavor) {
+        return ProcessQueueEntry.builder()
+                .requirements(Map.of(
+                        "agent", Map.of(
+                                "flavor", List.of(flavor)
+                        )
+                ))
+                .key(ProcessKey.random())
+                .build();
+    }
+
+}

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.server.process.queue.dispatcher;
 import com.walmartlabs.concord.server.process.queue.ProcessQueueEntry;
 import com.walmartlabs.concord.server.queueclient.message.ProcessRequest;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,9 @@ class DispatcherTest {
     @Mock
     private Dispatcher.RequirementsMatcherErrorHandler errHandler;
 
+    @Mock
+    private DSLContext tx;
+
     @BeforeAll
     static void setup() {
         var request = new ProcessRequest(Map.of("flavor", "default"));
@@ -55,15 +59,15 @@ class DispatcherTest {
     @Test
     void testInvalidInvalidRegex() {
         var candidate = generateCandidate("*invalidRegex*");
-        assertNull(Dispatcher.findRequest(candidate, requests, errHandler));
-        verify(errHandler, times(1)).handle(any(), any());
+        assertNull(Dispatcher.findRequest(candidate, requests, tx, errHandler));
+        verify(errHandler, times(1)).handleError(any(), any(), any());
     }
 
     @Test
     void testValid() {
         var candidate = generateCandidate(".*default.*");
-        assertNotNull(Dispatcher.findRequest(candidate, requests, errHandler));
-        verify(errHandler, times(0)).handle(any(), any());
+        assertNotNull(Dispatcher.findRequest(candidate, requests, tx, errHandler));
+        verify(errHandler, times(0)).handleError(any(), any(), any());
     }
 
     private static ProcessQueueEntry generateCandidate(String flavor) {

--- a/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
+++ b/server/impl/src/test/java/com/walmartlabs/concord/server/process/queue/dispatcher/DispatcherTest.java
@@ -25,16 +25,26 @@ import com.walmartlabs.concord.server.queueclient.message.ProcessRequest;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class DispatcherTest {
 
     private static List<Dispatcher.Request> requests;
+
+    @Mock
+    private Dispatcher.RequirementsMatcherErrorHandler errHandler;
 
     @BeforeAll
     static void setup() {
@@ -45,13 +55,15 @@ class DispatcherTest {
     @Test
     void testInvalidInvalidRegex() {
         var candidate = generateCandidate("*invalidRegex*");
-        assertNull(Dispatcher.findRequest(candidate, requests));
+        assertNull(Dispatcher.findRequest(candidate, requests, errHandler));
+        verify(errHandler, times(1)).handle(any(), any());
     }
 
     @Test
     void testValid() {
         var candidate = generateCandidate(".*default.*");
-        assertNotNull(Dispatcher.findRequest(candidate, requests));
+        assertNotNull(Dispatcher.findRequest(candidate, requests, errHandler));
+        verify(errHandler, times(0)).handle(any(), any());
     }
 
     private static ProcessQueueEntry generateCandidate(String flavor) {


### PR DESCRIPTION
A bad regex in a process request's agent requirements can completely halt the queue dispatcher since one exception causes the entire run to fail.

This change handles an exception per matching attempt so the dispatcher can carry on if any requests are catastrophically invalid. The process(es) with non-processable requirements are `FAILED`.

![Screenshot 2025-04-24 at 12 07 14 PM](https://github.com/user-attachments/assets/787aa36a-e3e8-4581-a090-4b0a15bcfb16)
