### PR TITLE
console2: fix `copyToClipboard is not a function`

### DIFF
--- a/console2/src/components/molecules/WithCopyToClipboard/index.tsx
+++ b/console2/src/components/molecules/WithCopyToClipboard/index.tsx
@@ -18,7 +18,7 @@
  * =====
  */
 
-import * as copyToClipboard from 'copy-to-clipboard';
+import copyToClipboard from 'copy-to-clipboard';
 import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 

--- a/console2/src/components/organisms/EncryptValueActivity/index.tsx
+++ b/console2/src/components/organisms/EncryptValueActivity/index.tsx
@@ -18,7 +18,7 @@
  * =====
  */
 
-import * as copyToClipboard from 'copy-to-clipboard';
+import copyToClipboard from 'copy-to-clipboard';
 import * as React from 'react';
 import { Form, Icon, Input, Message } from 'semantic-ui-react';
 

--- a/console2/src/components/organisms/PublicKeyPopup/index.tsx
+++ b/console2/src/components/organisms/PublicKeyPopup/index.tsx
@@ -18,7 +18,7 @@
  * =====
  */
 
-import * as copyToClipboard from 'copy-to-clipboard';
+import copyToClipboard from 'copy-to-clipboard';
 import * as React from 'react';
 import { Button, Loader, Popup, TextArea } from 'semantic-ui-react';
 


### PR DESCRIPTION
```
index.tsx:40 Uncaught TypeError: copyToClipboard is not a function                                                    
      at Object.onClick (index.tsx:40:33)                                                                                                                      
      at apply (chunk-XFIPZT3T.js?v=53609990:401:19)                                                                                                               
      at baseInvoke (chunk-XFIPZT3T.js?v=53609990:487:34)                                                                                                          
      at apply (chunk-XFIPZT3T.js?v=53609990:403:19)                                                                                                           
      at chunk-XFIPZT3T.js?v=53609990:526:12                                                                                                                   
      at Icon2._this.handleClick (chunk-XFIPZT3T.js?v=53609990:4622:11)                                                                                        
      at HTMLUnknownElement.callCallback2 (chunk-PVMPZHOQ.js?v=53609990:3680:22)                                                                               
      at Object.invokeGuardedCallbackDev (chunk-PVMPZHOQ.js?v=53609990:3705:24)                                                                                
      at invokeGuardedCallback (chunk-PVMPZHOQ.js?v=53609990:3739:39)                                                                                          
      at invokeGuardedCallbackAndCatchFirstError (chunk-PVMPZHOQ.js?v=53609990:3742:33)                                                                                                                                                                     
```