### PR TITLE
runtime-v2, concord-cli: add support for resources.concordCli

### DIFF
--- a/common/src/main/java/com/walmartlabs/concord/common/ResourceUtils.java
+++ b/common/src/main/java/com/walmartlabs/concord/common/ResourceUtils.java
@@ -1,0 +1,154 @@
+package com.walmartlabs.concord.common;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.sdk.Constants;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class ResourceUtils {
+
+    public static void copyResources(Path baseDir, List<String> includePatterns, Path destDir, CopyOption... options) throws IOException {
+        copyResources(baseDir, includePatterns, List.of(), destDir, null, options);
+    }
+
+    /**
+     * Copies Concord resources from baseDir to destDir.
+     * @param baseDir source
+     * @param includePatterns list of paths (glob, regexes, file paths) to include
+     * @param excludePatterns list of paths (glob, regexes, file paths) to exclude
+     * @param destDir destination
+     * @param visitor a FileVisitor to apply after each copied file (can be null)
+     * @param options array of CopyOptions
+     * @throws IOException
+     */
+    public static void copyResources(Path baseDir, List<String> includePatterns, List<String> excludePatterns, Path destDir, FileVisitor visitor, CopyOption... options) throws IOException {
+        var paths = findResources(baseDir, includePatterns, excludePatterns);
+        for (var fileName : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
+            var p = baseDir.resolve(fileName);
+            paths.add(p);
+        }
+        copy(paths, baseDir, destDir, visitor, options);
+    }
+
+    public static List<Path> findResources(Path baseDir, List<String> includePatterns) throws IOException {
+        return findResources(baseDir, includePatterns, List.of());
+    }
+
+    /**
+     * Finds paths in baseDir that match includePatterns and do not match excludePatterns.
+     * @param baseDir source
+     * @param includePatterns list of paths (glob, regexes, file paths) to include
+     * @param excludePatterns list of paths (glob, regexes, file paths) to exclude
+     * @return list of absolute paths
+     * @throws IOException
+     */
+    public static List<Path> findResources(Path baseDir, List<String> includePatterns, List<String> excludePatterns) throws IOException {
+        var result = new ArrayList<Path>();
+
+        var includeMatchers = includePatterns.stream().map(p -> parsePattern(baseDir, p)).toList();
+        var excludeMatchers = excludePatterns.stream().map(p -> parsePattern(baseDir, p)).toList();
+
+        try (var walker = Files.walk(baseDir)) {
+            walker.filter(candidate -> !Files.isDirectory(candidate))
+                    .filter(candidate ->
+                            includeMatchers.stream().anyMatch(m -> m.matches(candidate)) &&
+                            excludeMatchers.stream().noneMatch(pattern -> pattern.matches(candidate)))
+                    .forEach(result::add);
+        }
+
+        return result;
+    }
+
+    private static void copy(Collection<Path> files, Path baseDir, Path dest, FileVisitor visitor, CopyOption... options) throws IOException {
+        for (var f : files) {
+            if (Files.notExists(f)) {
+                continue;
+            }
+
+            var src = baseDir.relativize(f);
+            var dst = dest.resolve(src);
+
+            var dstParent = dst.getParent();
+            if (dstParent != null && Files.notExists(dstParent)) {
+                Files.createDirectories(dstParent);
+            }
+
+            if (Files.isSymbolicLink(f)) {
+                Path link = Files.readSymbolicLink(f);
+                Path target = f.getParent().resolve(link).normalize();
+
+                if (!target.startsWith(baseDir)) {
+                    throw new IOException("Symlinks outside the base directory are not supported: " + baseDir + " -> " + target);
+                }
+
+                if (Files.notExists(target)) {
+                    continue;
+                }
+
+                Files.createSymbolicLink(dst, link);
+            } else {
+                Files.copy(f, dst, options);
+            }
+
+            if (visitor != null) {
+                visitor.visit(src, dst);
+            }
+        }
+    }
+
+    static PathMatcher parsePattern(Path baseDir, String pattern) {
+        pattern = pattern.trim();
+
+        String normalizedPattern;
+        if (pattern.startsWith("glob:")) {
+            normalizedPattern = "glob:" + concat(baseDir, pattern.substring("glob:".length()));
+        } else if (pattern.startsWith("regex:")) {
+            normalizedPattern = "regex:" + concat(baseDir, pattern.substring("regex:".length()));
+        } else {
+            normalizedPattern = "glob:" + concat(baseDir, pattern
+                    .replace("*", "\\*")
+                    .replace("{", "\\{")
+                    .replace("}", "\\}")
+                    .replace("[", "\\[")
+                    .replace("]", "\\]")
+                    .replace("!", "\\!")
+                    .replace("?", "\\?"));
+        }
+
+        return FileSystems.getDefault().getPathMatcher(normalizedPattern);
+    }
+
+    private static String concat(Path path, String str) {
+        var separator = "/";
+        if (str.startsWith("/")) {
+            separator = "";
+        }
+        return path.toAbsolutePath() + separator + str;
+    }
+
+    private ResourceUtils() {
+    }
+}

--- a/common/src/test/java/com/walmartlabs/concord/common/ResourceUtilTest.java
+++ b/common/src/test/java/com/walmartlabs/concord/common/ResourceUtilTest.java
@@ -1,0 +1,54 @@
+package com.walmartlabs.concord.common;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResourceUtilTest {
+
+    @Test
+    public void testParsePattern() {
+        var baseDir = Paths.get("/tmp/foo");
+
+        var pattern = ResourceUtils.parsePattern(baseDir, "glob:*.txt");
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/bar.txt")));
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/bar!.txt")));
+        assertFalse(pattern.matches(Paths.get("/tmp/foo/baz.tmp")));
+
+        pattern = ResourceUtils.parsePattern(baseDir, "glob:concord/{**/,}{*.,}concord.{yml,yaml}");
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/concord/foo.concord.yml")));
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/concord/bar.concord.yaml")));
+        assertFalse(pattern.matches(Paths.get("/tmp/foo/qux.concord.yaml")));
+
+        pattern = ResourceUtils.parsePattern(baseDir, "regex:.*\\.qux");
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/bar.qux")));
+        assertFalse(pattern.matches(Paths.get("/tmp/foo/qux")));
+
+        pattern = ResourceUtils.parsePattern(baseDir, "baz.txt");
+        assertTrue(pattern.matches(Paths.get("/tmp/foo/baz.txt")));
+        assertFalse(pattern.matches(Paths.get("/tmp/foo/qux.txt")));
+    }
+}

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Resources.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/model/Resources.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 
 @Value.Immutable
@@ -38,14 +37,57 @@ import java.util.List;
 @JsonDeserialize(as = ImmutableResources.class)
 public interface Resources extends Serializable {
 
+    List<String> DEFAULT_CONCORD_RESOURCES = List.of("glob:concord/{**/,}{*.,}concord.{yml,yaml}");
+    List<String> DEFAULT_CONCORD_CLI_INCLUDES = List.of("glob:*", "glob:**/*");
+    List<String> DEFAULT_CONCORD_CLI_EXCLUDES = List.of("glob:target/**");
+
     long serialVersionUID = 1L;
 
+    /**
+     * List of files (glob patterns, regexes or plain paths) that the runtime uses.
+     * By default, the runtime loads the root concord.yaml or .yml file and all files in concord/ subdirectory
+     * with the .concord.y?ml extension.
+     */
     @Value.Default
     default List<String> concord() {
-        return Collections.singletonList("glob:concord/{**/,}{*.,}concord.{yml,yaml}");
+        return DEFAULT_CONCORD_RESOURCES;
+    }
+
+    /**
+     * List of files that the CLI copies into the ${workDir} before starting the runtime.
+     * By default, the CLI copies all files in the current directory except for the ./target/ directory.
+     */
+    @Value.Default
+    default ConcordCliResources concordCli() {
+        return ImmutableConcordCliResources.builder().build();
     }
 
     static ImmutableResources.Builder builder() {
         return ImmutableResources.builder();
+    }
+
+    @Value.Immutable
+    @Value.Style(jdkOnly = true)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonSerialize(as = ImmutableConcordCliResources.class)
+    @JsonDeserialize(as = ImmutableConcordCliResources.class)
+    interface ConcordCliResources extends Serializable {
+
+        /**
+         * Include patterns.
+         */
+        @Value.Default
+        default List<String> includes() {
+            return DEFAULT_CONCORD_CLI_INCLUDES;
+        }
+
+        /**
+         * Exclude patterns.
+         */
+        @Value.Default
+        default List<String> excludes() {
+            return DEFAULT_CONCORD_CLI_EXCLUDES;
+        }
     }
 }

--- a/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ResourcesGrammar.java
+++ b/runtime/v2/model/src/main/java/com/walmartlabs/concord/runtime/v2/parser/ResourcesGrammar.java
@@ -21,8 +21,10 @@ package com.walmartlabs.concord.runtime.v2.parser;
  */
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.walmartlabs.concord.runtime.v2.model.ImmutableConcordCliResources;
 import com.walmartlabs.concord.runtime.v2.model.ImmutableResources;
 import com.walmartlabs.concord.runtime.v2.model.Resources;
+import com.walmartlabs.concord.runtime.v2.model.Resources.ConcordCliResources;
 import io.takari.parc.Parser;
 
 import static com.walmartlabs.concord.runtime.v2.parser.GrammarMisc.*;
@@ -32,11 +34,20 @@ import static com.walmartlabs.concord.runtime.v2.parser.GrammarV2.stringArrayVal
 
 public final class ResourcesGrammar {
 
+    private static final Parser<Atom, ConcordCliResources> concordCliResources =
+            betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
+                    with(ImmutableConcordCliResources::builder,
+                            o -> options(
+                                    optional("includes", stringArrayVal.map(o::includes)),
+                                    optional("excludes", stringArrayVal.map(o::excludes))))
+                            .map(ImmutableConcordCliResources.Builder::build));
+
     private static final Parser<Atom, Resources> resources =
             betweenTokens(JsonToken.START_OBJECT, JsonToken.END_OBJECT,
                     with(ImmutableResources::builder,
                             o -> options(
-                                    optional("concord", stringArrayVal.map(o::concord))))
+                                    optional("concord", stringArrayVal.map(o::concord)),
+                                    optional("concordCli", concordCliResources.map(o::concordCli))))
                             .map(ImmutableResources.Builder::build));
 
     public static final Parser<Atom, Resources> resourcesVal =

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -2305,7 +2305,7 @@ public class YamlErrorParserTest extends AbstractParserTest {
 
     @Test
     public void test1801() throws Exception {
-        String msg = "(001.yml): Error @ line: 3, col: 5. Unknown options: ['trash' [ARRAY] @ line: 3, col: 5], expected: [concord]. Remove invalid options and/or fix indentation\n" +
+        String msg = "(001.yml): Error @ line: 3, col: 5. Unknown options: ['trash' [ARRAY] @ line: 3, col: 5], expected: [concord, concordCli]. Remove invalid options and/or fix indentation\n" +
                 "\twhile processing steps:\n" +
                 "\t'resources' @ line: 1, col: 1";
 

--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlOkParserTest.java
@@ -497,12 +497,18 @@ public class YamlOkParserTest extends AbstractParserTest {
     public void test015() throws Exception {
         ProcessDefinition pd = load("015.yml");
 
-        Resources resources = pd.resources();
-        assertEquals(3, resources.concord().size());
+        List<String> concordResources = pd.resources().concord();
+        assertEquals(3, concordResources.size());
+        assertEquals("glob:abc", concordResources.get(0));
+        assertEquals("regex:boo", concordResources.get(1));
+        assertEquals("concord/myfile.yml", concordResources.get(2));
 
-        assertEquals("glob:abc", resources.concord().get(0));
-        assertEquals("regex:boo", resources.concord().get(1));
-        assertEquals("concord/myfile.yml", resources.concord().get(2));
+        Resources.ConcordCliResources cliResources = pd.resources().concordCli();
+        assertEquals(2, cliResources.includes().size());
+        assertEquals("glob:*.foo", cliResources.includes().get(0));
+        assertEquals("bar.baz", cliResources.includes().get(1));
+        assertEquals(1, cliResources.excludes().size());
+        assertEquals("qux", cliResources.excludes().get(0));
     }
 
     // set variables definition

--- a/runtime/v2/model/src/test/resources/015.yml
+++ b/runtime/v2/model/src/test/resources/015.yml
@@ -3,3 +3,9 @@ resources:
     - "glob:abc"
     - "regex:boo"
     - "concord/myfile.yml"
+  concordCli:
+    includes:
+      - "glob:*.foo"
+      - "bar.baz"
+    excludes:
+      - "qux"

--- a/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
+++ b/runtime/v2/model/src/test/resources/serializer/processDefinition.yml
@@ -55,3 +55,9 @@ forms:
 resources:
   concord:
   - "glob:concord/{**/,}{*.,}concord.{yml,yaml}"
+  concordCli:
+    includes:
+    - "glob:*"
+    - "glob:**/*"
+    excludes:
+    - "glob:target/**"


### PR DESCRIPTION
Adds support for

```yaml
resources:
  concordCli:
    includes:
      - "glob:..."
      - "regex:..."
      - "path"
    excludes:      
      - "glob:..."
      - "regex:..."
      - "path"
```

syntax. Useful for running concord-cli in monorepos with GBs of files. Can be extended to support .gitignore in future.