### PR TITLE
concord-server-db: use session locks in Liquibase

### DIFF
--- a/server/db/pom.xml
+++ b/server/db/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.blagerweij</groupId>
+            <artifactId>liquibase-sessionlock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/server/db/src/main/resources/META-INF/services/liquibase.lockservice.LockService
+++ b/server/db/src/main/resources/META-INF/services/liquibase.lockservice.LockService
@@ -1,0 +1,1 @@
+com.github.blagerweij.sessionlock.PGLockService

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -94,6 +94,7 @@
         <kubernetes.client.version>7.0.1</kubernetes.client.version>
         <launcher.version>0.128</launcher.version>
         <liquibase.version>4.29.2</liquibase.version>
+        <liquibase.sessionlock.version>1.6.9</liquibase.sessionlock.version>
         <logback.version>1.5.18</logback.version>
         <maven.annotation.version>3.5</maven.annotation.version>
         <maven.api.version>3.0.5</maven.api.version>
@@ -1267,6 +1268,11 @@
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
                 <version>${jansi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.blagerweij</groupId>
+                <artifactId>liquibase-sessionlock</artifactId>
+                <version>${liquibase.sessionlock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Use `pg_try_advisory_lock` instead of a lock table by adding [liquibase-sessionlock](https://github.com/blagerweij/liquibase-sessionlock).

In environment like K8s it is not uncommon to have the server pod killed before it finishes the database migration (took too long, redeployed too fast, etc) -- which may leave lock records in Liquibase lock tables and cause subsequent restarts to fail.