### PR TITLE
concord-cli: do not call System.exit in RemoteSecretsProvider

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/AbortException.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/AbortException.java
@@ -1,0 +1,28 @@
+package com.walmartlabs.concord.cli;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public class AbortException extends RuntimeException {
+
+    public AbortException() {
+        super("Aborted");
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/secrets/RemoteSecretsProvider.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/secrets/RemoteSecretsProvider.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.cli.runner.secrets;
  * =====
  */
 
+import com.walmartlabs.concord.cli.AbortException;
 import com.walmartlabs.concord.cli.Version;
 import com.walmartlabs.concord.client2.*;
 import com.walmartlabs.concord.common.secret.BinaryDataSecret;
@@ -190,8 +191,7 @@ public class RemoteSecretsProvider implements SecretsProvider {
         int response = System.in.read();
         // y == 121, Y == 89
         if (response != 121 && response != 89) {
-            System.out.println(ansi().fgRed().a("Aborting.").reset());
-            System.exit(-1);
+            throw new AbortException();
         }
     }
 }


### PR DESCRIPTION
Make testing simpler by not using System.exit anywhere except the entrypoints.