### PR TITLE
concord-server-it: reduce agent and server poll delays to speed up tests

### DIFF
--- a/it/server/src/test/resources/agent.conf
+++ b/it/server/src/test/resources/agent.conf
@@ -14,5 +14,6 @@ concord-agent {
 
     server {
         apiKey = "cTJxMnEycTI="
+        processRequestDelay = "250 milliseconds"
     }
 }

--- a/it/server/src/test/resources/server.conf
+++ b/it/server/src/test/resources/server.conf
@@ -12,6 +12,13 @@ concord-server {
         projectSecretSalt = "aGVsbG93b3JsZA=="
     }
 
+    queue {
+        enqueuePollInterval = "250 milliseconds"
+        dispatcher {
+            pollDelay = "250 milliseconds"
+        }
+    }
+
     github {
         secret = "12345"
         useSenderLdapDn = true


### PR DESCRIPTION
In my local tests it shaves ~6 minutes off it/server run time. It might not be the case for (weaker) GHA runners.