### PR TITLE
concord-cli: add remote-run command

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/App.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/App.java
@@ -25,7 +25,7 @@ import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
-@Command(name = "concord", subcommands = {Lint.class, Run.class, SelfUpdate.class})
+@Command(name = "concord", subcommands = {Lint.class, Run.class, RemoteRun.class, SelfUpdate.class})
 public class App implements Runnable {
 
     @Spec

--- a/cli/src/main/java/com/walmartlabs/concord/cli/CliConfig.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/CliConfig.java
@@ -22,8 +22,12 @@ package com.walmartlabs.concord.cli;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -34,10 +38,71 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.fusesource.jansi.Ansi.ansi;
 
 public record CliConfig(Map<String, CliConfigContext> contexts) {
 
-    public static CliConfig load(Path path) throws IOException {
+    private static final Logger log = LoggerFactory.getLogger(CliConfig.class);
+
+    public static CliConfig.CliConfigContext load(Verbosity verbosity, String context, Overrides overrides) {
+        Path baseDir = Paths.get(System.getProperty("user.home"), ".concord");
+        Path cfgFile = baseDir.resolve("cli.yaml");
+        if (!Files.exists(cfgFile)) {
+            cfgFile = baseDir.resolve("cli.yml");
+        }
+        if (!Files.exists(cfgFile)) {
+            CliConfig cfg = CliConfig.create();
+            return assertCliConfigContext(cfg, context).withOverrides(overrides);
+        }
+
+        if (verbosity.verbose()) {
+            log.info("Using CLI configuration file: {} (\"{}\" context)", cfgFile, context);
+        }
+
+        try {
+            CliConfig cfg = loadConfigFile(cfgFile);
+            return assertCliConfigContext(cfg, context).withOverrides(overrides);
+        } catch (Exception e) {
+            handleCliConfigErrorAndBail(cfgFile.toAbsolutePath().toString(), e);
+            throw new IllegalStateException("should be unreachable");
+        }
+    }
+
+    private static void handleCliConfigErrorAndBail(String cfgPath, Throwable e) {
+        // unwrap runtime exceptions
+        if (e instanceof RuntimeException ex) {
+            if (ex.getCause() instanceof IllegalArgumentException) {
+                e = ex.getCause();
+            }
+        }
+
+        // handle YAML errors
+        if (e instanceof IllegalArgumentException) {
+            if (e.getCause() instanceof UnrecognizedPropertyException ex) {
+                System.out.println(ansi().fgRed().a("Invalid format of the CLI configuration file ").a(cfgPath).a(". ").a(ex.getMessage()));
+                System.exit(1);
+            }
+            System.out.println(ansi().fgRed().a("Invalid format of the CLI configuration file ").a(cfgPath).a(". ").a(e.getMessage()));
+            System.exit(1);
+        }
+
+        // all other errors
+        System.out.println(ansi().fgRed().a("Failed to read the CLI configuration file ").a(cfgPath).a(". ").a(e.getMessage()));
+        System.exit(1);
+    }
+
+    private static CliConfig.CliConfigContext assertCliConfigContext(CliConfig config, String context) {
+        CliConfig.CliConfigContext result = config.contexts().get(context);
+        if (result == null) {
+            System.out.println(ansi().fgRed().a("Configuration context not found: ").a(context).a(". Check the CLI configuration file."));
+            System.exit(1);
+        }
+        return result;
+    }
+
+    @VisibleForTesting
+    static CliConfig loadConfigFile(Path path) throws IOException {
         var mapper = new YAMLMapper();
 
         JsonNode defaults = mapper.readTree(readDefaultConfig());
@@ -98,19 +163,43 @@ public record CliConfig(Map<String, CliConfigContext> contexts) {
     public record Overrides(@Nullable Path secretStoreDir, @Nullable Path vaultDir, @Nullable String vaultId) {
     }
 
-    public record CliConfigContext(SecretsConfiguration secrets) {
+    public record CliConfigContext(@Nullable RemoteRunConfiguration remoteRun, SecretsConfiguration secrets) {
 
-        public CliConfigContext withOverrides(Overrides overrides) {
+        public CliConfigContext withOverrides(@Nullable Overrides overrides) {
+            if (overrides == null) {
+                return this;
+            }
+            var remoteRun = this.remoteRun();
             var secrets = this.secrets().withOverrides(overrides);
-            return new CliConfigContext(secrets);
+            return new CliConfigContext(remoteRun, secrets);
         }
+    }
+
+    public record SecretRef(String orgName, String secretName) {
+
+        public SecretRef(String orgName, String secretName) {
+            this.orgName = orgName == null ? "Default" : orgName;
+            if (this.orgName.isBlank()) {
+                throw new IllegalArgumentException("'orgName' is required");
+            }
+            this.secretName = requireNonNull(secretName);
+            if (this.secretName.isBlank()) {
+                throw new IllegalArgumentException("'secretName' is required");
+            }
+        }
+    }
+
+    public record RemoteRunConfiguration(@Nullable String baseUrl, @Nullable SecretRef apiKeyRef) {
     }
 
     public record SecretsConfiguration(VaultConfiguration vault,
                                        FileSecretsProviderConfiguration local,
                                        RemoteSecretsProviderConfiguration remote) {
 
-        public SecretsConfiguration withOverrides(Overrides overrides) {
+        public SecretsConfiguration withOverrides(@Nullable Overrides overrides) {
+            if (overrides == null) {
+                return this;
+            }
             var vault = this.vault().withOverrides(overrides);
             var localFiles = this.local().withOverrides(overrides);
             return new SecretsConfiguration(vault, localFiles, this.remote);
@@ -118,7 +207,10 @@ public record CliConfig(Map<String, CliConfigContext> contexts) {
 
         public record VaultConfiguration(Path dir, String id) {
 
-            public VaultConfiguration withOverrides(Overrides overrides) {
+            public VaultConfiguration withOverrides(@Nullable Overrides overrides) {
+                if (overrides == null) {
+                    return this;
+                }
                 return new VaultConfiguration(
                         Optional.ofNullable(overrides.vaultDir()).orElse(this.dir()),
                         Optional.ofNullable(overrides.vaultId()).orElse(this.id()));
@@ -127,7 +219,10 @@ public record CliConfig(Map<String, CliConfigContext> contexts) {
 
         public record FileSecretsProviderConfiguration(boolean enabled, boolean writable, Path dir) {
 
-            public FileSecretsProviderConfiguration withOverrides(Overrides overrides) {
+            public FileSecretsProviderConfiguration withOverrides(@Nullable Overrides overrides) {
+                if (overrides == null) {
+                    return this;
+                }
                 return new FileSecretsProviderConfiguration(
                         this.enabled,
                         this.writable,

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Confirmation.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Confirmation.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.cli.runner.secrets;
+package com.walmartlabs.concord.cli;
 
 /*-
  * *****
@@ -20,6 +20,19 @@ package com.walmartlabs.concord.cli.runner.secrets;
  * =====
  */
 
-public record SecretsProviderRef(String name, SecretsProvider provider, boolean writable) {
+import java.io.IOException;
 
+import static org.fusesource.jansi.Ansi.ansi;
+
+public final class Confirmation {
+
+    public static boolean confirm(String message) throws IOException {
+        System.out.println(ansi().fgBrightYellow().bold().a(message).reset());
+        int response = System.in.read();
+        // y == 121, Y == 89
+        return response == 121 || response == 89;
+    }
+
+    private Confirmation() {
+    }
 }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/RemoteRun.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/RemoteRun.java
@@ -1,0 +1,277 @@
+package com.walmartlabs.concord.cli;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.walmartlabs.concord.cli.secrets.CliSecretService;
+import com.walmartlabs.concord.client2.ApiClient;
+import com.walmartlabs.concord.client2.ApiException;
+import com.walmartlabs.concord.client2.ProcessApi;
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.common.TemporaryPath;
+import com.walmartlabs.concord.sdk.Constants;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.fusesource.jansi.Ansi.ansi;
+
+@Command(name = "remote-run", description = "Execute flows remotely. Sends the specified <workDir> as the process payload.")
+public class RemoteRun implements Callable<Integer> {
+
+    private static final String[] PAYLOAD_ARCHIVE_FILTERS = {Pattern.quote(".concord"), Pattern.quote(".git")};
+    private static final long LARGE_PAYLOAD_SIZE_BYTES = 16 * 1024 * 1024;
+    private static final String LARGE_PAYLOAD_SIZE_HUMAN = "16MB";
+
+    @Option(names = {"--context"}, description = "Configuration context to use")
+    String context = "default";
+
+    @Option(names = {"-v", "--verbose"}, description = "Use verbose output")
+    boolean[] verbosity = new boolean[0];
+
+    @Option(names = {"--profiles"}, description = "A comma-separated list of Concord profiles to use", split = ",")
+    String[] activeProfiles;
+
+    @Option(names = {"--org"}, description = "Start the process in the specified Concord organization")
+    String orgName;
+
+    @Option(names = {"--project"}, description = "Start the process in the specified Concord project")
+    String projectName;
+
+    @Option(names = {"--entry-point"}, description = "Name of the starting flow")
+    String entryPoint;
+
+    @Option(names = {"--args"}, description = "Process arguments (flow variables)")
+    Map<String, String> processArgs = new LinkedHashMap<>();
+
+    @Option(names = {"--cfg"}, description = "Process configuration in JSON format (dependencies, runtime, arguments, etc)")
+    String processCfg;
+
+    @Parameters(arity = "1", description = "A path to a single concord.yaml (or .yml) file or a directory with flows")
+    Path workDir = Paths.get(System.getProperty("user.dir"));
+
+    @Override
+    public Integer call() {
+        var verbosity = new Verbosity(this.verbosity);
+
+        var mapper = new ObjectMapper();
+        if (processCfg != null && !processCfg.isBlank()) {
+            try {
+                mapper.readValue(processCfg, ObjectNode.class);
+            } catch (JsonProcessingException e) {
+                return err("Expected a valid JSON object in <cfg>, got: " + processCfg);
+            }
+        }
+
+        var configContext = CliConfig.load(verbosity, context, null);
+
+        var remoteRunConfig = configContext.remoteRun();
+        if (remoteRunConfig == null) {
+            return missingConfig(context, "remoteRun");
+        }
+        if (remoteRunConfig.baseUrl() == null) {
+            return missingConfig(context, "remoteRun.baseUrl");
+        }
+        if (remoteRunConfig.apiKeyRef() == null) {
+            return missingConfig(context, "remoteRun.apiKeyRef");
+        }
+
+        var secretService = CliSecretService.create(configContext, workDir, verbosity);
+        String apiKey;
+        try {
+            apiKey = secretService.exportAsString(remoteRunConfig.apiKeyRef().orgName(), remoteRunConfig.apiKeyRef().secretName(), null);
+        } catch (Exception e) {
+            return err("Unable to fetch the API key. " + e.getMessage());
+        }
+
+        var client = new ApiClient(HttpClient.newBuilder().build())
+                .setBaseUrl(remoteRunConfig.baseUrl())
+                .setApiKey(apiKey);
+
+        var processApi = new ProcessApi(client);
+
+        info("Preparing the payload...");
+
+        if (!Files.exists(workDir)) {
+            return err("<workDir> not found: " + workDir);
+        }
+
+        try {
+            var payloadSize = getDirectorySize(workDir);
+            if (payloadSize >= LARGE_PAYLOAD_SIZE_BYTES) {
+                if (!Confirmation.confirm("The specified <workDir> is larger than %s. Continue? (y/N)".formatted(LARGE_PAYLOAD_SIZE_HUMAN))) {
+                    return err("Aborting.");
+                }
+            }
+        } catch (IOException e) {
+            return err("Unable to determine the payload size: " + e.getMessage());
+        }
+
+        try (var archive = prepareArchive(workDir)) {
+            var input = new HashMap<String, Object>();
+            input.put("archive", archive.path());
+            if (orgName != null) {
+                input.put(Constants.Multipart.ORG_NAME, orgName);
+            }
+            if (projectName != null) {
+                input.put(Constants.Multipart.PROJECT_NAME, projectName);
+            }
+            if (activeProfiles != null) {
+                input.put(Constants.Request.ACTIVE_PROFILES_KEY, activeProfiles);
+            }
+            if (entryPoint != null) {
+                input.put(Constants.Request.ENTRY_POINT_KEY, entryPoint);
+            }
+            if (processArgs != null) {
+                processArgs.forEach((key, value) -> input.put(Constants.Request.ARGUMENTS_KEY + "." + key, value));
+            }
+            if (processCfg != null && !processCfg.isBlank()) {
+                input.put("request", processCfg.getBytes(UTF_8));
+            }
+
+            info("Starting a new process...");
+            var response = processApi.startProcess(input);
+            info("Started %s/#/process/%s/log".formatted(remoteRunConfig.baseUrl(), response.getInstanceId()));
+        } catch (ApiException e) {
+            return handleApiException(e);
+        } catch (IOException e) {
+            return err("Failed to start a process. " + e.getMessage());
+        }
+
+        return 0;
+    }
+
+    private static TemporaryPath prepareArchive(Path src) throws IOException {
+        var badSrc = false;
+
+        if (Files.isRegularFile(src)) {
+            var fileName = src.getFileName().toString();
+            badSrc = !fileName.equals("concord.yml") && !fileName.equals("concord.yaml") && !fileName.endsWith(".yml") && !fileName.endsWith(".yaml");
+        } else if (!Files.isDirectory(src)) {
+            badSrc = true;
+        }
+
+        if (badSrc) {
+            throw new IOException("Expected a path to a single concord.yaml (or .yml) file or a directory with flows, got " + src);
+        }
+
+        var dst = IOUtils.tempFile("payload", ".zip");
+
+        try (var zip = new ZipArchiveOutputStream(dst.path(), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            if (Files.isRegularFile(src)) {
+                IOUtils.zipFile(zip, src, src.getFileName().toString());
+            } else if (Files.isDirectory(src)) {
+                IOUtils.zip(zip, src, PAYLOAD_ARCHIVE_FILTERS);
+            }
+        }
+
+        return dst;
+    }
+
+    private static long getDirectorySize(Path src) throws IOException {
+        try (var walker = Files.walk(src)) {
+            return walker.filter(Files::isRegularFile)
+                    .mapToLong(path -> {
+                        try {
+                            return Files.size(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).sum();
+        }
+    }
+
+    private static int handleApiException(ApiException apiException) {
+        if (apiException.getCode() != 400) {
+            return err("Failed to start a process. " + apiException.getMessage());
+        }
+
+        var contentType = apiException.getResponseHeaders().firstValue("Content-Type");
+        if (contentType.filter(t -> t.contains("vnd.concord-validation-errors-v1+json")).isEmpty()) {
+            return unexpectedErrorBody(apiException);
+        }
+
+        JsonNode validationErrors;
+        try {
+            var mapper = new ObjectMapper();
+            validationErrors = mapper.readTree(apiException.getResponseBody());
+        } catch (IOException e) {
+            return unexpectedErrorBody(apiException);
+        }
+
+        if (validationErrors == null || !validationErrors.isArray()) {
+            return unexpectedErrorBody(apiException);
+        }
+
+        var text = new StringBuilder();
+        for (var node : validationErrors) {
+            if (!node.isObject()) {
+                return unexpectedErrorBody(apiException);
+            }
+            var message = node.get("message");
+            if (message != null && !message.asText().isBlank()) {
+                text.append(message.asText());
+            }
+        }
+
+        validationErrors.forEach(e -> text.append(e.asText()).append(". "));
+        return err("Failed to start a process. " + text);
+    }
+
+    private static void info(String msg) {
+        System.out.println(msg);
+    }
+
+    private static int unexpectedErrorBody(ApiException e) {
+        warn("Unable to parse the API error response body: " + e.getResponseBody());
+        return err("Failed to start a process. " + e.getMessage());
+    }
+
+    private static int missingConfig(String context, String key) {
+        return err("Missing '%s' configuration in the '%s' context".formatted(key, context));
+    }
+
+    private static void warn(String msg) {
+        System.out.println(ansi().fgYellow().a(msg).reset());
+    }
+
+    private static int err(String msg) {
+        System.out.println(ansi().fgRed().a(msg).reset());
+        return -1;
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -26,7 +26,7 @@ import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.walmartlabs.concord.cli.CliConfig.CliConfigContext;
 import com.walmartlabs.concord.cli.Verbosity;
-import com.walmartlabs.concord.cli.runner.secrets.CliSecretService;
+import com.walmartlabs.concord.cli.secrets.CliSecretService;
 import com.walmartlabs.concord.client2.ApiClient;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.runtime.v2.runner.*;

--- a/cli/src/main/java/com/walmartlabs/concord/cli/secrets/CliSecretService.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/secrets/CliSecretService.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.cli.runner.secrets;
+package com.walmartlabs.concord.cli.secrets;
 
 /*-
  * *****

--- a/cli/src/main/java/com/walmartlabs/concord/cli/secrets/RemoteSecretsProvider.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/secrets/RemoteSecretsProvider.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.cli.runner.secrets;
+package com.walmartlabs.concord.cli.secrets;
 
 /*-
  * *****
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.cli.runner.secrets;
  * =====
  */
 
+import com.walmartlabs.concord.cli.Confirmation;
 import com.walmartlabs.concord.cli.Version;
 import com.walmartlabs.concord.client2.*;
 import com.walmartlabs.concord.common.secret.BinaryDataSecret;
@@ -27,6 +28,7 @@ import com.walmartlabs.concord.common.secret.KeyPair;
 import com.walmartlabs.concord.common.secret.UsernamePassword;
 import com.walmartlabs.concord.runtime.v2.sdk.SecretService;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -42,8 +44,8 @@ public class RemoteSecretsProvider implements SecretsProvider {
     private final SecretClient secretClient;
     private final boolean confirmAccess;
 
-    public RemoteSecretsProvider(Path workDir, String baseUrl, String apiKey, boolean confirmAccess) {
-        this.workDir = requireNonNull(workDir);
+    public RemoteSecretsProvider(@Nullable Path workDir, String baseUrl, String apiKey, boolean confirmAccess) {
+        this.workDir = workDir;
         this.confirmAccess = confirmAccess;
 
         var apiClient = new DefaultApiClientFactory(requireNonNull(baseUrl))
@@ -59,7 +61,7 @@ public class RemoteSecretsProvider implements SecretsProvider {
     public Optional<SecretService.KeyPair> exportKeyAsFile(String orgName, String secretName, String secretPassword) throws Exception {
         return getKeyPair(orgName, secretName, secretPassword)
                 .map(keyPair -> {
-                    var tmpDir = UncheckedIO.assertTmpDir(workDir);
+                    var tmpDir = UncheckedIO.assertTmpDir(assertWorkDir());
 
                     var publicKeyPath = tmpDir.resolve(secretName + ".pub");
                     UncheckedIO.write(publicKeyPath, keyPair.getPublicKey(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -86,7 +88,7 @@ public class RemoteSecretsProvider implements SecretsProvider {
         return getBinaryDataSecret(orgName, secretName, secretPassword)
                 .map(BinaryDataSecret::getData)
                 .map(data -> {
-                    var tmpDir = UncheckedIO.assertTmpDir(workDir);
+                    var tmpDir = UncheckedIO.assertTmpDir(assertWorkDir());
                     var secretPath = tmpDir.resolve(secretName + ".bin");
                     UncheckedIO.write(secretPath, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
                     return secretPath;
@@ -184,14 +186,16 @@ public class RemoteSecretsProvider implements SecretsProvider {
             return;
         }
 
-        System.out.println(ansi().fgBrightYellow().bold().a("Fetching remote secret ").a(orgName).a("/").a(secretName)
-                .a(". Are you sure you want to proceed? (y/N)").reset());
-
-        int response = System.in.read();
-        // y == 121, Y == 89
-        if (response != 121 && response != 89) {
+        if (!Confirmation.confirm("Fetching remote secret %s/%s. Are you sure you want to proceed? (y/N)".formatted(orgName, secretName))) {
             System.out.println(ansi().fgRed().a("Aborting.").reset());
             System.exit(-1);
         }
+    }
+
+    private Path assertWorkDir() {
+        if (this.workDir == null) {
+            throw new RuntimeException("The workDir must be specified for the export functions to work");
+        }
+        return this.workDir;
     }
 }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/secrets/SecretsProvider.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/secrets/SecretsProvider.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.cli.runner.secrets;
+package com.walmartlabs.concord.cli.secrets;
 
 /*-
  * *****

--- a/cli/src/main/java/com/walmartlabs/concord/cli/secrets/SecretsProviderRef.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/secrets/SecretsProviderRef.java
@@ -1,0 +1,25 @@
+package com.walmartlabs.concord.cli.secrets;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public record SecretsProviderRef(String name, SecretsProvider provider, boolean writable) {
+
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/secrets/UncheckedIO.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/secrets/UncheckedIO.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.concord.cli.runner.secrets;
+package com.walmartlabs.concord.cli.secrets;
 
 /*-
  * *****

--- a/cli/src/test/java/com/walmartlabs/concord/cli/CliConfigTest.java
+++ b/cli/src/test/java/com/walmartlabs/concord/cli/CliConfigTest.java
@@ -71,6 +71,6 @@ public class CliConfigTest {
 
     private static CliConfig load(String resource) throws IOException, URISyntaxException {
         var src = Paths.get(requireNonNull(CliConfigTest.class.getResource(resource)).toURI());
-        return CliConfig.load(src);
+        return CliConfig.loadConfigFile(src);
     }
 }


### PR DESCRIPTION
Similar to the regular `run` but submits the <workDir> to a remote Concord server.
The server(s) are configured in `~/.concord/cli.yaml`, e.g.

```yaml
contexts:
  default:
    remoteRun:
      baseUrl: http://localhost:8001
      apiKeyRef:
        orgName: Default
        secretName: concord-localhost-admin
```

Also, moves `com.walmartlabs.concord.cli.runner.secrets` one level up to re-use in commands other than `run`.