### PR TITLE
concord-server: do not log session token

### DIFF
--- a/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/message/ProcessResponse.java
+++ b/server/queue-client/src/main/java/com/walmartlabs/concord/server/queueclient/message/ProcessResponse.java
@@ -114,7 +114,7 @@ public class ProcessResponse extends Message {
     @Override
     public String toString() {
         return "ProcessResponse{" +
-                "sessionToken='" + sessionToken + '\'' +
+                "sessionToken='***'" +
                 ", processId=" + processId +
                 ", processCreatedAt=" + processCreatedAt + '\'' +
                 ", orgName='" + orgName + '\'' +


### PR DESCRIPTION
Sometimes `ProcessResponse` messages are [logged in full](https://github.com/walmartlabs/concord/blob/19119528f197357aa4d4982ec2dac16c6cf8a5ae/server/impl/src/main/java/com/walmartlabs/concord/server/message/MessageChannelManager.java#L85), including the session token.