### PR TITLE
server: make git allowedSchemes configurable and support non-string values in test server config

### DIFF
--- a/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
+++ b/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
@@ -48,7 +48,7 @@ import static java.util.Objects.requireNonNull;
 public class TestingConcordServer implements AutoCloseable {
 
     private final PostgreSQLContainer<?> db;
-    private final Map<String, String> extraConfiguration;
+    private final Map<String, Object> extraConfiguration;
     private final List<Function<Config, Module>> extraModules;
     private final int apiPort;
     private final String adminApiKey;
@@ -60,7 +60,7 @@ public class TestingConcordServer implements AutoCloseable {
         this(db, 8001, Map.of(), List.of());
     }
 
-    public TestingConcordServer(PostgreSQLContainer<?> db, int apiPort, Map<String, String> extraConfiguration, List<Function<Config, Module>> extraModules) {
+    public TestingConcordServer(PostgreSQLContainer<?> db, int apiPort, Map<String, Object> extraConfiguration, List<Function<Config, Module>> extraModules) {
         this.db = requireNonNull(db);
         this.extraConfiguration = requireNonNull(extraConfiguration);
         this.apiPort = apiPort;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/GitConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/GitConfiguration.java
@@ -92,6 +92,10 @@ public class GitConfiguration implements OauthTokenConfig, Serializable {
     private long maxGitCliOutputBytes;
 
     @Inject
+    @Config("git.allowedSchemes")
+    private List<String> allowedSchemes;
+
+    @Inject
     @Config("git.systemAuth")
     List<com.typesafe.config.Config> authConfigs;
 
@@ -144,6 +148,10 @@ public class GitConfiguration implements OauthTokenConfig, Serializable {
 
     public long maxGitCliOutputBytes() {
         return maxGitCliOutputBytes;
+    }
+
+    public List<String> getAllowedSchemes() {
+        return allowedSchemes;
     }
 
     public List<MappingAuthConfig> getSystemAuth() {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -74,6 +75,7 @@ public class RepositoryManager {
                 .sshTimeout(gitCfg.getSshTimeout())
                 .sshTimeoutRetryCount(gitCfg.getSshTimeoutRetryCount())
                 .maxGitCliOutputBytes(gitCfg.maxGitCliOutputBytes())
+                .allowedSchemes(new HashSet<>(gitCfg.getAllowedSchemes()))
                 .build();
 
         this.gitCfg = gitCfg;


### PR DESCRIPTION
It looks like we forgot to read `allowedSchemas` from the config. As a result, the tests that use git with a `file://` URL are failing, and there’s no way to configure this:(

```
Provided repository ('file:///tmp/git10280318353382042985') contains an unsupported URI scheme: 'file'.
```