### PR TITLE
runtime-v2: fix JoinCommand not waiting for threads in UNWINDING state

### DIFF
--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommand.java
@@ -27,9 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serial;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 public class JoinCommand<T extends Step> extends StepCommand<T> {
 
@@ -57,56 +55,52 @@ public class JoinCommand<T extends Step> extends StepCommand<T> {
         // We could've used futures instead, but it's way more
         // complicated - especially when suspend/resume are involved.
 
+        var finalStatuses = waitForChildren(state);
+        var failed = finalStatuses.entrySet().stream()
+                .filter(e -> e.getValue() == ThreadStatus.FAILED)
+                .map(Map.Entry::getKey)
+                .toList();
+        if (!failed.isEmpty()) {
+            throw new ParallelExecutionException(failed.stream()
+                    .map(state::clearThreadError)
+                    .filter(Objects::nonNull)
+                    .toList());
+        }
+
+        if (finalStatuses.containsValue(ThreadStatus.SUSPENDED)) {
+            log.trace("eval [{}] -> children suspended, suspending parent", threadId);
+            state.setStatus(threadId, ThreadStatus.SUSPENDED);
+            return;
+        }
+
+        state.peekFrame(threadId).pop();
+    }
+
+    private Map<ThreadId, ThreadStatus> waitForChildren(State state) {
         while (true) {
-            Map<ThreadId, ThreadStatus> status = state.threadStatus();
+            var allStatuses = state.threadStatus();
 
-            boolean allDone = status.entrySet().stream()
-                    .map(e -> ids.contains(e.getKey()) ? e.getValue() : ThreadStatus.DONE)
-                    .allMatch(e -> e == ThreadStatus.DONE);
-
-            // all children are done, proceed with the execution
-            if (allDone) {
-                state.peekFrame(threadId).pop();
-                return;
+            var targets = new HashMap<ThreadId, ThreadStatus>();
+            var active = false;
+            for (var id : ids) {
+                // null means the thread completed and was removed by gc()
+                var s = allStatuses.getOrDefault(id, ThreadStatus.DONE);
+                targets.put(id, s);
+                if (s == ThreadStatus.READY || s == ThreadStatus.UNWINDING) {
+                    active = true;
+                }
             }
 
-            boolean anySuspended = anyMatch(status, ids, ThreadStatus.SUSPENDED);
-            boolean anyReady = anyMatch(status, ids, ThreadStatus.READY);
-
-            // all children are either DONE or SUSPENDED - suspend the parent execution
-            if (!anyReady && anySuspended) {
-                log.trace("eval [{}] -> some of the children are SUSPENDED, suspending the parent thread", threadId);
-                state.setStatus(threadId, ThreadStatus.SUSPENDED);
-                return;
+            if (!active) {
+                return targets;
             }
 
-            // find if some of the threads has failed with an unhandled exception
-            Collection<ThreadId> failed = status.entrySet().stream()
-                    .filter(e -> ids.contains(e.getKey()))
-                    .filter(e -> e.getValue() == ThreadStatus.FAILED)
-                    .map(Map.Entry::getKey)
-                    .toList();
-
-            // nothing left to run and we got some unhandled exceptions
-            if (!failed.isEmpty() && !anyReady) {
-                throw new ParallelExecutionException(failed.stream()
-                        .map(state::clearThreadError)
-                        .filter(Objects::nonNull)
-                        .toList());
-            }
-
-            // some children are still running, wait for a bit and then check again
             try {
                 Thread.sleep(BUSY_WAIT_SLEEP);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                throw new RuntimeException("JoinCommand interrupted", e);
             }
         }
-    }
-
-    private static boolean anyMatch(Map<ThreadId, ThreadStatus> status, Collection<ThreadId> ids, ThreadStatus match) {
-        return status.entrySet().stream()
-                .filter(e -> ids.contains(e.getKey()))
-                .anyMatch(e -> e.getValue() == match);
     }
 }

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommandTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommandTest.java
@@ -31,6 +31,149 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JoinCommandTest {
 
     @Test
+    public void testAllChildrenDoneShouldContinueExecution() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child1 = state.nextThreadId();
+        ThreadId child2 = state.nextThreadId();
+
+        state.setStatus(child1, ThreadStatus.DONE);
+        state.setStatus(child2, ThreadStatus.DONE);
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child1, child2), null);
+        state.peekFrame(parentThread).push(joinCommand);
+
+        // Should not throw — all children completed successfully
+        assertDoesNotThrow(() -> joinCommand.execute(null, state, parentThread));
+
+        // Parent thread should NOT be suspended
+        assertNotEquals(ThreadStatus.SUSPENDED, state.getStatus(parentThread));
+    }
+
+    @Test
+    public void testSuspendedChildShouldSuspendParent() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child1 = state.nextThreadId();
+        ThreadId child2 = state.nextThreadId();
+
+        state.setStatus(child1, ThreadStatus.DONE);
+        state.setStatus(child2, ThreadStatus.SUSPENDED);
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child1, child2), null);
+
+        joinCommand.execute(null, state, parentThread);
+
+        assertEquals(ThreadStatus.SUSPENDED, state.getStatus(parentThread));
+    }
+
+    @Test
+    public void testMultipleFailedThreadsShouldCollectAllErrors() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child1 = state.nextThreadId();
+        ThreadId child2 = state.nextThreadId();
+        ThreadId child3 = state.nextThreadId();
+
+        state.setStatus(child1, ThreadStatus.DONE);
+        state.setStatus(child2, ThreadStatus.FAILED);
+        state.setStatus(child3, ThreadStatus.FAILED);
+
+        Exception error2 = new RuntimeException("error from child2");
+        Exception error3 = new RuntimeException("error from child3");
+        state.setThreadError(child2, error2);
+        state.setThreadError(child3, error3);
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child1, child2, child3), null);
+
+        ParallelExecutionException exception = assertThrows(
+                ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        assertEquals(2, exception.getExceptions().size());
+        assertTrue(exception.getExceptions().containsAll(List.of(error2, error3)));
+    }
+
+    @Test
+    public void testFailedThreadWithNoErrorShouldBeFilteredOut() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child1 = state.nextThreadId();
+        ThreadId child2 = state.nextThreadId();
+
+        state.setStatus(child1, ThreadStatus.FAILED);
+        state.setStatus(child2, ThreadStatus.FAILED);
+
+        // Only set error for child1; child2 has no error — clearThreadError returns null
+        Exception error1 = new RuntimeException("error 1");
+        state.setThreadError(child1, error1);
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child1, child2), null);
+
+        ParallelExecutionException exception = assertThrows(
+                ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        // Only non-null errors should be included
+        assertEquals(1, exception.getExceptions().size());
+        assertSame(error1, exception.getExceptions().get(0));
+    }
+
+    @Test
+    public void testFailedTakePriorityOverSuspended() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child1 = state.nextThreadId();
+        ThreadId child2 = state.nextThreadId();
+
+        state.setStatus(child1, ThreadStatus.FAILED);
+        state.setStatus(child2, ThreadStatus.SUSPENDED);
+
+        Exception error = new RuntimeException("failure");
+        state.setThreadError(child1, error);
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child1, child2), null);
+
+        // Should throw even though child2 is suspended — failures are checked first
+        ParallelExecutionException exception = assertThrows(
+                ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        assertEquals(1, exception.getExceptions().size());
+        assertSame(error, exception.getExceptions().get(0));
+    }
+
+    @Test
+    public void testErrorsClearedFromStateAfterFailure() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child = state.nextThreadId();
+
+        state.setStatus(child, ThreadStatus.FAILED);
+        state.setThreadError(child, new RuntimeException("err"));
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child), null);
+
+        assertThrows(ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        // clearThreadError should have removed the error from state
+        assertNull(state.getThreadError(child));
+    }
+
+    @Test
     public void testFailedThreadsShouldBeFilteredByOwnedIds() {
         // Setup state with a root frame for the parent thread
         Frame rootFrame = Frame.builder().root().build();


### PR DESCRIPTION
for failed test: 
```
ProcessIT.testThrowParallelWithPayload:771 expected: <[BOOM1, BOOM2]> but was: <[BOOM1]>
```

something like this I think:
```
T1 throws an exception: UNWINDING -> FAILED
T2 throws an exception later, still in UNWINDING state
JoinCommand sees: thread 1 = FAILED, thread 2 = UNWINDING
Check: !failed.isEmpty() = true, !anyReady = true (UNWINDING != READY)
and throws ParallelExecutionException with only BOOM1
                                     
T2 hasn't reached FAILED yet, its error is lost 
```