### PR TITLE
concord-server: assert permissions for process details

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/RunAsIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/RunAsIT.java
@@ -247,12 +247,13 @@ public class RunAsIT extends AbstractServerIT {
         Map<String, Object> data = Collections.singletonMap("msg", "Hello!");
         formsApi.submitForm(pe.getInstanceId(), formName, data);
 
-        // wait for the process to finish
+        // User B can submit the runAs form, but the process has no project and is still owned by user A.
+        setApiKey(apiKeyA.getKey());
 
+        // wait for the process to finish
         pe = waitForCompletion(getApiClient(), spr.getInstanceId());
 
         // check the logs
-
         resetApiKey();
 
         ab = getLog(pe.getInstanceId());

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessAccessManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessAccessManager.java
@@ -1,0 +1,84 @@
+package com.walmartlabs.concord.server.process;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.org.ResourceAccessLevel;
+import com.walmartlabs.concord.server.org.project.ProjectAccessManager;
+import com.walmartlabs.concord.server.process.queue.ProcessQueueManager;
+import com.walmartlabs.concord.server.sdk.ConcordApplicationException;
+import com.walmartlabs.concord.server.sdk.PartialProcessKey;
+import com.walmartlabs.concord.server.sdk.ProcessKey;
+import com.walmartlabs.concord.server.security.Roles;
+import com.walmartlabs.concord.server.security.UnauthorizedException;
+import com.walmartlabs.concord.server.security.UserPrincipal;
+import com.walmartlabs.concord.server.security.sessionkey.SessionKeyPrincipal;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response.Status;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+public class ProcessAccessManager {
+
+    private final ProjectAccessManager projectAccessManager;
+    private final ProcessQueueManager processQueueManager;
+
+    @Inject
+    public ProcessAccessManager(ProjectAccessManager projectAccessManager,
+                                ProcessQueueManager processQueueManager) {
+
+        this.projectAccessManager = projectAccessManager;
+        this.processQueueManager = processQueueManager;
+    }
+
+    public ProcessEntry assertAccess(UUID instanceId, Set<ProcessDataInclude> includes) {
+        var entry = processQueueManager.get(PartialProcessKey.from(instanceId), includes);
+        if (entry == null) {
+            throw new ConcordApplicationException("Process instance not found: " + instanceId, Status.NOT_FOUND);
+        }
+
+        if (Roles.isAdmin() || Roles.isGlobalReader()) {
+            return entry;
+        }
+
+        var current = UserPrincipal.assertCurrent();
+        if (current.getId().equals(entry.initiatorId())) {
+            return entry;
+        }
+
+        var sessionKey = SessionKeyPrincipal.getCurrent();
+        if (sessionKey != null) {
+            var processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
+            if (processKey.partOf(sessionKey.getProcessKey())) {
+                return entry;
+            }
+        }
+
+        if (entry.projectId() != null) {
+            projectAccessManager.assertAccess(entry.orgId(), entry.projectId(), null, ResourceAccessLevel.READER, false);
+            return entry;
+        }
+
+        throw new UnauthorizedException("The current user (" + current.getUsername() + ") doesn't have " +
+                                        "the necessary permissions to access process: " + entry.instanceId());
+    }
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessManager.java
@@ -148,7 +148,7 @@ public class ProcessManager {
             throw new ProcessException(processKey, "Process not found: " + processKey, Status.NOT_FOUND);
         }
 
-        ProcessEntry e = queueDao.get(rootProcessKey);
+        ProcessEntry e = queueManager.get(rootProcessKey);
         if (e == null) {
             throw new ProcessException(processKey, "Process not found: " + processKey, Status.NOT_FOUND);
         }
@@ -184,7 +184,7 @@ public class ProcessManager {
     }
 
     public void disable(ProcessKey processKey, boolean disabled) {
-        ProcessEntry e = queueDao.get(processKey);
+        ProcessEntry e = queueManager.get(processKey);
         if (e == null) {
             throw new ProcessException(processKey, "Process not found: " + processKey, Status.NOT_FOUND);
         }
@@ -279,7 +279,7 @@ public class ProcessManager {
     }
 
     public void restoreFromCheckpoint(ProcessKey processKey, UUID checkpointId) {
-        ProcessEntry entry = queueDao.get(processKey);
+        ProcessEntry entry = queueManager.get(processKey);
 
         checkpointManager.assertProcessAccess(entry);
 
@@ -305,7 +305,7 @@ public class ProcessManager {
         try {
             payload = payloadManager.createResumePayload(processKey, checkpointInfo.eventName(), null);
         } catch (IOException e) {
-            log.error("restore ['{}', '{}'] -> error creating a payload: {}", processKey, checkpointInfo.name(), e);
+            log.error("restore ['{}', '{}'] -> error creating a payload", processKey, checkpointInfo.name(), e);
             throw new ConcordApplicationException("Error creating a payload", e);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -491,13 +491,7 @@ public class ProcessResource implements Resource {
     @WithTimer
     @Deprecated
     public ProcessEntry get(@PathParam("id") UUID instanceId) {
-        PartialProcessKey processKey = PartialProcessKey.from(instanceId);
-        ProcessEntry e = processQueueManager.get(processKey);
-        if (e == null) {
-            log.warn("get ['{}'] -> not found", instanceId);
-            throw new ConcordApplicationException("Process instance not found", Status.NOT_FOUND);
-        }
-        return e;
+        return v2.get(instanceId, Set.of());
     }
 
     /**

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResourceV2.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResourceV2.java
@@ -30,7 +30,6 @@ import com.walmartlabs.concord.server.org.project.RepositoryDao;
 import com.walmartlabs.concord.server.process.queue.*;
 import com.walmartlabs.concord.server.process.queue.ProcessFilter.MetadataFilter;
 import com.walmartlabs.concord.server.sdk.ConcordApplicationException;
-import com.walmartlabs.concord.server.sdk.PartialProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessStatus;
 import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
 import com.walmartlabs.concord.server.sdk.rest.Resource;
@@ -47,8 +46,6 @@ import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -64,32 +61,30 @@ import static com.walmartlabs.concord.server.Utils.unwrap;
 @Tag(name = "ProcessV2")
 public class ProcessResourceV2 implements Resource {
 
-    private static final Logger log = LoggerFactory.getLogger(ProcessResourceV2.class);
-
     private final ProcessQueueDao queueDao;
-    private final ProcessQueueManager processQueueManager;
     private final ProjectDao projectDao;
     private final RepositoryDao repositoryDao;
     private final UserDao userDao;
     private final OrganizationManager orgManager;
     private final ProjectAccessManager projectAccessManager;
+    private final ProcessAccessManager processAccessManager;
 
     @Inject
     public ProcessResourceV2(ProcessQueueDao queueDao,
-                             ProcessQueueManager processQueueManager,
                              ProjectDao projectDao,
                              RepositoryDao repositoryDao,
                              UserDao userDao,
                              OrganizationManager orgManager,
-                             ProjectAccessManager projectAccessManager) {
+                             ProjectAccessManager projectAccessManager,
+                             ProcessAccessManager processAccessManager) {
 
         this.queueDao = queueDao;
-        this.processQueueManager = processQueueManager;
         this.projectDao = projectDao;
         this.repositoryDao = repositoryDao;
         this.userDao = userDao;
         this.orgManager = orgManager;
         this.projectAccessManager = projectAccessManager;
+        this.processAccessManager = processAccessManager;
     }
 
     /**
@@ -103,19 +98,7 @@ public class ProcessResourceV2 implements Resource {
     public ProcessEntry get(@PathParam("id") UUID instanceId,
                             @QueryParam("include") Set<ProcessDataInclude> includes) {
 
-        PartialProcessKey processKey = PartialProcessKey.from(instanceId);
-
-        ProcessEntry e = processQueueManager.get(processKey, includes);
-        if (e == null) {
-            log.warn("get ['{}'] -> not found", instanceId);
-            throw new ConcordApplicationException("Process instance not found", Status.NOT_FOUND);
-        }
-
-        if (e.projectId() != null) {
-            projectAccessManager.assertAccess(e.orgId(), e.projectId(), null, ResourceAccessLevel.READER, false);
-        }
-
-        return e;
+        return processAccessManager.assertAccess(instanceId, includes);
     }
 
     /**

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueDao.java
@@ -67,8 +67,6 @@ public class ProcessQueueDao extends AbstractDao {
 
     public static final String ENQUEUED_NOW_METRIC = "ENQUEUED_NOW";
 
-    private static final Set<ProcessDataInclude> DEFAULT_INCLUDES = Collections.singleton(ProcessDataInclude.CHILDREN_IDS);
-
     private static final TypeReference<List<ProcessCheckpointEntry>> LIST_OF_CHECKPOINTS = new TypeReference<List<ProcessCheckpointEntry>>() {
     };
     private static final TypeReference<List<CheckpointRestoreHistoryEntry>> LIST_OF_CHECKPOINTS_HISTORY = new TypeReference<List<CheckpointRestoreHistoryEntry>>() {
@@ -380,10 +378,6 @@ public class ProcessQueueDao extends AbstractDao {
 
             return i == 1;
         });
-    }
-
-    public ProcessEntry get(ProcessKey processKey) {
-        return get(processKey, DEFAULT_INCLUDES);
     }
 
     public ProcessEntry get(ProcessKey processKey, Set<ProcessDataInclude> includes) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/queue/ProcessQueueManager.java
@@ -45,15 +45,18 @@ import java.util.*;
 
 public class ProcessQueueManager {
 
+    private static final Set<ProcessDataInclude> DEFAULT_INCLUDES = Collections.singleton(ProcessDataInclude.CHILDREN_IDS);
+    private static final Set<ProcessStatus> TO_ENQUEUED_STATUSES = Set.of(
+            ProcessStatus.PREPARING,
+            ProcessStatus.RESUMING,
+            ProcessStatus.SUSPENDED
+    );
+
     private final ProcessQueueDao queueDao;
     private final ProcessKeyCache keyCache;
     private final ProcessEventManager eventManager;
     private final ProcessLogManager processLogManager;
     private final Set<ProcessStatusListener> statusListeners;
-
-    private static final Set<ProcessStatus> TO_ENQUEUED_STATUSES = new HashSet<>(Arrays.asList(
-            ProcessStatus.PREPARING, ProcessStatus.RESUMING, ProcessStatus.SUSPENDED
-    ));
 
     @Inject
     public ProcessQueueManager(ProcessQueueDao queueDao,
@@ -198,12 +201,16 @@ public class ProcessQueueManager {
         notifyStatusChange(tx, processKey, status);
     }
 
+    public ProcessEntry get(ProcessKey processKey) {
+        return queueDao.get(processKey, DEFAULT_INCLUDES);
+    }
+
     public ProcessEntry get(PartialProcessKey partialProcessKey) {
         ProcessKey key = keyCache.get(partialProcessKey.getInstanceId());
         if (key == null) {
             return null;
         }
-        return queueDao.get(key);
+        return queueDao.get(key, DEFAULT_INCLUDES);
     }
 
     public UUID getProjectId(PartialProcessKey partialProcessKey) {


### PR DESCRIPTION
I think we can be stricter here.

Note: this can break existing workflows that rely on being able to fetch process details as an arbitrary Concord user.