### PR TITLE
resource-task: Use the shared IOUtils assertInPath method for resource lookups

### DIFF
--- a/plugins/tasks/resource/pom.xml
+++ b/plugins/tasks/resource/pom.xml
@@ -26,6 +26,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.walmartlabs.concord</groupId>
+            <artifactId>concord-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
@@ -39,6 +39,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.walmartlabs.concord.common.IOUtils.assertInPath;
+
+//import static com.walmartlabs.concord.common.IOUtils.assertInPath;
+
 public class ResourceTaskCommon {
 
     private static final String RESOURCE_PREFIX = "resource_";
@@ -232,26 +236,17 @@ public class ResourceTaskCommon {
         return s;
     }
 
-    private Path normalizePath(String path) {
+    private Path normalizePath(String path) throws IOException {
         Path p = Paths.get(path);
+        assertWorkDirPath(path);
         if (p.isAbsolute()) {
             return p;
         }
         return workDir.resolve(path);
     }
 
-    private Path assertWorkDirPath(String path) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path cannot be null");
-        }
-        Path dst = Paths.get(path);
-        if (!dst.isAbsolute()) {
-            dst = workDir.resolve(path).normalize().toAbsolutePath();
-        }
-        if (!dst.startsWith(workDir)) {
-            throw new IllegalArgumentException("Invalid path: " + path);
-        }
-        return dst;
+    private Path assertWorkDirPath(String path) throws IOException {
+        return assertInPath(workDir, path);
     }
 
     private static ObjectWriter createYamlWriter() {

--- a/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
+++ b/plugins/tasks/resource/src/main/java/com/walmartlabs/concord/plugins/resource/ResourceTaskCommon.java
@@ -33,15 +33,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import static com.walmartlabs.concord.common.IOUtils.assertInPath;
-
-//import static com.walmartlabs.concord.common.IOUtils.assertInPath;
 
 public class ResourceTaskCommon {
 
@@ -236,17 +233,16 @@ public class ResourceTaskCommon {
         return s;
     }
 
-    private Path normalizePath(String path) throws IOException {
-        Path p = Paths.get(path);
-        assertWorkDirPath(path);
-        if (p.isAbsolute()) {
-            return p;
-        }
-        return workDir.resolve(path);
+    private Path normalizePath(String path) {
+        return assertWorkDirPath(path);
     }
 
-    private Path assertWorkDirPath(String path) throws IOException {
-        return assertInPath(workDir, path);
+    private Path assertWorkDirPath(String path) {
+        try {
+            return assertInPath(workDir,path);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Not authorized to access file outside of working directory: " + path);
+        }
     }
 
     private static ObjectWriter createYamlWriter() {


### PR DESCRIPTION
Using the IOUtils assertInPath to reduce duplicate code. 