### PR TITLE
concord-cli: use jansi, add colors to run output

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -101,6 +101,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -123,21 +128,23 @@
                     <include>**/*</include>
                 </includes>
             </resource>
-            <resource>
+        </resources>
+        <testResources>
+            <testResource>
                 <filtering>false</filtering>
                 <directory>${project.basedir}/src/test/resources</directory>
                 <includes>
                     <include>**/*</include>
                 </includes>
-            </resource>
-            <resource>
+            </testResource>
+            <testResource>
                 <filtering>true</filtering>
                 <directory>${project.basedir}/src/test/filtered-resources</directory>
                 <includes>
                     <include>**/*</include>
                 </includes>
-            </resource>
-        </resources>
+            </testResource>
+        </testResources>
 
         <plugins>
             <plugin>

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Lint.java
@@ -28,8 +28,8 @@ import com.walmartlabs.concord.process.loader.ConcordProjectLoader;
 import com.walmartlabs.concord.process.loader.ProjectLoader;
 import com.walmartlabs.concord.process.loader.model.ProcessDefinition;
 import com.walmartlabs.concord.process.loader.model.SourceMap;
+import org.fusesource.jansi.Ansi;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -42,6 +42,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+
+import static org.fusesource.jansi.Ansi.ansi;
 
 @Command(name = "lint", description = "Parse and validate Concord YAML files")
 public class Lint implements Callable<Integer> {
@@ -91,9 +93,9 @@ public class Lint implements Callable<Integer> {
         println();
         boolean hasErrors = hasErrors(lintResults);
         if (hasErrors) {
-            println("@|red,bold INVALID|@");
+            System.out.println(ansi().fgBrightRed().bold().a("INVALID").reset());
         } else {
-            println("@|green,bold VALID|@");
+            System.out.println(ansi().fgBrightGreen().bold().a("VALID").reset());
         }
 
         return hasErrors ? 10 : 0;
@@ -108,14 +110,14 @@ public class Lint implements Callable<Integer> {
 
     private void print(List<LintResult> results) {
         for (LintResult r : results) {
-            StringBuilder msg = new StringBuilder();
+            Ansi msg = ansi();
             switch (r.getType()) {
                 case ERROR: {
-                    msg.append("@|red ERROR:|@ ");
+                    ansi().fgBrightRed().a("ERROR:").reset();
                     break;
                 }
                 case WARNING: {
-                    msg.append("@|yellow WARN:|@ ");
+                    ansi().fgBrightYellow().a("WARN:").reset();
                     break;
                 }
                 default:
@@ -124,12 +126,12 @@ public class Lint implements Callable<Integer> {
 
             SourceMap sm = r.getSourceMap();
             if (sm != null) {
-                msg.append("@ [").append(sm.source()).append("] line: ").append(sm.line()).append(", col: ").append(sm.column());
+                msg.a("@ [").a(sm.source()).a("] line: ").a(sm.line()).a(", col: ").a(sm.column());
             }
 
             msg.append("\n\t").append(r.getMessage());
 
-            println(msg.toString());
+            println(msg);
             println("------------------------------------------------------------");
         }
     }
@@ -140,12 +142,8 @@ public class Lint implements Callable<Integer> {
         println("Result: " + errors + " error(s), " + warns + " warning(s)");
     }
 
-    private void println(String s) {
-        Ansi ansi = spec.commandLine()
-                .getColorScheme()
-                .ansi();
-
-        System.out.println(ansi.string(s));
+    private void println(Object o) {
+        System.out.println(o);
     }
 
     private void println() {

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Main.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Main.java
@@ -20,11 +20,14 @@ package com.walmartlabs.concord.cli;
  * =====
  */
 
+import org.fusesource.jansi.AnsiConsole;
 import picocli.CommandLine;
 
 public class Main {
 
     public static void main(String[] args) {
+        AnsiConsole.systemInstall();
+
         CommandLine cli = new CommandLine(new App());
         int code = cli.execute(args);
         System.exit(code);

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -47,6 +47,7 @@ import com.walmartlabs.concord.runtime.v2.sdk.*;
 import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
 import com.walmartlabs.concord.runtime.v2.runner.vm.ParallelExecutionException;
+import org.fusesource.jansi.Ansi;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -62,6 +63,10 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
+
+import static org.fusesource.jansi.Ansi.Color.GREEN;
+import static org.fusesource.jansi.Ansi.Color.YELLOW;
+import static org.fusesource.jansi.Ansi.ansi;
 
 @Command(name = "run", description = "Run the current directory as a Concord process")
 public class Run implements Callable<Integer> {
@@ -253,7 +258,7 @@ public class Run implements Callable<Integer> {
             return 0;
         }
 
-        System.out.println("Starting...");
+        System.out.println(ansi().fgBrightGreen().a("Starting...").reset());
 
         if (dryRunMode) {
             System.out.println("Running in the dry-run mode.");
@@ -291,7 +296,7 @@ public class Run implements Callable<Integer> {
             return 1;
         }
 
-        System.out.println("...done!");
+        System.out.println(ansi().fgBrightGreen().a("...done!").reset());
 
         return 0;
     }
@@ -408,8 +413,8 @@ public class Run implements Callable<Integer> {
     private static void dumpArguments(Map<String, Object> args) {
         ObjectMapper om = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
         try {
-            System.out.println("Process arguments:");
-            System.out.println(om.writerWithDefaultPrettyPrinter().writeValueAsString(args));
+            System.out.print(ansi().fgYellow().a("\nProcess arguments:\n\t"));
+            System.out.println(om.writerWithDefaultPrettyPrinter().writeValueAsString(args).replace("\n", "\n\t"));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -417,10 +422,10 @@ public class Run implements Callable<Integer> {
 
     private static void logException(Verbosity verbosity, Exception e) {
         if (verbosity.verbose()) {
-            System.err.print("Error: ");
+            System.err.print(ansi().fgBrightRed().a("Error: "));
             e.printStackTrace(System.err);
         } else {
-            System.err.println("Error: " + e.getMessage());
+            System.err.println("Error: " + e.getMessage()); // TODO
         }
     }
 
@@ -441,7 +446,7 @@ public class Run implements Callable<Integer> {
             }
 
             if (currentCount == notifyOnCount) {
-                System.out.println("Copying files into the target directory...");
+                System.out.println(ansi().fgBrightBlack().a("Copying files into the target directory..."));
                 currentCount = -1;
                 return;
             }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/FlowStepLogger.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/FlowStepLogger.java
@@ -29,6 +29,8 @@ import com.walmartlabs.concord.runtime.v2.sdk.Context;
 import com.walmartlabs.concord.svm.Runtime;
 import com.walmartlabs.concord.svm.*;
 
+import static org.fusesource.jansi.Ansi.ansi;
+
 public class FlowStepLogger implements ExecutionListener {
 
     @Override
@@ -45,7 +47,8 @@ public class FlowStepLogger implements ExecutionListener {
 
         Location loc = s.getStep().getLocation();
 
-        System.out.println(">>> '" + getDescription(runtime, state, threadId, s.getStep()) + "' @ " + loc.fileName() + ":" + loc.lineNum());
+        System.out.println(ansi().fgBrightCyan().bold().a(">>> '").a(getDescription(runtime, state, threadId, s.getStep())).boldOff()
+                .a("' @ ").a(loc.fileName()).a(":").a(loc.lineNum()).reset());
 
         return Result.CONTINUE;
     }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/TaskParamsLogger.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/TaskParamsLogger.java
@@ -25,11 +25,14 @@ import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallListener;
 import com.walmartlabs.concord.runtime.v2.sdk.Context;
 import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
 import com.walmartlabs.concord.runtime.v2.sdk.Variables;
+import org.fusesource.jansi.Ansi;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.fusesource.jansi.Ansi.ansi;
 
 public class TaskParamsLogger implements TaskCallListener {
 
@@ -39,12 +42,12 @@ public class TaskParamsLogger implements TaskCallListener {
         Map<String, Object> outVars = asMapOrNull(event.result());
 
         if (TaskCallEvent.Phase.PRE.equals(event.phase())) {
-            System.out.println("     in: " + inVars);
+            System.out.println(ansi().fgCyan().a("     in: " + inVars).reset());
         } else {
-            System.out.println("     out: " + outVars);
-            System.out.println("     duration: " + event.duration() + "ms");
+            System.out.println(ansi().fgCyan().a("     out: ").a(outVars).reset());
+            System.out.println(ansi().fgCyan().a("     duration: ").a(event.duration()).a("ms").reset());
             if (event.error() != null) {
-                System.out.println("    error: " + event.error());
+                System.out.println(ansi().fgBrightRed().a("    error: ").a(event.error()).reset());
             }
         }
     }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/VaultProvider.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/VaultProvider.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.fusesource.jansi.Ansi.ansi;
+
 /**
  * Implements a simple "vault" system.
  * When using {@code crypto.decryptString} in a flow executed by the CLI,
@@ -66,7 +68,7 @@ public class VaultProvider {
         }
 
         if (!items.containsKey(key)) {
-            System.out.println("There are no key '" + key + "' in vault '" + id + "'");
+            System.out.println(ansi().fgRed().a("There are no key '").a(key).a("' in vault '").a(id).a("'").reset());
         }
 
         return items.get(key);
@@ -86,7 +88,7 @@ public class VaultProvider {
             }
             return result;
         } catch (IOException e) {
-            System.out.println("Error loading vault file '" + file + "':" + e.getMessage());
+            System.out.println(ansi().fgBrightRed().a("Error loading vault file '").a(file).a("': ").a(e.getMessage()).reset());
             throw new RuntimeException(e.getMessage());
         }
     }

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,7 +1,8 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %green([%thread]) %highlight(%msg%n)</pattern>
         </encoder>
     </appender>
 

--- a/cli/src/test/java/com/walmartlabs/concord/cli/AbstractTest.java
+++ b/cli/src/test/java/com/walmartlabs/concord/cli/AbstractTest.java
@@ -57,8 +57,9 @@ public abstract class AbstractTest {
 
     protected void assertLog(String pattern, int times) {
         String outStr = out.toString();
-        if (grep(outStr, pattern) != times) {
-            fail("Expected a single log entry: '" + pattern + "', got: \n" + outStr);
+        int found = grep(outStr, pattern);
+        if (found != times) {
+            fail("Expected [" + times + "] log entries: '" + pattern + "', got [" + found + "]: \n" + outStr);
         }
     }
 

--- a/cli/src/test/resources/logback-test.xml
+++ b/cli/src/test/resources/logback-test.xml
@@ -1,8 +1,9 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
+        <!-- we should not use Jansi in tests, tests override System.out and System.err to capture output of CLI commands -->
+        <withJansi>false</withJansi>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %red([%thread]) %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/cli/src/test/resources/logback-test.xml
+++ b/cli/src/test/resources/logback-test.xml
@@ -1,7 +1,8 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %red([%thread]) %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -69,6 +69,7 @@
         <jackson.databind.version>2.18.3</jackson.databind.version>
         <jackson.jsonschema.version>1.0.39</jackson.jsonschema.version>
         <jackson.version>2.18.3</jackson.version>
+        <jansi.version>2.4.2</jansi.version>
         <javax.activation.version>1.2.0</javax.activation.version>
         <javax.annotations.api.version>1.3.2</javax.annotations.api.version>
         <javax.inject.version>1</javax.inject.version>
@@ -93,7 +94,7 @@
         <kubernetes.client.version>7.0.1</kubernetes.client.version>
         <launcher.version>0.128</launcher.version>
         <liquibase.version>4.29.2</liquibase.version>
-        <logback.version>1.5.13</logback.version>
+        <logback.version>1.5.18</logback.version>
         <maven.annotation.version>3.5</maven.annotation.version>
         <maven.api.version>3.0.5</maven.api.version>
         <maven.artifact.version>3.8.4</maven.artifact.version>
@@ -119,7 +120,7 @@
         <shiro.version>2.0.2</shiro.version>
         <siesta.version>2.3.2</siesta.version>
         <sisu.version>0.9.0.M2</sisu.version>
-        <slf4j.version>2.0.16</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <sshd.version>2.15.0</sshd.version>
         <sysoutslf4j.version>1.0.2</sysoutslf4j.version>
@@ -1261,6 +1262,11 @@
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${activation.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>${jansi.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Colorful output for concord-cli.

Before:
![Screenshot_20250505_125812](https://github.com/user-attachments/assets/ffe0d04c-8cb2-4e35-ab37-88a70ed50909)

After:
![Screenshot_20250505_125724](https://github.com/user-attachments/assets/fef22626-5c46-43d9-af05-57025eb15d1a)

Without verbose mode:
![Screenshot_20250505_125744](https://github.com/user-attachments/assets/bdeb7042-f005-4286-874a-64f90777d116)

Also changes the `lint` action to use Jansi instead of Picocli's ANSI support for consistency.