### PR TITLE
oidc: validate team and role mappings

### DIFF
--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcRealm.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcRealm.java
@@ -23,6 +23,8 @@ package com.walmartlabs.concord.server.plugins.oidc;
 import com.walmartlabs.concord.common.Matcher;
 import com.walmartlabs.concord.server.org.team.TeamDao;
 import com.walmartlabs.concord.server.org.team.TeamRole;
+import com.walmartlabs.concord.server.plugins.oidc.PluginConfiguration.TeamMapping;
+import com.walmartlabs.concord.server.role.RoleDao;
 import com.walmartlabs.concord.server.sdk.ConcordApplicationException;
 import com.walmartlabs.concord.server.sdk.security.AuthenticationException;
 import com.walmartlabs.concord.server.security.SecurityUtils;
@@ -31,10 +33,13 @@ import com.walmartlabs.concord.server.user.*;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.SimpleAccount;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.pac4j.oidc.profile.OidcProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.*;
@@ -42,32 +47,31 @@ import java.util.stream.Collectors;
 
 public class OidcRealm extends AuthorizingRealm {
 
+    private static final Logger log = LoggerFactory.getLogger(OidcRealm.class);
     private static final String REALM_NAME = "oidc";
 
-    private final PluginConfiguration cfg;
     private final UserManager userManager;
-
     private final UserDao userDao;
     private final TeamDao teamDao;
 
+    private final Map<String, List<PluginConfiguration.Source>> roleMapping;
+    private final Map<UUID, TeamMapping> teamMapping;
+
     @Inject
-    public OidcRealm(PluginConfiguration cfg, UserManager userManager, UserDao userDao, TeamDao teamDao) {
-        this.cfg = cfg;
+    public OidcRealm(PluginConfiguration cfg,
+                     UserManager userManager,
+                     UserDao userDao,
+                     RoleDao roleDao,
+                     TeamDao teamDao) {
+
         this.userManager = userManager;
         this.userDao = userDao;
         this.teamDao = teamDao;
 
-        setCredentialsMatcher((token, info) -> {
-            SimpleAccount account = (SimpleAccount) info;
+        this.roleMapping = validateRoleMapping(cfg.getRoleMapping(), roleDao);
+        this.teamMapping = validateTeamMapping(cfg.getTeamMapping(), teamDao);
 
-            OidcToken stored = (OidcToken) account.getCredentials();
-            OidcToken received = (OidcToken) token;
-
-            Object a = stored.getProfile().getAccessToken();
-            Object b = received.getProfile().getAccessToken();
-
-            return a.equals(b);
-        });
+        setCredentialsMatcher(new OidcCredentialsMatcher());
     }
 
     @Override
@@ -86,19 +90,22 @@ public class OidcRealm extends AuthorizingRealm {
         String username = profile.getEmail().toLowerCase();
         UserEntry u = userManager.getOrCreate(username, null, UserType.LOCAL)
                 .orElseThrow(() -> new ConcordApplicationException("User not found: " + profile.getEmail()));
+        UUID userId = u.getId();
 
-        userManager.update(u.getId(), profile.getDisplayName(), profile.getEmail(), null, false, null);
+        userManager.update(userId, profile.getDisplayName(), profile.getEmail(), null, false, null);
 
         Set<UUID> newTeams = new HashSet<>();
         teamDao.tx(tx -> {
-            List<UserTeam> currentTeams = userDao.listTeams(tx, u.getId());
+            List<UserTeam> currentTeams = userDao.listTeams(tx, userId);
 
-            for (Map.Entry<UUID, PluginConfiguration.TeamMapping> e : cfg.getTeamMapping().entrySet()) {
-                if (match(profile, e.getValue().getSources())) {
-                    if (!hasTeam(e.getKey(), e.getValue().getRole(), currentTeams)) {
-                        teamDao.upsertUser(tx, e.getKey(), u.getId(), e.getValue().getRole());
+            for (Map.Entry<UUID, TeamMapping> e : teamMapping.entrySet()) {
+                UUID teamId = e.getKey();
+                TeamMapping mapping = e.getValue();
+                if (match(profile, mapping.sources())) {
+                    if (!hasTeam(teamId, mapping.role(), currentTeams)) {
+                        teamDao.upsertUser(tx, teamId, userId, mapping.role());
                     }
-                    newTeams.add(e.getKey());
+                    newTeams.add(teamId);
                 }
             }
 
@@ -106,7 +113,7 @@ public class OidcRealm extends AuthorizingRealm {
                     .map(UserTeam::teamId)
                     .filter(o -> !newTeams.contains(o))
                     .collect(Collectors.toList());
-            userDao.excludeFromTeams(tx, u.getId(), toRemove);
+            userDao.excludeFromTeams(tx, userId, toRemove);
         });
 
         UserPrincipal userPrincipal = new UserPrincipal(REALM_NAME, u);
@@ -123,9 +130,12 @@ public class OidcRealm extends AuthorizingRealm {
         OidcToken token = principals.oneByType(OidcToken.class);
 
         List<String> roles = new ArrayList<>();
-        for (Map.Entry<String, List<PluginConfiguration.Source>> e : cfg.getRoleMapping().entrySet()) {
-            if (match(token.getProfile(), e.getValue())) {
-                roles.add(e.getKey());
+        for (Map.Entry<String, List<PluginConfiguration.Source>> e : roleMapping.entrySet()) {
+            String roleName = e.getKey();
+            List<PluginConfiguration.Source> sources = e.getValue();
+
+            if (match(token.getProfile(), sources)) {
+                roles.add(roleName);
             }
         }
         return SecurityUtils.toAuthorizationInfo(principals, roles);
@@ -133,8 +143,8 @@ public class OidcRealm extends AuthorizingRealm {
 
     private static boolean match(OidcProfile profile, List<PluginConfiguration.Source> sources) {
         for (PluginConfiguration.Source source : sources) {
-            String attr = source.getAttribute();
-            String pattern = source.getPattern();
+            String attr = source.attribute();
+            String pattern = source.pattern();
             Object attrValue = profile.getAttribute(attr);
             if (Matcher.matches(attrValue, pattern)) {
                 return true;
@@ -145,5 +155,65 @@ public class OidcRealm extends AuthorizingRealm {
 
     private static boolean hasTeam(UUID teamId, TeamRole role, List<UserTeam> teams) {
         return teams.stream().anyMatch(ut -> ut.teamId() == teamId && ut.role() == role);
+    }
+
+    private static Map<String, List<PluginConfiguration.Source>> validateRoleMapping(Map<String, List<PluginConfiguration.Source>> input, RoleDao roleDao) {
+        Map<String, List<PluginConfiguration.Source>> output = new HashMap<>();
+
+        for (Map.Entry<String, List<PluginConfiguration.Source>> entry : input.entrySet()) {
+            String roleName = entry.getKey();
+            if (roleDao.getId(roleName) == null) {
+                log.warn("validateRoleMapping -> possibly invalid OIDC role mapping for roleName={}, role not found. It will still be used during user authorization.", roleName);
+            }
+        }
+
+        return output;
+    }
+
+    private static Map<UUID, TeamMapping> validateTeamMapping(Map<UUID, TeamMapping> input, TeamDao teamDao) {
+        Map<UUID, TeamMapping> output = new HashMap<>();
+
+        for (Map.Entry<UUID, TeamMapping> entry : input.entrySet()) {
+            boolean valid = true;
+
+            UUID teamId = entry.getKey();
+            TeamMapping teamMapping = entry.getValue();
+
+            if (teamDao.get(teamId) == null) {
+                log.warn("validateTeamMapping -> invalid OIDC team mapping, teamId={} doesn't exist", teamId);
+                valid = false;
+            }
+
+            for (PluginConfiguration.Source src : teamMapping.sources()) {
+                if (src.attribute() == null || src.attribute().isBlank()) {
+                    log.warn("validateTeamMapping -> invalid OIDC team mapping for teamId={}, empty source attribute name in {} mapping", teamId, src);
+                    valid = false;
+                }
+            }
+
+            if (valid) {
+                output.put(teamId, teamMapping);
+            } else {
+                log.warn("validateTeamMapping -> removing invalid teamId={} to mapping={}. It will not be considered during user authorization.", teamId, teamMapping);
+            }
+        }
+
+        return output;
+    }
+
+    static class OidcCredentialsMatcher implements CredentialsMatcher {
+
+        @Override
+        public boolean doCredentialsMatch(AuthenticationToken token, AuthenticationInfo info) {
+            SimpleAccount account = (SimpleAccount) info;
+
+            OidcToken stored = (OidcToken) account.getCredentials();
+            OidcToken received = (OidcToken) token;
+
+            Object a = stored.getProfile().getAccessToken();
+            Object b = received.getProfile().getAccessToken();
+
+            return a.equals(b);
+        }
     }
 }

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
@@ -203,43 +203,9 @@ public class PluginConfiguration {
         }
     }
 
-    public static class Source {
-
-        private final String attribute;
-
-        private final String pattern;
-
-        public Source(String attribute, String pattern) {
-            this.attribute = attribute;
-            this.pattern = pattern;
-        }
-
-        public String getAttribute() {
-            return attribute;
-        }
-
-        public String getPattern() {
-            return pattern;
-        }
+    public record Source(String attribute, String pattern) {
     }
 
-    public static class TeamMapping {
-
-        private final List<Source> sources;
-
-        private final TeamRole role;
-
-        public TeamMapping(List<Source> sources, TeamRole role) {
-            this.sources = sources;
-            this.role = role;
-        }
-
-        public List<Source> getSources() {
-            return sources;
-        }
-
-        public TeamRole getRole() {
-            return role;
-        }
+    public record TeamMapping(List<Source> sources, TeamRole role) {
     }
 }


### PR DESCRIPTION
Validate `oidc.roleMappings`, warn about non-existing roles but still add them as-is to authorized users. Technically, roles do not have to exist in the database to be useful.

Validate `oidc.teamMappings`, warn and skip invalid mappings. Teams must exist in the database before they can be assigned to authorized users.