### PR TITLE
concord-tasks: add createApiKey action

### DIFF
--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordTaskIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordTaskIT.java
@@ -28,9 +28,11 @@ import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.List;
+import java.util.UUID;
+
 import static com.walmartlabs.concord.it.common.ITUtils.randomString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConcordTaskIT extends AbstractTest {
 
@@ -212,5 +214,33 @@ public class ConcordTaskIT extends AbstractTest {
 
         // ---
         proc.assertLog(".*Done!.*");
+    }
+
+
+    @Test
+    public void testCreateApiKey() throws Exception {
+        String apiKeyName = "test_" + randomString();
+
+        Payload payload = new Payload()
+                .archive(resource("concord/createApiKey"))
+                .arg("apiKeyName", apiKeyName);
+
+        // ---
+
+        ConcordProcess proc = concord.processes().start(payload);
+        expectStatus(proc, ProcessEntry.StatusEnum.FINISHED);
+
+        // ---
+
+        proc.assertLog(".*result1=.*");
+        proc.assertNoLog(".*result2=.*");
+        proc.assertLog(".*error=.*");
+        proc.assertLog(".*result3=.*");
+
+        // ---
+
+        ApiKeysApi apiKeysApi = new ApiKeysApi(concord.apiClient());
+        List<ApiKeyEntry> apiKeys = apiKeysApi.listUserApiKeys(UUID.fromString("230c5c9c-d9a7-11e6-bcfd-bb681c07b26c"));// admin
+        assertTrue(apiKeys.stream().anyMatch(k -> k.getName().equals(apiKeyName)));
     }
 }

--- a/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/concord/createApiKey/concord.yml
+++ b/it/runtime-v2/src/test/resources/com/walmartlabs/concord/it/runtime/v2/concord/createApiKey/concord.yml
@@ -1,0 +1,34 @@
+configuration:
+  runtime: "concord-v2"
+
+flows:
+  default:
+    # create a new API key
+    - task: concord
+      in:
+        action: createApiKey
+        username: admin
+        name: ${apiKeyName}
+      out: result1
+    - log: "result1=${result1}"
+
+    # try creating a new API key with the same name
+    - try:
+        - task: concord
+          in:
+            action: createApiKey
+            username: admin
+            name: ${apiKeyName}
+        - log: "result2=${result2}"
+      error:
+        - log: "error=${lastError}"
+
+    # try creating a new API key with the same name but ignore existings
+    - task: concord
+      in:
+        action: createApiKey
+        username: admin
+        name: ${apiKeyName}
+        ignoreExisting: true
+      out: result3
+    - log: "result3=${result3}"

--- a/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
+++ b/plugins/tasks/concord/src/main/java/com/walmartlabs/concord/client/ConcordTaskCommon.java
@@ -84,23 +84,15 @@ public class ConcordTaskCommon {
 
     public TaskResult execute(ConcordTaskParams in) throws Exception {
         Action action = in.action();
-        switch (action) {
-            case START: {
-                return startChildProcess((StartParams) in);
-            }
-            case STARTEXTERNAL: {
-                return startExternalProcess((StartExternalParams) in);
-            }
-            case FORK: {
-                return fork((ForkParams) in);
-            }
-            case KILL: {
+        return switch (action) {
+            case START -> startChildProcess((StartParams) in);
+            case STARTEXTERNAL -> startExternalProcess((StartExternalParams) in);
+            case FORK -> fork((ForkParams) in);
+            case KILL -> {
                 kill((KillParams) in);
-                return TaskResult.success();
+                yield TaskResult.success();
             }
-            default:
-                throw new IllegalArgumentException("Unsupported action type: " + action);
-        }
+        };
     }
 
     public List<ProcessEntry> listSubProcesses(ListSubProcesses in) throws Exception {


### PR DESCRIPTION
E.g.

```yaml
    - task: concord
      in:
        action: createApiKey
        baseUrl: http://localhost:8001
        apiKey: foobar # API key for calling the baseUrl API, not the value of the key
        userId: 230c5c9c-d9a7-11e6-bcfd-bb681c07b26c
        name: foo
        ignoreExisting: true
```