### PR TITLE
concord-server: split ProcessSecurityContext

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/events/TriggerProcessExecutor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/events/TriggerProcessExecutor.java
@@ -35,6 +35,7 @@ import com.walmartlabs.concord.server.sdk.PartialProcessKey;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import com.walmartlabs.concord.server.security.Roles;
 import com.walmartlabs.concord.server.security.SecurityUtils;
+import com.walmartlabs.concord.server.security.UserSecurityContext;
 import com.walmartlabs.concord.server.user.UserEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public class TriggerProcessExecutor {
     private final ProcessManager processManager;
     private final RepositoryDao repositoryDao;
     private final ProjectDao projectDao;
-    private final ProcessSecurityContext processSecurityContext;
+    private final UserSecurityContext userSecurityContext;
     private final ExecutorService executor;
 
     @Inject
@@ -72,14 +73,14 @@ public class TriggerProcessExecutor {
                                   ProcessManager processManager,
                                   RepositoryDao repositoryDao,
                                   ProjectDao projectDao,
-                                  ProcessSecurityContext processSecurityContext) {
+                                  UserSecurityContext userSecurityContext) {
 
         this.eventsCfg = eventsCfg;
         this.triggersCfg = triggersCfg;
         this.processManager = processManager;
         this.repositoryDao = repositoryDao;
         this.projectDao = projectDao;
-        this.processSecurityContext = processSecurityContext;
+        this.userSecurityContext = userSecurityContext;
         this.executor = createExecutor(eventsCfg.getWorkerThreads());
     }
 
@@ -209,7 +210,7 @@ public class TriggerProcessExecutor {
 
         PartialProcessKey processKey = PartialProcessKey.create();
 
-        processSecurityContext.runAs(initiator.getId(), () -> {
+        userSecurityContext.runAs(initiator.getId(), () -> {
             Payload payload = PayloadBuilder.start(processKey)
                     .initiator(initiator.getId(), initiator.getName())
                     .organization(orgId)

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueWatchdog.java
@@ -37,6 +37,7 @@ import com.walmartlabs.concord.server.sdk.PartialProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import com.walmartlabs.concord.server.sdk.ScheduledTask;
+import com.walmartlabs.concord.server.security.UserSecurityContext;
 import com.walmartlabs.concord.server.user.UserDao;
 import org.jooq.*;
 import org.slf4j.Logger;
@@ -111,7 +112,7 @@ public class ProcessQueueWatchdog implements ScheduledTask {
     private final PayloadManager payloadManager;
     private final ProcessManager processManager;
     private final ProcessQueueManager queueManager;
-    private final ProcessSecurityContext processSecurityContext;
+    private final UserSecurityContext userSecurityContext;
 
     @Inject
     public ProcessQueueWatchdog(ProcessWatchdogConfiguration cfg,
@@ -123,7 +124,7 @@ public class ProcessQueueWatchdog implements ScheduledTask {
                                 PayloadManager payloadManager,
                                 ProcessManager processManager,
                                 ProcessQueueManager queueManager,
-                                ProcessSecurityContext processSecurityContext) {
+                                UserSecurityContext userSecurityContext) {
         this.cfg = cfg;
 
         this.queueDao = queueDao;
@@ -134,7 +135,7 @@ public class ProcessQueueWatchdog implements ScheduledTask {
         this.payloadManager = payloadManager;
         this.processManager = processManager;
         this.queueManager = queueManager;
-        this.processSecurityContext = processSecurityContext;
+        this.userSecurityContext = userSecurityContext;
     }
 
     @Override
@@ -184,7 +185,7 @@ public class ProcessQueueWatchdog implements ScheduledTask {
                         parent.initiatorId, username, parent.projectId, req, null,
                         null, parent.imports);
 
-                processSecurityContext.runAs(parent.initiatorId, () -> processManager.startFork(payload));
+                userSecurityContext.runAs(parent.initiatorId, () -> processManager.startFork(payload));
 
                 logManager.info(parent.processKey, "{} started: {}", toString(entry.handlerKind), LogTags.instanceId(payload.getProcessKey().getInstanceId()));
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/SecurityModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/SecurityModule.java
@@ -42,6 +42,8 @@ public class SecurityModule implements Module {
 
     @Override
     public void configure(Binder binder) {
+        binder.bind(UserSecurityContext.class);
+
         newSetBinder(binder, AuthenticationHandler.class).addBinding().to(BasicAuthenticationHandler.class).in(SINGLETON);
         newSetBinder(binder, AuthenticationHandler.class).addBinding().to(ApiKeyAuthenticationHandler.class).in(SINGLETON);
         newSetBinder(binder, AuthenticationHandler.class).addBinding().to(SessionTokenAuthenticationHandler.class).in(SINGLETON);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserSecurityContext.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserSecurityContext.java
@@ -1,0 +1,75 @@
+package com.walmartlabs.concord.server.security;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.security.internal.InternalRealm;
+import com.walmartlabs.concord.server.user.UserEntry;
+import com.walmartlabs.concord.server.user.UserManager;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+
+import javax.inject.Inject;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+public class UserSecurityContext {
+
+    private final SecurityManager securityManager;
+    private final UserManager userManager;
+
+    @Inject
+    public UserSecurityContext(SecurityManager securityManager, UserManager userManager) {
+        this.securityManager = securityManager;
+        this.userManager = userManager;
+    }
+
+    /**
+     * Run the specified {@link Callable} as if it was started by another user.
+     */
+    public <T> T runAs(UUID userID, Callable<T> c) throws Exception {
+        UserEntry u = userManager.get(userID).orElse(null);
+        if (u == null) {
+            throw new UnauthorizedException("User '" + userID + "'not found");
+        }
+
+        try {
+            ThreadContext.bind(securityManager);
+
+            SimplePrincipalCollection principals = new SimplePrincipalCollection();
+            principals.add(new UserPrincipal(InternalRealm.REALM_NAME, u), InternalRealm.REALM_NAME);
+
+            Subject subject = new Subject.Builder()
+                    .sessionCreationEnabled(false)
+                    .authenticated(true)
+                    .principals(principals)
+                    .buildSubject();
+
+            ThreadContext.bind(subject);
+
+            return c.call();
+        } finally {
+            ThreadContext.unbindSubject();
+            ThreadContext.unbindSecurityManager();
+        }
+    }
+}


### PR DESCRIPTION
Before this change ProcessSecurityContext was responsible for both runAs (generic "run as this user ID" method) and runAsCurrentUser (i.e. "run as the current user of the specified process ID").

This change separates those concerns. The new UserSecurityContext can be used in situations where there is no notion of processes at all (i.e. testing or re-use in other projects).