### PR TITLE
project: update testcontainers-concord version

### DIFF
--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -123,7 +123,7 @@
         <snakeyaml.version>2.3</snakeyaml.version>
         <sshd.version>2.15.0</sshd.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
-        <testcontainers.concord.version>2.0.1</testcontainers.concord.version>
+        <testcontainers.concord.version>2.0.3</testcontainers.concord.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <threetenbp.version>1.3.5</threetenbp.version>
         <uuid.generator.version>5.1.0</uuid.generator.version>


### PR DESCRIPTION
Fixes compatibility with Concord 2.25.0+ wrt to the removed `acceptsRawPayload` property.