### PR TITLE
concord-server: do not create UserPrincipal for API keys without userId

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserPrincipal.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserPrincipal.java
@@ -26,6 +26,8 @@ import com.walmartlabs.concord.server.user.UserType;
 import java.io.Serializable;
 import java.util.UUID;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * <b>Note:</b> this class is serialized when user principals are stored in
  * the process state. It must maintain backward compatibility.
@@ -46,8 +48,8 @@ public class UserPrincipal implements Serializable {
     private final UserEntry user;
 
     public UserPrincipal(String realm, UserEntry user) {
-        this.realm = realm;
-        this.user = user;
+        this.realm = requireNonNull(realm);
+        this.user = requireNonNull(user);
     }
 
     public String getRealm() {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyRealm.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/apikey/ApiKeyRealm.java
@@ -37,7 +37,8 @@ import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 
 import javax.inject.Inject;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ApiKeyRealm extends AuthorizingRealm {
 
@@ -80,17 +81,21 @@ public class ApiKeyRealm extends AuthorizingRealm {
                 .field("apiKeyId", t.getKeyId())
                 .log();
 
-        UserPrincipal p = new UserPrincipal(REALM_NAME, u);
-        return new SimpleAccount(Arrays.asList(p, t), t.getKey(), getName());
+        List<Object> principals = new ArrayList<>();
+        if (u != null) {
+            principals.add(new UserPrincipal(REALM_NAME, u));
+        }
+        principals.add(t);
+
+        return new SimpleAccount(principals, t.getKey(), getName());
     }
 
     @Override
     protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
-        UserPrincipal p = principals.oneByType(UserPrincipal.class);
-        if (!REALM_NAME.equals(p.getRealm())) {
+        ApiKey principal = principals.oneByType(ApiKey.class);
+        if (principal == null) {
             return null;
         }
-
         return SecurityUtils.toAuthorizationInfo(principals);
     }
 }


### PR DESCRIPTION
UserPrincipal#user should not be null. Instead, we should skip `UserPrincipal` entirely when authenticating via an API key without the user.