### PR TITLE
project: use central-publishing-maven-plugin

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ encoding/decoding sensitive data
 as in runtime-v2 ITs
 ([#1156](https://github.com/walmartlabs/concord/pull/1156));
 - docker-images: update JDK versions
-([#1158](https://github.com/walmartlabs/concord/pull/1158)).
+([#1158](https://github.com/walmartlabs/concord/pull/1158));
+- project: use central-publishing-maven-plugin
+([#1160](https://github.com/walmartlabs/concord/pull/1160)).
 
 
 

--- a/agent-operator/pom.xml
+++ b/agent-operator/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>concord-agent-operator</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-agent</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <runnerV1.path>
             ${project.basedir}/../runtime/v1/impl/target/concord-runtime-impl-v1-${project.version}-jar-with-dependencies.jar

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-cli</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <main.class>com.walmartlabs.concord.cli.Main</main.class>
     </properties>
@@ -191,25 +193,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.oneops.maven.plugins</groupId>
-                <artifactId>really-executable-jar-maven-plugin</artifactId>
-                <version>1.4.2</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>really-executable-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <flags>-Xmx128m -client</flags>
-                    <classifier>uber</classifier>
-                    <outputClassifier>executable</outputClassifier>
-                    <allowOtherTypes>true</allowOtherTypes>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/client2/pom.xml
+++ b/client2/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-client2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-common</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-config</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/console2/pom.xml
+++ b/console2/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-console2</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <skipNpm>false</skipNpm>
         <node.downloadRoot>https://nodejs.org/dist/</node.downloadRoot>

--- a/dependency-manager/pom.xml
+++ b/dependency-manager/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-dependency-manager</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/docker-images/agent-operator/pom.xml
+++ b/docker-images/agent-operator/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-agent-operator</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <agent.image>${docker.namespace}/concord-agent-operator</agent.image>
         <docker.tagbase>${agent.image}</docker.tagbase>

--- a/docker-images/agent/pom.xml
+++ b/docker-images/agent/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-agent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <agent.image>${docker.namespace}/concord-agent</agent.image>
         <docker.tagbase>${agent.image}</docker.tagbase>

--- a/docker-images/ansible/pom.xml
+++ b/docker-images/ansible/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-ansible</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <ansible.image>${docker.namespace}/concord-ansible</ansible.image>
         <docker.tagbase>${ansible.image}</docker.tagbase>

--- a/docker-images/base/pom.xml
+++ b/docker-images/base/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-base</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <base.image>${docker.namespace}/concord-base</base.image>
         <docker.tagbase>${base.image}</docker.tagbase>

--- a/docker-images/pom.xml
+++ b/docker-images/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>base</module>
         <module>ansible</module>

--- a/docker-images/server/pom.xml
+++ b/docker-images/server/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-server</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <server.image>${docker.namespace}/concord-server</server.image>
         <docker.tagbase>${server.image}</docker.tagbase>

--- a/forms/pom.xml
+++ b/forms/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-forms</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/imports/pom.xml
+++ b/imports/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-imports</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/common/pom.xml
+++ b/it/common/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-common-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/compat/pom.xml
+++ b/it/compat/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-compat-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <!-- version of Agent to use in tests -->
         <!-- should be one or more release versions behind the current version -->

--- a/it/console/pom.xml
+++ b/it/console/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-console-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <!-- pin down the version of DB and Selenium images -->
         <db.image>library/postgres:10.4-alpine</db.image>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>tasks/broken-deps</module>
         <module>tasks/dependency-manager-test</module>

--- a/it/runtime-v1/pom.xml
+++ b/it/runtime-v1/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-v1-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <it.local.mode>false</it.local.mode>
         <maxParallelTestThreads>3</maxParallelTestThreads>

--- a/it/runtime-v2/pom.xml
+++ b/it/runtime-v2/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-v2-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <it.local.mode>false</it.local.mode>
         <db.image>library/postgres:10</db.image>

--- a/it/server/pom.xml
+++ b/it/server/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-server-it</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <agent.image>walmartlabs/concord-agent</agent.image>
         <ansible.image>walmartlabs/concord-ansible</ansible.image>

--- a/it/tasks/broken-deps/pom.xml
+++ b/it/tasks/broken-deps/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>broken-deps</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/tasks/dependency-manager-test/pom.xml
+++ b/it/tasks/dependency-manager-test/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>dependency-manager-test</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/tasks/serialization-test/pom.xml
+++ b/it/tasks/serialization-test/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>serialization-test</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/tasks/suspend-test/pom.xml
+++ b/it/tasks/suspend-test/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>suspend-test</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/it/testing-server/pom.xml
+++ b/it/testing-server/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>testing-concord-server</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -14,6 +14,8 @@
 
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>tasks/ansible</module>
         <module>tasks/asserts</module>

--- a/plugins/tasks/ansible/pom.xml
+++ b/plugins/tasks/ansible/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>ansible-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/asserts/pom.xml
+++ b/plugins/tasks/asserts/pom.xml
@@ -12,8 +12,7 @@
     <artifactId>asserts-tasks</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-    </properties>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/plugins/tasks/concord/pom.xml
+++ b/plugins/tasks/concord/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/crypto/pom.xml
+++ b/plugins/tasks/crypto/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>crypto-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/docker/pom.xml
+++ b/plugins/tasks/docker/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>docker-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/dynamic-tasks/pom.xml
+++ b/plugins/tasks/dynamic-tasks/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>dynamic-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/example/pom.xml
+++ b/plugins/tasks/example/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>example-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/files/pom.xml
+++ b/plugins/tasks/files/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>file-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime.v2</groupId>

--- a/plugins/tasks/http/pom.xml
+++ b/plugins/tasks/http/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>http-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/kv/pom.xml
+++ b/plugins/tasks/kv/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>kv-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/locale/pom.xml
+++ b/plugins/tasks/locale/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>locale-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/lock/pom.xml
+++ b/plugins/tasks/lock/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>lock-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/log/pom.xml
+++ b/plugins/tasks/log/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>log-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/misc/pom.xml
+++ b/plugins/tasks/misc/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>misc-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/mock/pom.xml
+++ b/plugins/tasks/mock/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>mock-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/noderoster/pom.xml
+++ b/plugins/tasks/noderoster/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>noderoster-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/resource/pom.xml
+++ b/plugins/tasks/resource/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>resource-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/slack/pom.xml
+++ b/plugins/tasks/slack/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>slack-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/sleep/pom.xml
+++ b/plugins/tasks/sleep/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>sleep-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/smtp/pom.xml
+++ b/plugins/tasks/smtp/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>smtp-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/throw/pom.xml
+++ b/plugins/tasks/throw/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>throw-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/tasks/variables/pom.xml
+++ b/plugins/tasks/variables/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>variables-tasks</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/plugins/templates/ansible/pom.xml
+++ b/plugins/templates/ansible/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>ansible-template</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.plugins.basic</groupId>

--- a/policy-engine/pom.xml
+++ b/policy-engine/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-policy-engine</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,15 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>${frontend.plugin.version}</version>
@@ -229,7 +238,7 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <pushChanges>false</pushChanges>
                         <useReleaseProfile>false</useReleaseProfile>
-                        <goals>deploy</goals>
+                        <goals>install org.sonatype.central:central-publishing-maven-plugin:publish</goals>
                         <arguments>--batch-mode -DskipTests -Pconcord-release</arguments>
                     </configuration>
                 </plugin>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-repository</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/runtime/common/pom.xml
+++ b/runtime/common/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>concord-runtime-common</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/runtime/loader/pom.xml
+++ b/runtime/loader/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>concord-runtime-loader</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime</groupId>

--- a/runtime/model/pom.xml
+++ b/runtime/model/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>concord-runtime-model</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/runtime/v1/impl/pom.xml
+++ b/runtime/v1/impl/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-impl-v1</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime</groupId>

--- a/runtime/v1/model/pom.xml
+++ b/runtime/v1/model/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-model-v1</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime</groupId>

--- a/runtime/v1/pom.xml
+++ b/runtime/v1/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>model</module>
         <module>impl</module>

--- a/runtime/v2/model/pom.xml
+++ b/runtime/v2/model/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-model-v2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime</groupId>

--- a/runtime/v2/pom.xml
+++ b/runtime/v2/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>vm</module>
         <module>sdk</module>

--- a/runtime/v2/runner-test/pom.xml
+++ b/runtime/v2/runner-test/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runner-v2-test</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime.v2</groupId>

--- a/runtime/v2/runner/pom.xml
+++ b/runtime/v2/runner/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runner-v2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/runtime/v2/sdk/pom.xml
+++ b/runtime/v2/sdk/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-sdk-v2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.runtime.v2</groupId>

--- a/runtime/v2/vm/pom.xml
+++ b/runtime/v2/vm/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-runtime-vm-v2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-sdk</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.immutables</groupId>

--- a/server/db/pom.xml
+++ b/server/db/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-server-db</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <db.image>library/postgres:10.4-alpine</db.image>
         <db.baseDir>${project.build.directory}/db</db.baseDir>

--- a/server/dist/pom.xml
+++ b/server/dist/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-server</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>

--- a/server/impl/pom.xml
+++ b/server/impl/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-server-impl</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>

--- a/server/liquibase-ext/pom.xml
+++ b/server/liquibase-ext/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>liquibase-ext</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/server/plugins/ansible/client2/pom.xml
+++ b/server/plugins/ansible/client2/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-ansible-plugin-client2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/server/plugins/ansible/db/pom.xml
+++ b/server/plugins/ansible/db/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-ansible-plugin-db</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <db.image>library/postgres:10.4-alpine</db.image>
         <db.baseDir>${project.build.directory}/db</db.baseDir>

--- a/server/plugins/ansible/impl/pom.xml
+++ b/server/plugins/ansible/impl/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-ansible-plugin</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server.plugins.ansible</groupId>

--- a/server/plugins/ansible/pom.xml
+++ b/server/plugins/ansible/pom.xml
@@ -12,8 +12,9 @@
 
     <groupId>com.walmartlabs.concord.server.plugins.ansible</groupId>
     <artifactId>parent</artifactId>
-
     <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <modules>
         <module>db</module>

--- a/server/plugins/kafka-event-sink/pom.xml
+++ b/server/plugins/kafka-event-sink/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>kafka-event-sink</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>

--- a/server/plugins/noderoster/client2/pom.xml
+++ b/server/plugins/noderoster/client2/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-noderoster-plugin-client2</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/server/plugins/noderoster/db/pom.xml
+++ b/server/plugins/noderoster/db/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-noderoster-plugin-db</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <db.image>library/postgres:10.4-alpine</db.image>
         <db.baseDir>${project.build.directory}/db</db.baseDir>

--- a/server/plugins/noderoster/impl/pom.xml
+++ b/server/plugins/noderoster/impl/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-noderoster-plugin</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/server/plugins/noderoster/pom.xml
+++ b/server/plugins/noderoster/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>db</module>
         <module>impl</module>

--- a/server/plugins/oidc/pom.xml
+++ b/server/plugins/oidc/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>oidc</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/server/plugins/oneops/pom.xml
+++ b/server/plugins/oneops/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>concord-oneops-plugin</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/server/plugins/pfed-sso/pom.xml
+++ b/server/plugins/pfed-sso/pom.xml
@@ -10,6 +10,8 @@
     <artifactId>pfed-sso</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.nimbusds</groupId>

--- a/server/plugins/pom.xml
+++ b/server/plugins/pom.xml
@@ -11,8 +11,9 @@
 
     <groupId>com.walmartlabs.concord.server.plugins</groupId>
     <artifactId>parent</artifactId>
-
     <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <modules>
         <module>ansible</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,6 +14,8 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>sdk</module>
         <module>liquibase-ext</module>

--- a/server/queue-client/pom.xml
+++ b/server/queue-client/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-queue-client</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>com.walmartlabs.concord</groupId>

--- a/server/sdk/pom.xml
+++ b/server/sdk/pom.xml
@@ -13,6 +13,8 @@
     <artifactId>concord-server-sdk</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>


### PR DESCRIPTION
I have no idea why the project `<name>` is not being inherited from the parent POM. Worked for concord-plugins. :man_shrugging: 

Also, the artifact produced by really-executable-jar-maven-plugin is being rejected by the central portal for whatever reason. Disabling it for now, will work on a workaround/replacement in a patch release.