### PR TITLE
ci: split Docker base image builds

### DIFF
--- a/.github/workflows/docker-base-images.yml
+++ b/.github/workflows/docker-base-images.yml
@@ -1,0 +1,175 @@
+name: docker-base-images
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build
+        required: true
+        default: master
+        type: string
+      docker_tag:
+        description: Docker tag to apply to the published base images
+        required: true
+        default: latest
+        type: string
+      extra_docker_tag:
+        description: Optional additional Docker tag to apply to the published base images
+        required: false
+        type: string
+      docker_namespace:
+        description: Docker Hub namespace to publish into
+        required: true
+        default: walmartlabs
+        type: string
+  schedule:
+    - cron: '17 7 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-base-images-${{ github.event.inputs.docker_tag || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || 'master' }}
+
+      - name: Resolve build target
+        run: |
+          validate_tag() {
+            local tag="$1"
+            local name="$2"
+
+            if ! [[ "${tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
+              echo "${name} '${tag}' is not a valid Docker tag." >&2
+              exit 1
+            fi
+          }
+
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            build_ref='${{ github.event.inputs.ref }}'
+            build_tag='${{ github.event.inputs.docker_tag }}'
+            extra_tag='${{ github.event.inputs.extra_docker_tag }}'
+            docker_namespace='${{ github.event.inputs.docker_namespace }}'
+          else
+            build_ref='master'
+            build_tag="weekly-$(date -u +%Y%m%d)-$(git rev-parse --short=12 HEAD)"
+            extra_tag='latest'
+            docker_namespace='walmartlabs'
+          fi
+
+          validate_tag "${build_tag}" "Docker tag"
+          if [[ -n "${extra_tag}" ]]; then
+            validate_tag "${extra_tag}" "Extra Docker tag"
+          fi
+
+          if [[ -z "${docker_namespace}" ]]; then
+            echo "Docker namespace must not be empty." >&2
+            exit 1
+          fi
+
+          if [[ "${docker_namespace}" == */* ]]; then
+            echo "Docker base image publishing expects a Docker Hub namespace only, e.g. 'walmartlabs'." >&2
+            exit 1
+          fi
+
+          echo "BUILD_REF=${build_ref}" >> "$GITHUB_ENV"
+          echo "BUILD_TAG=${build_tag}" >> "$GITHUB_ENV"
+          echo "EXTRA_DOCKER_TAG=${extra_tag}" >> "$GITHUB_ENV"
+          echo "DOCKER_NAMESPACE=${docker_namespace}" >> "$GITHUB_ENV"
+          echo "Using BUILD_REF=${build_ref}"
+          echo "Using BUILD_TAG=${build_tag}"
+          echo "Using EXTRA_DOCKER_TAG=${extra_tag}"
+          echo "Using DOCKER_NAMESPACE=${docker_namespace}"
+          git rev-parse HEAD
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          driver: docker-container
+          driver-opts: |
+            network=host
+
+      - name: Login to DockerHub
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          username: ${{ secrets.OSS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.OSS_DOCKERHUB_PASSWORD }}
+
+      - name: Build Docker base images
+        working-directory: docker-images
+        run: |
+          platform_args=()
+          IFS=',' read -ra platforms <<< "${IMAGE_PLATFORMS}"
+          for platform in "${platforms[@]}"; do
+            platform="${platform//[[:space:]]/}"
+            if [[ -n "${platform}" ]]; then
+              platform_args+=(--set "*.platform=${platform}")
+            fi
+          done
+
+          docker buildx bake \
+            --push \
+            "${platform_args[@]}" \
+            --var "DOCKER_NAMESPACE=${DOCKER_NAMESPACE}" \
+            --var "DOCKER_TAG=${BUILD_TAG}" \
+            --var "JDK_VERSION=17" \
+            base-images
+
+      - name: Tag Docker base images
+        if: env.EXTRA_DOCKER_TAG != '' && env.EXTRA_DOCKER_TAG != env.BUILD_TAG
+        run: |
+          images=(
+            concord-base
+            concord-ansible
+          )
+
+          for image in "${images[@]}"; do
+            source_ref="${DOCKER_NAMESPACE}/${image}:${BUILD_TAG}"
+            target_ref="${DOCKER_NAMESPACE}/${image}:${EXTRA_DOCKER_TAG}"
+
+            echo "Tagging ${source_ref} as ${target_ref}"
+            docker buildx imagetools create \
+              -t "${target_ref}" \
+              "${source_ref}"
+          done
+
+      - name: Verify multi-arch manifests
+        run: |
+          images=(
+            concord-base
+            concord-ansible
+          )
+
+          tags=("${BUILD_TAG}")
+          if [[ -n "${EXTRA_DOCKER_TAG}" ]] && [[ "${EXTRA_DOCKER_TAG}" != "${BUILD_TAG}" ]]; then
+            tags+=("${EXTRA_DOCKER_TAG}")
+          fi
+
+          for tag in "${tags[@]}"; do
+            for image in "${images[@]}"; do
+              ref="${DOCKER_NAMESPACE}/${image}:${tag}"
+              echo "Inspecting ${ref}"
+              output=$(docker buildx imagetools inspect "${ref}")
+              printf '%s\n' "${output}"
+
+              printf '%s\n' "${output}" | grep -q 'linux/amd64'
+              printf '%s\n' "${output}" | grep -q 'linux/arm64'
+            done
+          done

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: walmartlabs
         type: string
+      base_docker_tag:
+        description: Docker tag of the published concord-base and concord-ansible images to use
+        required: true
+        default: latest
+        type: string
   pull_request:
     branches: [ 'master' ]
 
@@ -70,7 +75,11 @@ jobs:
             build_ref='${{ github.event.inputs.ref }}'
             build_tag='${{ github.event.inputs.docker_tag }}'
             docker_namespace='${{ github.event.inputs.docker_namespace }}'
+            base_docker_tag='${{ github.event.inputs.base_docker_tag }}'
+            bake_group='app-images'
             maven_also_make=''
+            maven_projects='docker-images/agent,docker-images/server,docker-images/agent-operator'
+            verify_images='concord-agent concord-server concord-agent-operator'
 
             release_tag="${build_ref#refs/tags/}"
             if ! [[ "${release_tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -89,11 +98,20 @@ jobs:
             build_ref='${{ github.event.pull_request.head.sha }}'
             build_tag="pr-${{ github.event.pull_request.number }}-$(git rev-parse --short=12 HEAD)"
             docker_namespace="${LOCAL_REGISTRY}/walmartlabs"
+            base_docker_tag=''
+            bake_group='default'
             maven_also_make='-am'
+            maven_projects='docker-images/base,docker-images/ansible,docker-images/agent,docker-images/server,docker-images/agent-operator'
+            verify_images='concord-base concord-ansible concord-agent concord-server concord-agent-operator'
           fi
 
           if ! [[ "${build_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
             echo "Tag '${build_tag}' is not a valid Docker tag." >&2
+            exit 1
+          fi
+
+          if [[ -n "${base_docker_tag}" ]] && ! [[ "${base_docker_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "Base image tag '${base_docker_tag}' is not a valid Docker tag." >&2
             exit 1
           fi
 
@@ -110,11 +128,18 @@ jobs:
           echo "BUILD_TAG=${build_tag}" >> "$GITHUB_ENV"
           echo "BUILD_REF=${build_ref}" >> "$GITHUB_ENV"
           echo "DOCKER_NAMESPACE=${docker_namespace}" >> "$GITHUB_ENV"
+          echo "BASE_DOCKER_TAG=${base_docker_tag}" >> "$GITHUB_ENV"
+          echo "BAKE_GROUP=${bake_group}" >> "$GITHUB_ENV"
           echo "MAVEN_ALSO_MAKE=${maven_also_make}" >> "$GITHUB_ENV"
+          echo "MAVEN_PROJECTS=${maven_projects}" >> "$GITHUB_ENV"
+          echo "VERIFY_IMAGES=${verify_images}" >> "$GITHUB_ENV"
           echo "Using BUILD_REF=${build_ref}"
           echo "Using BUILD_TAG=${build_tag}"
           echo "Using DOCKER_NAMESPACE=${docker_namespace}"
+          echo "Using BASE_DOCKER_TAG=${base_docker_tag}"
+          echo "Using BAKE_GROUP=${bake_group}"
           echo "Using MAVEN_ALSO_MAKE=${maven_also_make}"
+          echo "Using MAVEN_PROJECTS=${maven_projects}"
           git rev-parse HEAD
 
       - name: Restore Maven cache
@@ -168,6 +193,32 @@ jobs:
           username: ${{ secrets.OSS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.OSS_DOCKERHUB_PASSWORD }}
 
+      - name: Resolve published base images
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          resolve_image() {
+            local ref="$1"
+            local name="$2"
+            local output
+            local digest
+
+            echo "Inspecting ${ref}"
+            output=$(docker buildx imagetools inspect "${ref}")
+            printf '%s\n' "${output}"
+
+            digest=$(printf '%s\n' "${output}" | awk '$1 == "Digest:" { print $2; exit }')
+            if [[ -z "${digest}" ]]; then
+              echo "Unable to resolve digest for ${ref}" >&2
+              exit 1
+            fi
+
+            echo "${name}=${ref%:*}@${digest}" >> "$GITHUB_ENV"
+            echo "Using ${name}=${ref%:*}@${digest}"
+          }
+
+          resolve_image "${DOCKER_NAMESPACE}/concord-base:${BASE_DOCKER_TAG}" CONCORD_BASE_IMAGE
+          resolve_image "${DOCKER_NAMESPACE}/concord-ansible:${BASE_DOCKER_TAG}" CONCORD_ANSIBLE_IMAGE
+
       - name: Prepare Docker image contexts
         run: |
           mkdir -p "${WORK}" "${MAVEN_REPO_LOCAL}"
@@ -183,7 +234,7 @@ jobs:
             -Djava.io.tmpdir="${WORK}" \
             -DskipTests \
             -Pgha \
-            -pl docker-images/base,docker-images/ansible,docker-images/agent,docker-images/server,docker-images/agent-operator \
+            -pl "${MAVEN_PROJECTS}" \
             "${maven_reactor_args[@]}"
 
       - name: Build Docker images
@@ -198,22 +249,27 @@ jobs:
             fi
           done
 
-          docker buildx bake \
-            --push \
-            "${platform_args[@]}" \
-            --var "DOCKER_NAMESPACE=${DOCKER_NAMESPACE}" \
-            --var "DOCKER_TAG=${BUILD_TAG}" \
+          bake_args=(
+            --push
+            "${platform_args[@]}"
+            --var "DOCKER_NAMESPACE=${DOCKER_NAMESPACE}"
+            --var "DOCKER_TAG=${BUILD_TAG}"
             --var "JDK_VERSION=17"
+          )
+
+          if [[ -n "${CONCORD_BASE_IMAGE:-}" ]]; then
+            bake_args+=(--var "CONCORD_BASE_IMAGE=${CONCORD_BASE_IMAGE}")
+          fi
+
+          if [[ -n "${CONCORD_ANSIBLE_IMAGE:-}" ]]; then
+            bake_args+=(--var "CONCORD_ANSIBLE_IMAGE=${CONCORD_ANSIBLE_IMAGE}")
+          fi
+
+          docker buildx bake "${bake_args[@]}" "${BAKE_GROUP}"
 
       - name: Verify multi-arch manifests
         run: |
-          images=(
-            concord-base
-            concord-ansible
-            concord-agent
-            concord-server
-            concord-agent-operator
-          )
+          read -ra images <<< "${VERIFY_IMAGES}"
 
           for image in "${images[@]}"; do
             ref="${DOCKER_NAMESPACE}/${image}:${BUILD_TAG}"

--- a/README.md
+++ b/README.md
@@ -128,10 +128,18 @@ See the [examples](examples) directory.
   $ git push origin RELEASE_TAG
   $ git push origin master
   ```
-- build and push the Docker images:
+- ensure the published Docker base images are current. They are rebuilt weekly
+  by `docker-base-images.yml` as `latest` plus an immutable weekly tag, but they
+  can also be refreshed manually:
+  ```
+  $ gh workflow run docker-base-images.yml --ref master -f ref=master -f docker_tag=latest -f docker_namespace=walmartlabs
+  ```
+- build and push the Docker application images. The workflow resolves the
+  published `concord-base` and `concord-ansible` images from `base_docker_tag`
+  to digests before building:
   ```
   $ git checkout RELEASE_TAG
-  $ gh workflow run docker-multiarch.yml --ref master -f ref=RELEASE_TAG -f docker_tag=RELEASE_TAG -f docker_namespace=walmartlabs
+  $ gh workflow run docker-multiarch.yml --ref master -f ref=RELEASE_TAG -f docker_tag=RELEASE_TAG -f docker_namespace=walmartlabs -f base_docker_tag=latest
   ```
 - sync to [Sonatype](https://oss.sonatype.org/);
 - check the Central repository if the sync is complete:
@@ -140,7 +148,7 @@ See the [examples](examples) directory.
   ```
 - once the sync is complete, push the `latest` Docker images:
   ```
-  $ gh workflow run docker-multiarch.yml --ref master -f ref=RELEASE_TAG -f docker_tag=latest -f docker_namespace=walmartlabs
+  $ gh workflow run docker-multiarch.yml --ref master -f ref=RELEASE_TAG -f docker_tag=latest -f docker_namespace=walmartlabs -f base_docker_tag=latest
   ```
 
 ## Development Notes

--- a/docker-images/docker-bake.hcl
+++ b/docker-images/docker-bake.hcl
@@ -10,12 +10,35 @@ variable "JDK_VERSION" {
   default = "17"
 }
 
+variable "CONCORD_BASE_IMAGE" {
+  default = "walmartlabs/concord-base:latest"
+}
+
+variable "CONCORD_ANSIBLE_IMAGE" {
+  default = "walmartlabs/concord-ansible:latest"
+}
+
 group "default" {
   targets = [
     "concord-base",
     "concord-ansible",
     "concord-agent",
     "concord-server",
+    "concord-agent-operator",
+  ]
+}
+
+group "base-images" {
+  targets = [
+    "concord-base",
+    "concord-ansible",
+  ]
+}
+
+group "app-images" {
+  targets = [
+    "concord-agent-from-registry",
+    "concord-server-from-registry",
     "concord-agent-operator",
   ]
 }
@@ -64,6 +87,18 @@ target "concord-agent" {
   }
 }
 
+target "concord-agent-from-registry" {
+  inherits = ["_common"]
+  context = "./agent"
+  dockerfile = "oss/debian/Dockerfile"
+  tags = ["${DOCKER_NAMESPACE}/concord-agent:${DOCKER_TAG}"]
+  args = {
+    concord_ansible_image = CONCORD_ANSIBLE_IMAGE
+    concord_version = DOCKER_TAG
+    docker_namespace = DOCKER_NAMESPACE
+  }
+}
+
 target "concord-server" {
   inherits = ["_common"]
   context = "./server"
@@ -76,6 +111,18 @@ target "concord-server" {
   }
   contexts = {
     "concord-base" = "target:concord-base"
+  }
+}
+
+target "concord-server-from-registry" {
+  inherits = ["_common"]
+  context = "./server"
+  dockerfile = "oss/Dockerfile"
+  tags = ["${DOCKER_NAMESPACE}/concord-server:${DOCKER_TAG}"]
+  args = {
+    concord_base_image = CONCORD_BASE_IMAGE
+    concord_version = DOCKER_TAG
+    docker_namespace = DOCKER_NAMESPACE
   }
 }
 


### PR DESCRIPTION
## Summary
- add a weekly/manual docker-base-images workflow for concord-base and concord-ansible
- add Buildx bake groups for base-image and app-image builds
- change docker-multiarch release dispatch to build app images from published base images resolved to digests
- update release docs for the base_docker_tag input

## Verification
- git diff --check
- ruby YAML parse for docker-base-images.yml and docker-multiarch.yml
- docker buildx bake --print for base-images and app-images groups