### PR TITLE
concord-server: use ProjectLoader interface, bind explicitly

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
@@ -24,8 +24,8 @@ import com.walmartlabs.concord.cli.lint.*;
 import com.walmartlabs.concord.cli.lint.LintResult.Type;
 import com.walmartlabs.concord.cli.runner.CliImportsListener;
 import com.walmartlabs.concord.imports.NoopImportManager;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.process.loader.ProjectLoader;
-import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.process.loader.model.SourceMap;
 import picocli.CommandLine.Command;
@@ -66,7 +66,7 @@ public class Lint implements Callable<Integer> {
             throw new IllegalArgumentException("Not a directory: " + targetDir);
         }
 
-        ProjectLoader loader = new ProjectLoader(ProjectLoaderConfiguration.defaultConfiguration(), new NoopImportManager());
+        ProjectLoader loader = new ConcordProjectLoader(new NoopImportManager());
         ProcessDefinition pd = loader.loadProject(targetDir, new DummyImportsNormalizer(), verbose ? new CliImportsListener() : null).projectDefinition();
 
         List<LintResult> lintResults = new ArrayList<>();

--- a/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ConcordProjectLoader.java
+++ b/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ConcordProjectLoader.java
@@ -1,0 +1,180 @@
+package com.walmartlabs.concord.process.loader;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.walmartlabs.concord.imports.ImportManager;
+import com.walmartlabs.concord.imports.ImportsListener;
+import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
+import com.walmartlabs.concord.process.loader.v1.ProcessDefinitionV1;
+import com.walmartlabs.concord.process.loader.v2.ProcessDefinitionV2;
+import com.walmartlabs.concord.repository.Snapshot;
+import com.walmartlabs.concord.runtime.v2.model.ImmutableProcessDefinition;
+import com.walmartlabs.concord.sdk.Constants;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Handles loading of supported Concord project files.
+ */
+public class ConcordProjectLoader implements ProjectLoader {
+
+    public static final String CONCORD_V1_RUNTIME_TYPE = "concord-v1";
+    public static final String CONCORD_V2_RUNTIME_TYPE = "concord-v2";
+
+    private final Configuration cfg;
+    private final com.walmartlabs.concord.project.ProjectLoader v1;
+    private final com.walmartlabs.concord.runtime.v2.ProjectLoaderV2 v2;
+
+    @Inject
+    public ConcordProjectLoader(Configuration cfg, ImportManager importManager) {
+        this.cfg = cfg;
+        this.v1 = new com.walmartlabs.concord.project.ProjectLoader(importManager);
+        this.v2 = new com.walmartlabs.concord.runtime.v2.ProjectLoaderV2(importManager);
+    }
+
+    public ConcordProjectLoader(ImportManager importManager) {
+        this(Configuration.defaultConfiguration(), importManager);
+    }
+
+    @Override
+    public Result loadProject(Path workDir, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception {
+        String runtime = getRuntimeType(workDir, CONCORD_V1_RUNTIME_TYPE); // TODO constants
+        return loadProject(workDir, runtime, importsNormalizer, listener);
+    }
+
+    @Override
+    public Result loadProject(Path workDir, String runtime, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception {
+        if (runtime == null) {
+            runtime = CONCORD_V1_RUNTIME_TYPE;
+        }
+
+        if (CONCORD_V2_RUNTIME_TYPE.equals(runtime)) {
+            return toResult(v2.load(workDir, importsNormalizer::normalize, listener));
+        } else if (CONCORD_V1_RUNTIME_TYPE.equals(runtime)) {
+            return toResult(v1.loadProject(workDir, importsNormalizer::normalize, listener));
+        } else {
+            if (cfg.extraRuntimes().contains(runtime)) {
+                return basicRuntime();
+            }
+            throw new UnsupportedRuntimeTypeException(runtime);
+        }
+    }
+
+    private static Result toResult(com.walmartlabs.concord.project.ProjectLoader.Result r) {
+        List<Snapshot> snapshots = r.getSnapshots();
+        ProcessDefinition pd = new ProcessDefinitionV1(r.getProjectDefinition());
+
+        return new Result() {
+            @Override
+            public List<Snapshot> snapshots() {
+                return snapshots;
+            }
+
+            @Override
+            public ProcessDefinition projectDefinition() {
+                return pd;
+            }
+        };
+    }
+
+    private static Result toResult(com.walmartlabs.concord.runtime.v2.ProjectLoaderV2.Result r) {
+        List<Snapshot> snapshots = r.getSnapshots();
+        ProcessDefinition pd = new ProcessDefinitionV2(r.getProjectDefinition());
+
+        return new Result() {
+            @Override
+            public List<Snapshot> snapshots() {
+                return snapshots;
+            }
+
+            @Override
+            public ProcessDefinition projectDefinition() {
+                return pd;
+            }
+        };
+    }
+
+    private static Result basicRuntime() {
+        return new Result() {
+            @Override
+            public List<Snapshot> snapshots() {
+                return List.of();
+            }
+
+            @Override
+            public ProcessDefinition projectDefinition() {
+                return new ProcessDefinitionV2(
+                        ImmutableProcessDefinition.builder()
+                                .build());
+            }
+        };
+    }
+
+    public static boolean isConcordFileExists(Path path) {
+
+        return com.walmartlabs.concord.project.ProjectLoader.isConcordFileExists(path);
+    }
+
+    public static String getRuntimeType(Path workDir, String defaultType) throws IOException {
+        for (String filename : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
+            Path src = workDir.resolve(filename);
+            if (Files.exists(src)) {
+                ObjectMapper om = new ObjectMapper(new YAMLFactory());
+                try (InputStream in = Files.newInputStream(src)) {
+                    JsonNode n = om.readTree(in);
+
+                    n = n.get(Constants.Request.CONFIGURATION_KEY);
+                    if (n == null) {
+                        continue;
+                    }
+
+                    n = n.get(Constants.Request.RUNTIME_KEY);
+                    if (n == null) {
+                        continue;
+                    }
+
+                    String s = n.textValue();
+                    if (s != null) {
+                        return s;
+                    }
+                }
+            }
+        }
+
+        return defaultType;
+    }
+
+    public record Configuration(Set<String> extraRuntimes) {
+
+        public static Configuration defaultConfiguration() {
+            return new Configuration(Set.of());
+        }
+    }
+}

--- a/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ProjectLoader.java
+++ b/runtime/loader/src/main/java/com/walmartlabs/concord/process/loader/ProjectLoader.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.process.loader;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2019 Walmart Inc.
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,164 +20,29 @@ package com.walmartlabs.concord.process.loader;
  * =====
  */
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.walmartlabs.concord.imports.ImportManager;
 import com.walmartlabs.concord.imports.ImportsListener;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
-import com.walmartlabs.concord.process.loader.v1.ProcessDefinitionV1;
-import com.walmartlabs.concord.process.loader.v2.ProcessDefinitionV2;
 import com.walmartlabs.concord.repository.Snapshot;
-import com.walmartlabs.concord.runtime.v2.model.ImmutableProcessDefinition;
-import com.walmartlabs.concord.sdk.Constants;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 
-/**
- * Handles loading of supported Concord project files.
- */
-@Named
-public class ProjectLoader {
+public interface ProjectLoader {
 
-    public static final String CONCORD_V1_RUNTIME_TYPE = "concord-v1";
-    public static final String CONCORD_V2_RUNTIME_TYPE = "concord-v2";
+    /**
+     * Loads the directory as a project. The runtime is detected based on the directory's content.
+     */
+    Result loadProject(Path workDir, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception;
 
-    private final ProjectLoaderConfiguration cfg;
-    private final com.walmartlabs.concord.project.ProjectLoader v1;
-    private final com.walmartlabs.concord.runtime.v2.ProjectLoaderV2 v2;
+    /**
+     * Loads the directory as a project of the specified runtime.
+     */
+    Result loadProject(Path workDir, String runtime, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception;
 
-    @Inject
-    public ProjectLoader(ProjectLoaderConfiguration cfg, ImportManager importManager) {
-        this.cfg = cfg;
-        this.v1 = new com.walmartlabs.concord.project.ProjectLoader(importManager);
-        this.v2 = new com.walmartlabs.concord.runtime.v2.ProjectLoaderV2(importManager);
-    }
-
-    public Result loadProject(Path workDir, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception {
-        String runtime = getRuntimeType(workDir, CONCORD_V1_RUNTIME_TYPE); // TODO constants
-        return loadProject(workDir, runtime, importsNormalizer, listener);
-    }
-
-    public Result loadProject(Path workDir, String runtime, ImportsNormalizer importsNormalizer, ImportsListener listener) throws Exception {
-        if (runtime == null) {
-            runtime = CONCORD_V1_RUNTIME_TYPE;
-        }
-
-        if (CONCORD_V2_RUNTIME_TYPE.equals(runtime)) {
-            return toResult(v2.load(workDir, importsNormalizer::normalize, listener));
-        } else if (CONCORD_V1_RUNTIME_TYPE.equals(runtime)) {
-            return toResult(v1.loadProject(workDir, importsNormalizer::normalize, listener));
-        } else {
-            if (cfg.extraRuntimes().contains(runtime)) {
-                return basicRuntime();
-            }
-            throw new UnsupportedRuntimeTypeException(runtime);
-        }
-    }
-
-    private static Result toResult(com.walmartlabs.concord.project.ProjectLoader.Result r) {
-        List<Snapshot> snapshots = r.getSnapshots();
-        ProcessDefinition pd = new ProcessDefinitionV1(r.getProjectDefinition());
-
-        return new Result() {
-            @Override
-            public List<Snapshot> snapshots() {
-                return snapshots;
-            }
-
-            @Override
-            public ProcessDefinition projectDefinition() {
-                return pd;
-            }
-        };
-    }
-
-    private static Result toResult(com.walmartlabs.concord.runtime.v2.ProjectLoaderV2.Result r) {
-        List<Snapshot> snapshots = r.getSnapshots();
-        ProcessDefinition pd = new ProcessDefinitionV2(r.getProjectDefinition());
-
-        return new Result() {
-            @Override
-            public List<Snapshot> snapshots() {
-                return snapshots;
-            }
-
-            @Override
-            public ProcessDefinition projectDefinition() {
-                return pd;
-            }
-        };
-    }
-
-    private static Result basicRuntime() {
-        return new Result() {
-            @Override
-            public List<Snapshot> snapshots() {
-                return List.of();
-            }
-
-            @Override
-            public ProcessDefinition projectDefinition() {
-                return new ProcessDefinitionV2(
-                        ImmutableProcessDefinition.builder()
-                                .build());
-            }
-        };
-    }
-
-    public static boolean isConcordFileExists(Path path) {
-
-        return com.walmartlabs.concord.project.ProjectLoader.isConcordFileExists(path);
-    }
-
-    public static String getRuntimeType(Path workDir, String defaultType) throws IOException {
-        for (String filename : Constants.Files.PROJECT_ROOT_FILE_NAMES) {
-            Path src = workDir.resolve(filename);
-            if (Files.exists(src)) {
-                ObjectMapper om = new ObjectMapper(new YAMLFactory());
-                try (InputStream in = Files.newInputStream(src)) {
-                    JsonNode n = om.readTree(in);
-
-                    n = n.get(Constants.Request.CONFIGURATION_KEY);
-                    if (n == null) {
-                        continue;
-                    }
-
-                    n = n.get(Constants.Request.RUNTIME_KEY);
-                    if (n == null) {
-                        continue;
-                    }
-
-                    String s = n.textValue();
-                    if (s != null) {
-                        return s;
-                    }
-                }
-            }
-        }
-
-        return defaultType;
-    }
-
-    public interface Result {
+    interface Result {
 
         List<Snapshot> snapshots();
 
         ProcessDefinition projectDefinition();
-    }
-
-    public record ProjectLoaderConfiguration(Set<String> extraRuntimes) {
-
-        public static ProjectLoaderConfiguration defaultConfiguration() {
-            return new ProjectLoaderConfiguration(Set.of());
-        }
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggerResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/triggers/TriggerResource.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.server.org.triggers;
 import com.walmartlabs.concord.common.validation.ConcordKey;
 import com.walmartlabs.concord.imports.ImportsListener;
 import com.walmartlabs.concord.process.loader.ProjectLoader;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.repository.Repository;
 import com.walmartlabs.concord.server.org.OrganizationEntry;
@@ -154,7 +155,7 @@ public class TriggerResource implements Resource {
         try {
             pd = repositoryManager.withLock(repo.getUrl(), () -> {
                 Repository repository = repositoryManager.fetch(repo.getProjectId(), repo);
-                ProjectLoader.Result result = projectLoader.loadProject(repository.path(), importsNormalizerFactory.forProject(repo.getProjectId()), ImportsListener.NOP_LISTENER);
+                ConcordProjectLoader.Result result = projectLoader.loadProject(repository.path(), importsNormalizerFactory.forProject(repo.getProjectId()), ImportsListener.NOP_LISTENER);
                 return result.projectDefinition();
             });
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ConcordProjectLoaderConfigurationProvider.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ConcordProjectLoaderConfigurationProvider.java
@@ -20,7 +20,7 @@ package com.walmartlabs.concord.server.process;
  * =====
  */
 
-import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.server.cfg.ProcessConfiguration;
 
 import javax.inject.Inject;
@@ -28,17 +28,17 @@ import javax.inject.Provider;
 import java.util.Optional;
 import java.util.Set;
 
-public class ProjectLoaderConfigurationProvider implements Provider<ProjectLoaderConfiguration> {
+public class ConcordProjectLoaderConfigurationProvider implements Provider<ConcordProjectLoader.Configuration> {
 
     private final Set<String> extraRuntimes;
 
     @Inject
-    public ProjectLoaderConfigurationProvider(ProcessConfiguration cfg) {
+    public ConcordProjectLoaderConfigurationProvider(ProcessConfiguration cfg) {
         this.extraRuntimes = Optional.ofNullable(cfg.getExtraRuntimes()).map(Set::copyOf).orElse(Set.of());
     }
 
     @Override
-    public ProjectLoaderConfiguration get() {
-        return new ProjectLoaderConfiguration(Set.copyOf(extraRuntimes));
+    public ConcordProjectLoader.Configuration get() {
+        return new ConcordProjectLoader.Configuration(Set.copyOf(extraRuntimes));
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
@@ -23,7 +23,8 @@ package com.walmartlabs.concord.server.process;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.walmartlabs.concord.imports.ImportManager;
-import com.walmartlabs.concord.process.loader.ProjectLoader.ProjectLoaderConfiguration;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
+import com.walmartlabs.concord.process.loader.ProjectLoader;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointResource;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV2Resource;
 import com.walmartlabs.concord.server.process.event.ProcessEventDao;
@@ -74,7 +75,8 @@ public class ProcessModule implements Module {
         binder.bind(ProcessStateManager.class).in(SINGLETON);
         binder.bind(ProcessWaitManager.class).in(SINGLETON);
 
-        binder.bind(ProjectLoaderConfiguration.class).toProvider(ProjectLoaderConfigurationProvider.class);
+        binder.bind(ConcordProjectLoader.Configuration.class).toProvider(ConcordProjectLoaderConfigurationProvider.class);
+        binder.bind(ProjectLoader.class).to(ConcordProjectLoader.class);
 
         bindSingletonScheduledTask(binder, ProcessCleaner.class);
         bindSingletonScheduledTask(binder, ProcessLocksWatchdog.class);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ProcessDefinitionProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ProcessDefinitionProcessor.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.imports.Import;
 import com.walmartlabs.concord.imports.ImportProcessingException;
 import com.walmartlabs.concord.imports.ImportsListener;
 import com.walmartlabs.concord.process.loader.ProjectLoader;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.repository.Snapshot;
 import com.walmartlabs.concord.sdk.Constants;
@@ -45,7 +46,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static com.walmartlabs.concord.process.loader.ProjectLoader.CONCORD_V1_RUNTIME_TYPE;
+import static com.walmartlabs.concord.process.loader.ConcordProjectLoader.CONCORD_V1_RUNTIME_TYPE;
 
 /**
  * Loads the process definition using the working directory and configured {@code imports}.
@@ -83,7 +84,7 @@ public class ProcessDefinitionProcessor implements PayloadProcessor {
 
         try {
             String runtime = getRuntimeType(payload);
-            ProjectLoader.Result result = projectLoader.loadProject(workDir, runtime, importsNormalizer.forProject(projectId),
+            ConcordProjectLoader.Result result = projectLoader.loadProject(workDir, runtime, importsNormalizer.forProject(projectId),
                     new ProcessImportsListener(processKey));
 
             List<Snapshot> snapshots = result.snapshots();
@@ -138,7 +139,7 @@ public class ProcessDefinitionProcessor implements PayloadProcessor {
         }
 
         Path workDir = payload.getHeader(Payload.WORKSPACE_DIR);
-        return ProjectLoader.getRuntimeType(workDir, CONCORD_V1_RUNTIME_TYPE);
+        return ConcordProjectLoader.getRuntimeType(workDir, CONCORD_V1_RUNTIME_TYPE);
     }
 
     class ProcessImportsListener implements ImportsListener {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
@@ -23,7 +23,7 @@ package com.walmartlabs.concord.server.repository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
-import com.walmartlabs.concord.process.loader.ProjectLoader;
+import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.repository.*;
 import com.walmartlabs.concord.sdk.Secret;
 import com.walmartlabs.concord.server.cfg.GitConfiguration;
@@ -107,7 +107,7 @@ public class RepositoryManager {
                             .build(), path);
 
             if (repoCfg.isConcordFileValidationEnabled()) {
-                if (!ProjectLoader.isConcordFileExists(repo.path())) {
+                if (!ConcordProjectLoader.isConcordFileExists(repo.path())) {
                     throw new InvalidRepositoryPathException("Invalid repository path: `concord.yml` or `.concord.yml` is missing!");
                 }
             }


### PR DESCRIPTION
Extract ProjectLoader interface out of the current impl + remove `@Named`.

Before this change, RepositoryManager had a hard dependency on a specific implementation of ProjectLoader and was hard coded to treat any repository as a "project" (i.e. containing files for v1, v2 or other supported runtimes).

The change allows simpler testing and re-use in other projects.