### PR TITLE
 concord-client2: add Concord-specific media type for validation errors @ibodrov

### DIFF
--- a/client2/src/main/template/libraries/native/api.mustache
+++ b/client2/src/main/template/libraries/native/api.mustache
@@ -362,6 +362,7 @@ public class {{classname}} {
     {{/bodyParam}}
     String acceptHeaderValue = "{{#hasProduces}}{{#produces}}{{mediaType}}{{^-last}}, {{/-last}}{{/produces}}{{/hasProduces}}{{#hasProduces}}{{^produces}}application/json{{/produces}}{{/hasProduces}}{{^hasProduces}}application/json{{/hasProduces}}";
     acceptHeaderValue += ",application/vnd.siesta-validation-errors-v1+json";
+    acceptHeaderValue += ",application/vnd.concord-validation-errors-v1+json";
     localVarRequestBuilder.header("Accept", acceptHeaderValue);
     {{#bodyParam}}
     {{#isString}}

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/ValidationIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/ValidationIT.java
@@ -21,12 +21,26 @@ package com.walmartlabs.concord.it.server;
  */
 
 import com.walmartlabs.concord.client2.*;
+import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import java.util.Map;
+
+import static com.walmartlabs.concord.it.common.ITUtils.archive;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValidationIT extends AbstractServerIT {
+
+    @Test
+    public void testValidationExceptionMapping() throws Exception {
+        var processApi = new ProcessApi(getApiClient());
+        var input = Map.<String, Object>of(Constants.Multipart.ORG_NAME, "org_" + randomString(),
+                Constants.Multipart.PROJECT_NAME, "foo",
+                "archive", archive(ProcessIT.class.getResource("example").toURI()));
+        var ex = assertThrows(ApiException.class, () -> processApi.startProcess(input));
+        assertEquals(400, ex.getCode());
+        assertTrue(ex.getMessage().contains("Organization not found"));
+    }
 
     @Test
     public void testProjectCreation() throws Exception {


### PR DESCRIPTION
Not sure how did the ITs work without it until now. :-)