### PR TITLE
webapp: fix prefix matching

### DIFF
--- a/server/plugins/webapp/pom.xml
+++ b/server/plugins/webapp/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>javax.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/plugins/webapp/src/test/java/ca/ibodrov/concord/webapp/ExcludedPrefixesTest.java
+++ b/server/plugins/webapp/src/test/java/ca/ibodrov/concord/webapp/ExcludedPrefixesTest.java
@@ -1,0 +1,46 @@
+package ca.ibodrov.concord.webapp;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExcludedPrefixesTest {
+
+    @Test
+    public void matchWorksAsIntended() {
+        var excludedPrefixes = new ExcludedPrefixes(Stream.of("/", "/api/*", "/foo/*", "/bar"));
+
+        assertTrue(excludedPrefixes.matches("/"));
+        assertTrue(excludedPrefixes.matches("/api/foobar"));
+        assertTrue(excludedPrefixes.matches("/foo/bar"));
+        assertTrue(excludedPrefixes.matches("/bar"));
+
+        assertFalse(excludedPrefixes.matches("/test"));
+        assertFalse(excludedPrefixes.matches("/api"));
+        assertFalse(excludedPrefixes.matches("/foo"));
+        assertFalse(excludedPrefixes.matches("/baz"));
+    }
+}


### PR DESCRIPTION
Fixes behavior for servlets that are mapped to common prefixes without `/*`, e.g. if there is a custom servet bound to `/`.