### PR TITLE
concord-agent, concord-agent-operator: better shutdown hook, handle SIGTERM

### DIFF
--- a/agent-operator/README.md
+++ b/agent-operator/README.md
@@ -49,7 +49,7 @@ present in your minikube instance):
 5. Create the custom resource:
   ```
   $ minikube kubectl -- create -f deploy/crds/crd.yml -n default
-  $ minikube kubectl -- create -f deploy/crds/cr.yml -n default
+  $ minikube kubectl -- create -f deploy/crds/example.agentpool.yml -n default
   ```
 6. Start the operator:
   ```
@@ -103,7 +103,7 @@ minikube kubectl -- logs -f <pod_name> -c <container_name> -n default
   $ minikube kubectl -- create -f deploy/operator.yml
   ```
 4. Check the operator's pod logs;
-5. Deploy one or more CRs using `deploy/crds/cr.yml` as a template.
+5. Deploy one or more CRs using `deploy/crds/example.agentpool.yml` as a template.
 
 ## How To Release New Versions
 

--- a/agent-operator/deploy/crds/cr.yml
+++ b/agent-operator/deploy/crds/cr.yml
@@ -116,10 +116,10 @@ spec:
               name: process-tmp
           resources:
             requests:
-              cpu: "1"
+              cpu: 1
               memory: "1G"
             limits:
-              cpu: "2"
+              cpu: 2
               memory: "2G"
           env:
             - name: CONCORD_TMP_DIR

--- a/agent-operator/deploy/crds/example.agentpool.yml
+++ b/agent-operator/deploy/crds/example.agentpool.yml
@@ -12,7 +12,7 @@
 apiVersion: concord.walmartlabs.com/v1alpha1
 kind: AgentPool
 metadata:
-  name: example-agentpool
+  name: example
 spec:
   queueSelector:
     agent:
@@ -150,7 +150,7 @@ spec:
             preStop:
               exec:
                 command:
-                  - "sh"
+                  - "/bin/bash"
                   - "/opt/concord/hooks/preStopHook.sh"
       volumes:
         - name: cfg

--- a/agent-operator/src/main/java/com/walmartlabs/concord/agentoperator/Operator.java
+++ b/agent-operator/src/main/java/com/walmartlabs/concord/agentoperator/Operator.java
@@ -20,8 +20,6 @@ package com.walmartlabs.concord.agentoperator;
  * =====
  */
 
-
-import com.walmartlabs.concord.agentoperator.agent.AgentClientFactory;
 import com.walmartlabs.concord.agentoperator.crd.AgentPool;
 import com.walmartlabs.concord.agentoperator.crd.AgentPoolList;
 import com.walmartlabs.concord.agentoperator.scheduler.AutoScalerFactory;

--- a/agent-operator/src/main/java/com/walmartlabs/concord/agentoperator/scheduler/DefaultAutoScaler.java
+++ b/agent-operator/src/main/java/com/walmartlabs/concord/agentoperator/scheduler/DefaultAutoScaler.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 public class DefaultAutoScaler implements AutoScaler {
@@ -93,7 +92,8 @@ public class DefaultAutoScaler implements AutoScaler {
 
         AgentPoolConfiguration cfg = i.getResource().getSpec();
 
-        if (!canBeScaledUp.apply(i) && !canBeScaledDown.apply(i)) {
+        boolean canBeScaled = canBeScaledUp.apply(i) || canBeScaledDown.apply(i);
+        if (!canBeScaled) {
             // was updated recently, skipping
             return i;
         }
@@ -222,7 +222,6 @@ public class DefaultAutoScaler implements AutoScaler {
     private static int getProcessCount(AgentPoolConfiguration cfg, List<ProcessQueueEntry> processQueueEntries) {
         return (int) processQueueEntries.stream()
                 .map(ProcessQueueEntry::getRequirements)
-                .filter(Objects::nonNull)
                 .filter(a -> isEmpty(cfg.getQueueSelector()) || Matcher.matches(a, cfg.getQueueSelector()))
                 .count();
     }

--- a/agent-operator/src/main/resources/prestop-hook.sh
+++ b/agent-operator/src/main/resources/prestop-hook.sh
@@ -1,25 +1,35 @@
-workers="1"
-num_retries=0
+#!/usr/bin/env bash
+
+echo "PreStop hook started at $(date)"
+
 MAX_RETRIES=5
+RETRY_DELAY=1
 
-while [ "$workers" != "0" ] && [ "$num_retries" -lt "$MAX_RETRIES" ]
+current_workers="1"
+num_retries=0
+
+while [ "$current_workers" != "0" ] && [ "$num_retries" -lt "$MAX_RETRIES" ]
 do
-  echo "[$HOSTNAME]: Agent is still executing a process.. enabling maintenance mode and checking the number of workers"
-  mmode_response=`wget -qO - --post-data="" http://127.0.0.1:8010/maintenance-mode`
+  echo "[$HOSTNAME]: Agent is still executing a process.. enabling maintenance mode and checking the number of current_workers"
 
-  mmode_enabled=`echo $mmode_response | sed -n 's/^.*\"maintenanceMode\":\([a-z]*\).*$/\1/p'`
+  response=$(exec 3<>/dev/tcp/127.0.0.1/8010;
+             echo -e "POST /maintenance-mode HTTP/1.1\r\nHost: 127.0.0.1:8010\r\nContent-Length: 0\r\nConnection: close\r\n\r\n" >&3;
+             cat <&3;
+             exec 3>&-)
+
+  mmode_response=$(echo "$response" | sed -n '/^\r*$/,$p' | tail -n +2)
+  mmode_enabled=$(echo "$mmode_response" | sed -n 's/^.*\"maintenanceMode\":\([a-z]*\).*$/\1/p')
+
   if [ "$mmode_enabled" == "true" ]; then
     echo "[$HOSTNAME]: Maintenance mode enabled: $mmode_enabled"
-
-    workers=`echo $mmode_response | sed -n 's/^.*\"workersAlive\":\([0-9]*\).*$/\1/p'`
-    echo "[$HOSTNAME]: Number of workers: $workers"
-
+    current_workers=$(echo "$mmode_response" | sed -n 's/^.*\"workersAlive\":\([0-9]*\).*$/\1/p')
+    echo "[$HOSTNAME]: Number of current_workers: $current_workers"
   else
     echo "[$HOSTNAME]: trouble enabling maintenance mode"
-    num_retries=`expr $num_retries + 1`
+    num_retries=$(("$num_retries" + 1))
   fi
 
-sleep 5
+  sleep ${RETRY_DELAY}
 done
 
 if [ "$num_retries" -ge "$MAX_RETRIES" ]; then

--- a/agent/src/main/java/com/walmartlabs/concord/agent/Agent.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/Agent.java
@@ -77,16 +77,25 @@ public class Agent {
     }
 
     public void start() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Received SIGTERM, stopping...");
+            Agent.this.stop();
+        }, "shutdown-hook"));
+
         executor.submit(() -> {
             run();
             return null;
         });
+
+        log.info("start -> done");
     }
 
     @SuppressWarnings("unused")
     public void stop() {
         queueClient.stop();
         executor.shutdownNow();
+
+        log.info("stop -> done");
     }
 
     private void run() throws Exception {


### PR DESCRIPTION
Fix handling of processes with empty `requirements` when using empty `queueSelector` in agent pools.
Replace wget usage in prestop-hook.sh with a Bash-only version.
Explicitly handle SIGTERM in the agent for faster termination in k8s environment.