### PR TITLE
project: fix concord-runner-v2 test discovery

### DIFF
--- a/it/runtime-v2/pom.xml
+++ b/it/runtime-v2/pom.xml
@@ -107,6 +107,16 @@
             <artifactId>groovy-all</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test-junit5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Node Roster stuff -->

--- a/runtime/v2/runner-test/pom.xml
+++ b/runtime/v2/runner-test/pom.xml
@@ -69,6 +69,16 @@
             <artifactId>groovy-all</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test-junit5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/runtime/v2/runner/pom.xml
+++ b/runtime/v2/runner/pom.xml
@@ -249,6 +249,16 @@
             <artifactId>groovy-all</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-test-junit5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImplTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/context/ResumeEventImplTest.java
@@ -21,7 +21,7 @@ package com.walmartlabs.concord.runtime.v2.runner.context;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptorTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/tasks/TaskCallInterceptorTest.java
@@ -22,7 +22,7 @@ package com.walmartlabs.concord.runtime.v2.runner.tasks;
 
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallInterceptor.Method;
 import com.walmartlabs.concord.runtime.v2.sdk.Task;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
Fix test discovery (and test skipping)
```
10:04:02 [INFO ] [INFO] --- maven-surefire-plugin:3.0.0-M5:test (default-test) @ concord-runner-v2 ---
10:04:02 [INFO ] [INFO] 
10:04:02 [INFO ] [INFO] -------------------------------------------------------
10:04:02 [INFO ] [INFO]  T E S T S
10:04:02 [INFO ] [INFO] -------------------------------------------------------
10:04:03 [ERROR] May 02, 2025 3:04:03 PM org.junit.platform.launcher.core.DefaultLauncher handleThrowable
10:04:03 [ERROR] WARNING: TestEngine with ID 'junit-jupiter' failed to discover tests
10:04:03 [ERROR] java.lang.NoClassDefFoundError: org/junit/platform/engine/support/discovery/SelectorResolver
```