### PR TITLE
concord-server-it: make dependency resolver timeout same as in runtime-v2 ITs

### DIFF
--- a/it/server/src/test/resources/agent.conf
+++ b/it/server/src/test/resources/agent.conf
@@ -1,6 +1,6 @@
 concord-agent {
 
-    dependencyResolveTimeout = "5 seconds"
+    dependencyResolveTimeout = "30 seconds"
     logMaxDelay = "250 milliseconds"
     pollInterval = "250 milliseconds"
 


### PR DESCRIPTION
Additionally, log the configured timeout and the elapsed time in the error.