### PR TITLE
cli: allow tasks to interact with remote during local runs

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -237,6 +237,10 @@ public class Run implements Callable<Integer> {
                 .debug(processDefinition.configuration().debug())
                 .build();
 
+        if (verbosity.verbose()) {
+            System.out.println("Using '" + runnerCfg.api().baseUrl() + "' as API base URL");
+        }
+
         Map<String, Object> overlayArgs = MapUtils.getMap(overlayCfg, Constants.Request.ARGUMENTS_KEY, Collections.emptyMap());
         Map<String, Object> args = ConfigurationUtils.deepMerge(processDefinition.configuration().arguments(), overlayArgs, extraVars);
         args.put(Constants.Context.TX_ID_KEY, instanceId.toString());

--- a/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/Run.java
@@ -277,6 +277,7 @@ public class Run implements Callable<Integer> {
 
         ProcessInfo processInfo = ProcessInfo.builder()
                 .activeProfiles(profiles)
+                .sessionToken("<undefined>")
                 .build();
 
         ProcessConfiguration cfg = from(processDefinition.configuration(), processInfo, projectInfo(args))

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
@@ -1,0 +1,44 @@
+package com.walmartlabs.concord.cli.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.cli.CliConfig;
+import com.walmartlabs.concord.cli.Verbosity;
+import com.walmartlabs.concord.cli.secrets.CliSecretService;
+
+import java.nio.file.Path;
+
+public record ApiKey(String value) {
+
+    public static ApiKey create(CliConfig.CliConfigContext cliConfigContext, Path workDir, Verbosity verbosity) {
+        CliConfig.RemoteRunConfiguration remoteRunConfig = cliConfigContext.remoteRun();
+        if (remoteRunConfig == null || remoteRunConfig.apiKeyRef() == null) {
+            return new ApiKey(null);
+        }
+
+        CliSecretService secretService = CliSecretService.create(cliConfigContext, workDir, verbosity);
+        try {
+            return new ApiKey(secretService.exportAsString(remoteRunConfig.apiKeyRef().orgName(), remoteRunConfig.apiKeyRef().secretName(), null));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to fetch the API key. " + e.getMessage());
+        }
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
@@ -34,6 +34,10 @@ public record ApiKey(String value) {
             return new ApiKey(null);
         }
 
+        if (verbosity.verbose()) {
+            System.out.println("Using '" + remoteRunConfig.apiKeyRef() + "' as a secret for API key");
+        }
+
         CliSecretService secretService = CliSecretService.create(cliConfigContext, workDir, verbosity);
         try {
             return new ApiKey(secretService.exportAsString(remoteRunConfig.apiKeyRef().orgName(), remoteRunConfig.apiKeyRef().secretName(), null));

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/ApiKey.java
@@ -41,4 +41,9 @@ public record ApiKey(String value) {
             throw new RuntimeException("Unable to fetch the API key. " + e.getMessage());
         }
     }
+
+    @Override
+    public String toString() {
+        return "***";
+    }
 }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliApiClientFactory.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliApiClientFactory.java
@@ -1,0 +1,47 @@
+package com.walmartlabs.concord.cli.runner;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.client2.ApiClient;
+import com.walmartlabs.concord.client2.ApiClientConfiguration;
+import com.walmartlabs.concord.client2.ApiClientFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+public class CliApiClientFactory implements Provider<ApiClient> {
+
+    private final ApiClientFactory clientFactory;
+    private final ApiKey apiKey;
+
+    @Inject
+    public CliApiClientFactory(ApiClientFactory clientFactory, ApiKey apiKey) {
+        this.clientFactory = clientFactory;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public ApiClient get() {
+        return clientFactory.create(ApiClientConfiguration.builder()
+                .apiKey(apiKey.value())
+                .build());
+    }
+}

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliApiClientProvider.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliApiClientProvider.java
@@ -23,25 +23,29 @@ package com.walmartlabs.concord.cli.runner;
 import com.walmartlabs.concord.client2.ApiClient;
 import com.walmartlabs.concord.client2.ApiClientConfiguration;
 import com.walmartlabs.concord.client2.ApiClientFactory;
+import com.walmartlabs.concord.runtime.v2.sdk.ProcessConfiguration;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-public class CliApiClientFactory implements Provider<ApiClient> {
+public class CliApiClientProvider implements Provider<ApiClient> {
 
     private final ApiClientFactory clientFactory;
     private final ApiKey apiKey;
+    private final ProcessConfiguration processCfg;
 
     @Inject
-    public CliApiClientFactory(ApiClientFactory clientFactory, ApiKey apiKey) {
+    public CliApiClientProvider(ApiClientFactory clientFactory, ApiKey apiKey, ProcessConfiguration processCfg) {
         this.clientFactory = clientFactory;
         this.apiKey = apiKey;
+        this.processCfg = processCfg;
     }
 
     @Override
     public ApiClient get() {
         return clientFactory.create(ApiClientConfiguration.builder()
                 .apiKey(apiKey.value())
+                .sessionToken(processCfg.processInfo().sessionToken())
                 .build());
     }
 }

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -83,7 +83,8 @@ public class CliServicesModule extends AbstractModule {
         bind(ProcessStatusCallback.class).toInstance(instanceId -> {
         });
 
-        bind(ApiClient.class).toProvider(ApiClientProvider.class);
+        bind(ApiKey.class).toInstance(ApiKey.create(cliConfigContext, workDir, verbosity));
+        bind(ApiClient.class).toProvider(CliApiClientFactory.class);
 
         bind(DefaultTaskVariablesService.class)
                 .toInstance(new MapBackedDefaultTaskVariablesService(readDefaultVars(defaultTaskVars)));

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -84,7 +84,7 @@ public class CliServicesModule extends AbstractModule {
         });
 
         bind(ApiKey.class).toInstance(ApiKey.create(cliConfigContext, workDir, verbosity));
-        bind(ApiClient.class).toProvider(CliApiClientFactory.class);
+        bind(ApiClient.class).toProvider(CliApiClientProvider.class);
 
         bind(DefaultTaskVariablesService.class)
                 .toInstance(new MapBackedDefaultTaskVariablesService(readDefaultVars(defaultTaskVars)));

--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -34,7 +34,6 @@ import com.walmartlabs.concord.runtime.v2.runner.checkpoints.CheckpointService;
 import com.walmartlabs.concord.runtime.v2.runner.guice.BaseRunnerModule;
 import com.walmartlabs.concord.runtime.v2.runner.logging.RunnerLogger;
 import com.walmartlabs.concord.runtime.v2.runner.logging.SimpleLogger;
-import com.walmartlabs.concord.runtime.v2.runner.remote.ApiClientProvider;
 import com.walmartlabs.concord.runtime.v2.runner.tasks.TaskCallListener;
 import com.walmartlabs.concord.runtime.v2.sdk.DockerService;
 import com.walmartlabs.concord.runtime.v2.sdk.LockService;


### PR DESCRIPTION
For example, if a flow has a `jsonStore` task and you want to run the flow locally, why shouldn’t the task be able to call the server...