### PR TITLE
runtime-v2: validate form name constaints as documented

### DIFF
--- a/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
+++ b/runtime/v2/model/src/test/java/com/walmartlabs/concord/project/runtime/v2/parser/YamlErrorParserTest.java
@@ -1630,6 +1630,16 @@ public class YamlErrorParserTest extends AbstractParserTest {
     }
 
     @Test
+    public void test913() throws Exception {
+        String msg =
+                "(013.yml): Error @ line: 2, col: 3. Invalid value: invalid.name, expected: [String matching regex \"^[A-Za-z0-9_$]+$\"]\n" +
+                        "\twhile processing steps:\n" +
+                        "\t'forms' @ line: 1, col: 1";
+
+        assertErrorMessage("errors/forms/013.yml", msg);
+    }
+
+    @Test
     public void test1000() throws Exception {
         String msg =
                 "(000.yml): Error @ line: 3, col: 12. Invalid value type, expected: STRING, got: NULL. Remove attribute or complete the definition\n" +

--- a/runtime/v2/model/src/test/resources/errors/forms/013.yml
+++ b/runtime/v2/model/src/test/resources/errors/forms/013.yml
@@ -1,0 +1,3 @@
+forms:
+  invalid.name:
+    - fullName: { type: "string+" }

--- a/runtime/v2/runner-test/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/form/concord.yml
+++ b/runtime/v2/runner-test/src/test/resources/com/walmartlabs/concord/runtime/v2/runner/form/concord.yml
@@ -1,7 +1,9 @@
 flows:
   default:
+    - set:
+        formName: "myForm"
     - log: "Before"
-    - form: myForm
+    - form: "${formName}"
     - log: "After: ${myForm}"
 
 forms:

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FormCallCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/FormCallCommand.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.runtime.v2.runner.vm;
 import com.walmartlabs.concord.forms.Form;
 import com.walmartlabs.concord.forms.FormOptions;
 import com.walmartlabs.concord.runtime.common.FormService;
+import com.walmartlabs.concord.runtime.v2.exception.InvalidValueException;
 import com.walmartlabs.concord.runtime.v2.model.*;
 import com.walmartlabs.concord.runtime.v2.parser.FormFieldParser;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
@@ -57,6 +58,14 @@ public class FormCallCommand extends StepCommand<FormCall> implements ElementEve
         FormCall call = getStep();
         ExpressionEvaluator expressionEvaluator = runtime.getService(ExpressionEvaluator.class);
         String formName = expressionEvaluator.eval(evalContext, call.getName(), String.class);
+
+        if (!formName.matches("^[A-Za-z0-9_$]+$")) {
+            throw InvalidValueException.builder()
+                    .location(call.getLocation())
+                    .actual(formName)
+                    .expected("name matching regex \"^[A-Za-z0-9_$]+$\"")
+                    .build();
+        }
 
         ProcessDefinition processDefinition = runtime.getService(ProcessDefinition.class);
         ProcessConfiguration processConfiguration = runtime.getService(ProcessConfiguration.class);


### PR DESCRIPTION
Make good on this [documented constraint](https://concord.walmartlabs.com/docs/getting-started/forms.html#declaration):
> **Note**: Form names can only contain alphanumerics, whitespaces, underscores(_) and dollar signs($).

Still supports expressions for form call steps `- form: "${findOutLater}"`