### PR TITLE
concord-runtime-v1/v2-it: reduce agent and server poll rates to speed up tests

### DIFF
--- a/it/console/src/test/resources/agent.conf
+++ b/it/console/src/test/resources/agent.conf
@@ -1,4 +1,9 @@
 concord-agent {
+
+    dependencyResolveTimeout = "30 seconds"
+    logMaxDelay = "250 milliseconds"
+    pollInterval = "250 milliseconds"
+
     server {
         apiKey = "cTJxMnEycTI="
     }

--- a/it/console/src/test/resources/server.conf
+++ b/it/console/src/test/resources/server.conf
@@ -6,6 +6,13 @@ concord-server {
         }
     }
 
+    queue {
+        enqueuePollInterval = "250 milliseconds"
+        dispatcher {
+            pollDelay = "250 milliseconds"
+        }
+    }
+
     secretStore {
         serverPassword = "aXRpdGl0"
         secretStoreSalt = "aXRpdGl0"

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
@@ -36,7 +36,24 @@ public final class ConcordConfiguration {
                 .streamServerLogs(true)
                 .streamAgentLogs(true)
                 .useLocalMavenRepository(true)
-                .extraConfigurationSupplier(() -> "concord-agent { prefork { enabled = true } }");
+                .extraConfigurationSupplier(() -> """
+                        concord-server {
+                            queue {
+                                enqueuePollInterval = "250 milliseconds"
+                                dispatcher {
+                                    pollDelay = "250 milliseconds"
+                                }
+                            }
+                        }
+                        concord-agent {
+                            dependencyResolveTimeout = "30 seconds"
+                            logMaxDelay = "250 milliseconds"
+                            pollInterval = "250 milliseconds"
+                            prefork {
+                                enabled = true
+                            }
+                        }
+                        """);
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -59,6 +59,14 @@ public final class ConcordConfiguration {
                 .sharedContainerDir(sharedDir)
                 .useLocalMavenRepository(true)
                 .extraConfigurationSupplier(() -> """
+                    concord-server {
+                        queue {
+                            enqueuePollInterval = "250 milliseconds"
+                            dispatcher {
+                                pollDelay = "250 milliseconds"
+                            }
+                        }
+                    }
                     concord-agent {
                         dependencyResolveTimeout = "30 seconds"
                         logMaxDelay = "250 milliseconds"


### PR DESCRIPTION
Continuation of #1159, now applied to it/runtime-v1, it/runtime-v2 and console ITs.
