### PR TITLE
project: enable trimHeaderLine in license-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
                     <processStartTag>*****</processStartTag>
                     <sectionDelimiter>-----</sectionDelimiter>
                     <processEndTag>=====</processEndTag>
+                    <trimHeaderLine>true</trimHeaderLine>
                     <roots>
                         <root>src/main/java</root>
                         <root>src/test/java</root>


### PR DESCRIPTION
Enable trimHeaderLine in license-maven-plugin to avoid trailing white space in the license header.
Most formatters (including Checkstyle) do not like trailing white space and it was a constant source of random superfluous diffs in Git.
Not going to reformat the existing files though but all new files should have their license headers "fixed".