### PR TITLE
project: enable full annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,9 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
+                <configuration>
+                    <compilerArgs>-proc:full</compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
To get rid of the Maven warning about the annotation processing not being explicitly enabled.