### PR TITLE
concord-cli: produce an executable binary again

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -166,7 +166,7 @@
                         </goals>
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>uber</shadedClassifierName>
+                            <shadedClassifierName>executable</shadedClassifierName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/sisu/javax.inject.Named</resource>
@@ -193,6 +193,26 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <flags>-Xmx128m -client</flags>
+                    <classifier>executable</classifier>
+                    <allowOtherTypes>true</allowOtherTypes>
+                    <programFile>concord-cli-${project.version}</programFile>
+                    <programFileType>sh</programFileType>
+                    <attachProgramFile>true</attachProgramFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,11 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.11.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.skife.maven</groupId>
+                    <artifactId>really-executable-jar-maven-plugin</artifactId>
+                    <version>2.1.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The Central Portal doesn't like .jar files that are not exactly jars -- e.g. prepended with a shell script to make the JAR "really executable".