### PR TITLE
oidc: remove pac4j dependency

### DIFF
--- a/server/plugins/oidc/pom.xml
+++ b/server/plugins/oidc/pom.xml
@@ -16,15 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-oidc</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.walmartlabs.concord.server</groupId>
             <artifactId>concord-server-sdk</artifactId>
             <scope>provided</scope>
@@ -77,6 +68,11 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcCallbackFilter.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcCallbackFilter.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * *****
  * Concord
  * -----
- * Copyright (C) 2020 Ivan Bodrov
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,16 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * =====
  */
 
-import org.pac4j.core.config.Config;
-import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.session.SessionStore;
-import org.pac4j.core.engine.CallbackLogic;
-import org.pac4j.core.exception.TechnicalException;
-import org.pac4j.core.util.Pac4jConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
 public class OidcCallbackFilter implements Filter {
@@ -42,39 +37,43 @@ public class OidcCallbackFilter implements Filter {
     private static final Logger log = LoggerFactory.getLogger(OidcCallbackFilter.class);
 
     public static final String URL = "/api/service/oidc/callback";
+    private static final String SESSION_STATE_KEY = "OIDC_STATE";
+    private static final String SESSION_REDIRECT_KEY = "OIDC_REDIRECT_URL";
+    private static final String SESSION_PROFILE_KEY = "OIDC_USER_PROFILE";
 
     private final PluginConfiguration cfg;
-    private final Config pac4jConfig;
+    private final OidcService oidcService;
 
     @Inject
-    public OidcCallbackFilter(PluginConfiguration cfg,
-                              @Named("oidc") Config pac4jConfig) {
-
+    public OidcCallbackFilter(PluginConfiguration cfg, OidcService oidcService) {
         this.cfg = cfg;
-        this.pac4jConfig = pac4jConfig;
+        this.oidcService = oidcService;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException {
-        HttpServletRequest req = (HttpServletRequest) request;
-        HttpServletResponse resp = (HttpServletResponse) response;
+        var req = (HttpServletRequest) request;
+        var resp = (HttpServletResponse) response;
 
         if (!cfg.isEnabled()) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "OIDC disabled");
             return;
         }
 
-        JEEContext context = new JEEContext(req, resp, pac4jConfig.getSessionStore());
+        var session = req.getSession(false);
+        if (session == null) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "No session");
+            return;
+        }
 
-        String postLoginUrl = removeRequestedUrl(context);
+        var postLoginUrl = (String) session.getAttribute(SESSION_REDIRECT_KEY);
         if (postLoginUrl == null || postLoginUrl.trim().isEmpty()) {
             postLoginUrl = cfg.getAfterLoginUrl();
         }
 
-        String error = req.getParameter("error");
+        var error = req.getParameter("error");
         if (error != null) {
-            String derivedError = "unknown";
+            var derivedError = "unknown";
             if ("access_denied".equals(error)) {
                 derivedError = "oidc_access_denied";
             }
@@ -82,37 +81,31 @@ public class OidcCallbackFilter implements Filter {
             return;
         }
 
+        var code = req.getParameter("code");
+        var state = req.getParameter("state");
+        var expectedState = (String) session.getAttribute(SESSION_STATE_KEY);
+
+        if (code == null || state == null || !state.equals(expectedState)) {
+            log.warn("Invalid callback parameters: code={}, state={}, expectedState={}", code != null, state, expectedState);
+            session.invalidate();
+            resp.sendRedirect(resp.encodeRedirectURL(OidcAuthFilter.URL + "?from=" + postLoginUrl));
+            return;
+        }
+
         try {
-            CallbackLogic<?, JEEContext> callback = pac4jConfig.getCallbackLogic();
-            callback.perform(context, pac4jConfig, pac4jConfig.getHttpActionAdapter(), postLoginUrl, true, false, true, OidcPluginModule.CLIENT_NAME);
-        } catch (TechnicalException e) {
+            var redirectUri = cfg.getUrlBase() + URL + "?client_name=oidc";
+            var profile = oidcService.exchangeCodeForProfile(code, redirectUri);
+
+            session.setAttribute(SESSION_PROFILE_KEY, profile);
+            session.removeAttribute(SESSION_STATE_KEY);
+            session.removeAttribute(SESSION_REDIRECT_KEY);
+
+            resp.sendRedirect(resp.encodeRedirectURL(postLoginUrl));
+
+        } catch (Exception e) {
             log.warn("OIDC callback error: {}", e.getMessage());
-            HttpSession session = req.getSession(false);
-            if (session != null) {
-                session.invalidate();
-            }
+            session.invalidate();
             resp.sendRedirect(resp.encodeRedirectURL(OidcAuthFilter.URL + "?from=" + postLoginUrl));
         }
-    }
-
-    @Override
-    public void init(FilterConfig filterConfig) {
-        // do nothing
-    }
-
-    @Override
-    public void destroy() {
-        // do nothing
-    }
-
-    @SuppressWarnings("unchecked")
-    private static String removeRequestedUrl(JEEContext context) {
-        SessionStore<JEEContext> sessionStore = context.getSessionStore();
-        Object result = sessionStore.get(context, Pac4jConstants.REQUESTED_URL).orElse(null);
-        sessionStore.set(context, Pac4jConstants.REQUESTED_URL, "");
-        if (result instanceof String) {
-            return (String) result;
-        }
-        return null;
     }
 }

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcFilterChainConfigurator.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcFilterChainConfigurator.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * *****
  * Concord
  * -----
- * Copyright (C) 2020 Ivan Bodrov
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ import com.walmartlabs.concord.server.boot.FilterChainConfigurator;
 import org.apache.shiro.web.filter.mgt.FilterChainManager;
 
 import javax.inject.Inject;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class OidcFilterChainConfigurator implements FilterChainConfigurator {
 
@@ -36,9 +39,9 @@ public class OidcFilterChainConfigurator implements FilterChainConfigurator {
                                        OidcCallbackFilter callbackFilter,
                                        OidcLogoutFilter logoutFilter) {
 
-        this.authFilter = authFilter;
-        this.callbackFilter = callbackFilter;
-        this.logoutFilter = logoutFilter;
+        this.authFilter = requireNonNull(authFilter);
+        this.callbackFilter = requireNonNull(callbackFilter);
+        this.logoutFilter = requireNonNull(logoutFilter);
     }
 
     @Override

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcPluginModule.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcPluginModule.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,70 +21,23 @@ package com.walmartlabs.concord.server.plugins.oidc;
  */
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.walmartlabs.concord.server.boot.FilterChainConfigurator;
 import com.walmartlabs.concord.server.boot.filters.AuthenticationHandler;
 import org.apache.shiro.realm.Realm;
-import org.pac4j.core.client.Clients;
-import org.pac4j.core.config.Config;
-import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.session.JEESessionStore;
-import org.pac4j.core.engine.DefaultCallbackLogic;
-import org.pac4j.core.engine.DefaultLogoutLogic;
-import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
-import org.pac4j.oidc.client.OidcClient;
-import org.pac4j.oidc.config.OidcConfiguration;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 @Named
 public class OidcPluginModule extends AbstractModule {
 
-    public static final String CLIENT_NAME = "oidc";
-
     @Override
     protected void configure() {
+        bind(OidcService.class).in(SINGLETON);
         newSetBinder(binder(), AuthenticationHandler.class).addBinding().to(OidcAuthenticationHandler.class);
         newSetBinder(binder(), FilterChainConfigurator.class).addBinding().to(OidcFilterChainConfigurator.class);
         newSetBinder(binder(), Realm.class).addBinding().to(OidcRealm.class);
-    }
-
-    @Provides
-    public OidcConfiguration oidcConfiguration(PluginConfiguration cfg) {
-        OidcConfiguration oidcCfg = new OidcConfiguration();
-        oidcCfg.setClientId(cfg.getClientId());
-        oidcCfg.setSecret(cfg.getSecret());
-        oidcCfg.setDiscoveryURI(cfg.getDiscoveryUri());
-        if (cfg.getScopes() != null) {
-            oidcCfg.setScope(String.join(" ", cfg.getScopes()));
-        }
-        return oidcCfg;
-    }
-
-    @Provides
-    @Singleton
-    public OidcClient<?> oidcClient(PluginConfiguration cfg, OidcConfiguration oidcCfg) {
-        OidcClient<?> client = new OidcClient<>(oidcCfg);
-        client.setName(CLIENT_NAME);
-        client.setCallbackUrl(cfg.getUrlBase() + OidcCallbackFilter.URL);
-        return client;
-    }
-
-    @Provides
-    @Named("oidc")
-    public Config pac4jConfig(OidcClient<?> client) {
-        Config config = new Config();
-        config.setSessionStore(new JEESessionStore());
-        config.setCallbackLogic(new DefaultCallbackLogic<Object, JEEContext>());
-        config.setLogoutLogic(new DefaultLogoutLogic<Object, JEEContext>());
-        config.setHttpActionAdapter(JEEHttpActionAdapter.INSTANCE);
-
-        Clients clients = new Clients(client);
-        config.setClients(clients);
-
-        return config;
     }
 }

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcService.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcService.java
@@ -1,0 +1,173 @@
+package com.walmartlabs.concord.server.plugins.oidc;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class OidcService {
+
+    private final PluginConfiguration cfg;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private volatile DiscoveryDocument discoveryDocument;
+
+    @Inject
+    public OidcService(PluginConfiguration cfg) {
+        this.cfg = requireNonNull(cfg);
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public String buildAuthorizationUrl(String redirectUri, String state) {
+        var discovery = getDiscoveryDocument();
+        var scopes = cfg.getScopes() != null ? String.join(" ", cfg.getScopes()) : "openid email profile";
+        return discovery.authorizationEndpoint() + "?" +
+               "response_type=code" +
+               "&client_id=" + urlEncode(cfg.getClientId()) +
+               "&redirect_uri=" + urlEncode(redirectUri) +
+               "&scope=" + urlEncode(scopes) +
+               "&state=" + urlEncode(state);
+    }
+
+    public UserProfile exchangeCodeForProfile(String code, String redirectUri) throws IOException {
+        var discovery = getDiscoveryDocument();
+
+        var tokenRequest = "grant_type=authorization_code" +
+                           "&code=" + urlEncode(code) +
+                           "&redirect_uri=" + urlEncode(redirectUri) +
+                           "&client_id=" + urlEncode(cfg.getClientId()) +
+                           "&client_secret=" + urlEncode(cfg.getSecret());
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(discovery.tokenEndpoint()))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(BodyPublishers.ofString(tokenRequest))
+                .build();
+
+        try {
+            var response = httpClient.send(request, BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new IOException("Token exchange failed: " + response.statusCode() + " " + response.body());
+            }
+
+            var tokenResponse = objectMapper.readTree(response.body());
+            var accessToken = tokenResponse.get("access_token").asText();
+            if (accessToken == null) {
+                throw new IOException("No access token in response");
+            }
+
+            return getUserInfo(accessToken, discovery.userinfoEndpoint());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Request interrupted", e);
+        }
+    }
+
+    public UserProfile validateToken(String accessToken) throws IOException {
+        var discovery = getDiscoveryDocument();
+        return getUserInfo(accessToken, discovery.userinfoEndpoint());
+    }
+
+    private UserProfile getUserInfo(String accessToken, String userinfoEndpoint) throws IOException {
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(userinfoEndpoint))
+                .header("Authorization", "Bearer " + accessToken)
+                .GET()
+                .build();
+
+        try {
+            var response = httpClient.send(request, BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new IOException("UserInfo request failed: " + response.statusCode() + " " + response.body());
+            }
+
+            var userInfo = objectMapper.readTree(response.body());
+            var id = userInfo.get("sub").asText();
+            var email = userInfo.get("email").asText();
+            var displayName = userInfo.get("name").asText(email);
+            return new UserProfile(id, email, displayName, accessToken, userInfo);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Request interrupted", e);
+        }
+    }
+
+    private DiscoveryDocument getDiscoveryDocument() {
+        if (discoveryDocument == null) {
+            synchronized (this) {
+                if (discoveryDocument == null) {
+                    discoveryDocument = fetchDiscoveryDocument();
+                }
+            }
+        }
+        return discoveryDocument;
+    }
+
+    private DiscoveryDocument fetchDiscoveryDocument() {
+        try {
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create(cfg.getDiscoveryUri()))
+                    .GET()
+                    .build();
+
+            var response = httpClient.send(request, BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("Discovery document fetch failed: " + response.statusCode());
+            }
+
+            var discovery = objectMapper.readTree(response.body());
+            return new DiscoveryDocument(
+                    discovery.get("authorization_endpoint").asText(),
+                    discovery.get("token_endpoint").asText(),
+                    discovery.get("userinfo_endpoint").asText()
+            );
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to fetch OIDC discovery document", e);
+        }
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, UTF_8);
+    }
+
+    private record DiscoveryDocument(
+            String authorizationEndpoint,
+            String tokenEndpoint,
+            String userinfoEndpoint
+    ) {
+    }
+}

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcToken.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/OidcToken.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,27 +21,28 @@ package com.walmartlabs.concord.server.plugins.oidc;
  */
 
 import org.apache.shiro.authc.AuthenticationToken;
-import org.pac4j.oidc.profile.OidcProfile;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class OidcToken implements AuthenticationToken, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
-    private final OidcProfile profile;
+    private final UserProfile profile;
 
-    public OidcToken(OidcProfile profile) {
+    public OidcToken(UserProfile profile) {
         this.profile = profile;
     }
 
-    public OidcProfile getProfile() {
+    public UserProfile getProfile() {
         return profile;
     }
 
     @Override
     public Object getPrincipal() {
-        return profile.getId();
+        return profile.id();
     }
 
     @Override

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/PluginConfiguration.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.server.plugins.oidc;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc.
+ * Copyright (C) 2017 - 2025 Walmart Inc.
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/UserProfile.java
+++ b/server/plugins/oidc/src/main/java/com/walmartlabs/concord/server/plugins/oidc/UserProfile.java
@@ -1,0 +1,35 @@
+package com.walmartlabs.concord.server.plugins.oidc;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record UserProfile(
+        String id,
+        String email,
+        String displayName,
+        String accessToken,
+        JsonNode attributes) {
+
+    public Object getAttribute(String name) {
+        return attributes != null ? attributes.get(name) : null;
+    }
+}

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -106,7 +106,6 @@
         <mockito.version>4.9.0</mockito.version>
         <mustache.version>0.9.10</mustache.version>
         <nimbus.jwt.version>8.23</nimbus.jwt.version>
-        <pac4j.version>4.5.8</pac4j.version>
         <parc.version>0.1.2</parc.version>
         <picocli.version>4.7.0</picocli.version>
         <postgres.version>42.7.3</postgres.version>
@@ -1231,16 +1230,6 @@
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
                 <version>${jna.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.pac4j</groupId>
-                <artifactId>pac4j-core</artifactId>
-                <version>${pac4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.pac4j</groupId>
-                <artifactId>pac4j-oidc</artifactId>
-                <version>${pac4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
Remove pac4j-oidc and implement the authorization flow manually.

Note, this change can break SUSPENDED processes with OIDC initiators due to the way concord-server serializes security principals.