### PR TITLE
Default Git Credentials Hostname Whitelist

### DIFF
--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -302,20 +302,11 @@ public class GitClient {
     private String updateUrl(String url, Secret secret) {
         url = url.trim();
 
-        int hostnameStart = url.indexOf("://") + 3;
-        int hostnameEnd = url.indexOf("/", hostnameStart);
-
-        if(hostnameStart==2 || hostnameEnd < 0) {
-            // probably this is invalid, but I don't know what proper handling of this looks like
-            // however you definitely don't want to give credentials to whatever this git url looks like.
-            return url;
-        }
-
-        String hostname = url.substring(hostnameStart, hostnameEnd);
+        URI uri = URI.create(url);
 
         List<String> allowedDefaultHosts = cfg.authorizedGitHosts();
 
-        if(secret == null && allowedDefaultHosts!= null && !allowedDefaultHosts.contains(hostname)) {
+        if(secret == null && allowedDefaultHosts!= null && !allowedDefaultHosts.contains(uri.getHost())) {
             // in this case the user has not provided authentication AND the host is not in the whitelist of hosts
             // which may use the default git credentials. return the url un-modified to attempt anonymous auth;
             // if it fails

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.*;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -319,7 +319,6 @@ public class GitClient {
             // in this case the user has not provided authentication AND the host is not in the whitelist of hosts
             // which may use the default git credentials. return the url un-modified to attempt anonymous auth;
             // if it fails
-            System.out.println("Forbidden host for default credentials: " + hostname);
             return url;
         }
 
@@ -330,7 +329,6 @@ public class GitClient {
         }
 
         // using default credentials
-        System.out.println("Using default credentials: " + "https://" + cfg.oauthToken() + "@" + url.substring("https://".length()));
         return "https://" + cfg.oauthToken() + "@" + url.substring("https://".length());
     }
 

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClientConfiguration.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClientConfiguration.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
+import java.util.List;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true)
@@ -31,6 +32,8 @@ public interface GitClientConfiguration {
 
     @Nullable
     String oauthToken();
+    @Nullable
+    List<String> authorizedGitHosts();
 
     @Value.Default
     default Duration defaultOperationTimeout() {

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClientConfiguration.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClientConfiguration.java
@@ -32,6 +32,7 @@ public interface GitClientConfiguration {
 
     @Nullable
     String oauthToken();
+    
     @Nullable
     List<String> authorizedGitHosts();
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/GitConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/GitConfiguration.java
@@ -26,6 +26,7 @@ import org.eclipse.sisu.Nullable;
 import javax.inject.Inject;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.List;
 
 public class GitConfiguration implements Serializable {
 
@@ -35,6 +36,11 @@ public class GitConfiguration implements Serializable {
     @Config("git.oauth")
     @Nullable
     private String oauthToken;
+
+    @Inject
+    @Config("git.authorizedGitHosts")
+    @Nullable
+    private List<String> authorizedGitHosts;
 
     @Inject
     @Config("git.shallowClone")
@@ -86,6 +92,10 @@ public class GitConfiguration implements Serializable {
 
     public String getOauthToken() {
         return oauthToken;
+    }
+
+    public List<String> getAuthorizedGitHosts() {
+        return authorizedGitHosts;
     }
 
     public int getHttpLowSpeedLimit() {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
@@ -66,6 +66,7 @@ public class RepositoryManager {
 
         GitClientConfiguration gitCliCfg = GitClientConfiguration.builder()
                 .oauthToken(gitCfg.getOauthToken())
+                .authorizedGitHosts(gitCfg.getAuthorizedGitHosts())
                 .defaultOperationTimeout(gitCfg.getDefaultOperationTimeout())
                 .fetchTimeout(gitCfg.getFetchTimeout())
                 .httpLowSpeedLimit(gitCfg.getHttpLowSpeedLimit())


### PR DESCRIPTION
Adds a field to the git client configuration which serves as a whitelist for allowed hosts to use the default git credentials with (to prevent leaking of said credentials.) WIP Label bc I'm not confident that I've covered all bases and would appreciate more eyes on it :)