### PR TITLE
runtime-v2, cli: improve parallel execution error diagnostics

### DIFF
--- a/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
+++ b/cli/src/main/java/com/walmartlabs/concord/cli/runner/CliServicesModule.java
@@ -94,6 +94,7 @@ public class CliServicesModule extends AbstractModule {
         bind(com.walmartlabs.concord.runtime.v2.sdk.DependencyManager.class).to(DefaultDependencyManager.class).in(Singleton.class);
 
         Multibinder<ExecutionListener> executionListeners = Multibinder.newSetBinder(binder(), ExecutionListener.class);
+        executionListeners.addBinding().to(StackTraceCollector.class);
         if (verbosity.logFlowSteps()) {
             executionListeners.addBinding().to(FlowStepLogger.class);
         }

--- a/cli/src/test/java/com/walmartlabs/concord/cli/RunTest.java
+++ b/cli/src/test/java/com/walmartlabs/concord/cli/RunTest.java
@@ -109,6 +109,14 @@ class RunTest extends AbstractTest {
         assertLog(".*projectInfo: \\{orgName=test-org}.*");
     }
 
+    @Test
+    void testParallelErrorCallStack() throws Exception {
+        int exitCode = run("parallelErrorCallStack", Collections.emptyList());
+        assertExitCode(-1, exitCode);
+        assertOutContainsRegex("(?s).*Parallel execution errors:.*\\[\\d+\\].*Error: boom.*Call stack:.*flow: innerFlow.*flow: flowA.*");
+        assertOutContainsRegex("(?s).*Parallel execution errors:.*\\[\\d+\\].*Error: boom.*Call stack:.*flow: innerFlow.*flow: flowB.*");
+    }
+
     private void assertExitCode(int expected, int current) {
         assertEquals(expected, current, () -> "out:\n" + stdOut() + "\n\n" + "err:\n" + stdErr());
     }

--- a/cli/src/test/resources/com/walmartlabs/concord/cli/parallelErrorCallStack/concord.yml
+++ b/cli/src/test/resources/com/walmartlabs/concord/cli/parallelErrorCallStack/concord.yml
@@ -1,0 +1,14 @@
+flows:
+  default:
+    - parallel:
+        - call: flowA
+        - call: flowB
+
+  flowA:
+    - call: innerFlow
+
+  flowB:
+    - call: innerFlow
+
+  innerFlow:
+    - throw: boom

--- a/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/LogExceptionsTest.java
+++ b/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/LogExceptionsTest.java
@@ -159,7 +159,9 @@ public class LogExceptionsTest {
 
         // error
         assertLog(runtime.lastLog(), ".*" + quote("(concord.yaml): Error @ line: 4, col: 11. boom!") + ".*");
-        assertMultiLineLog(runtime.lastLog(), ".*" + quote("(concord.yaml): Error @ line: 3, col: 7. Parallel execution errors: ") + "\n" + quote("(concord.yaml): Error @ line: 4, col: 11, thread: 1: boom!"));
+        assertMultiLineLog(runtime.lastLog(), ".*" + quote("(concord.yaml): Error @ line: 3, col: 7. Parallel execution errors: ") + "\n" +
+                quote("[1] (concord.yaml): Error @ line: 4, col: 11, thread: 1") + "\n" +
+                quote("  Error: boom!"));
 
         assertLogExactMatch(runtime.lastLog(), 1, ".*" + quote("Parallel execution errors") + ".*");
 

--- a/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -140,9 +140,15 @@ public class MainTest  {
             // ignore
         }
 
-        assertLog(runtime.lastLog(), ".*" + Pattern.quote("(concord.yml) @ line: 10, col: 7, thread: 1, flow: flowB") + ".*");
-        assertLog(runtime.lastLog(), ".*" + Pattern.quote("(concord.yml) @ line: 4, col: 11, thread: 1, flow: flowA") + ".*");
-        assertLog(runtime.lastLog(), ".*" + Pattern.quote("(concord.yml) @ line: 5, col: 11, thread: 2, flow: flowB") + ".*");
+        String logString = new String(runtime.lastLog());
+        String expected1 = "  Call stack:\n" +
+                "    (concord.yml) @ line: 10, col: 7, thread: 1, flow: flowB\n" +
+                "    (concord.yml) @ line: 4, col: 11, thread: 1, flow: flowA";
+        String expected2 = "  Call stack:\n" +
+                "    (concord.yml) @ line: 5, col: 11, thread: 2, flow: flowB";
+
+        assertTrue(logString.contains(expected1), "expected log contains: " + expected1 + ", actual: " + logString);
+        assertTrue(logString.contains(expected2), "expected log contains: " + expected2 + ", actual: " + logString);
     }
 
     @Test
@@ -160,9 +166,9 @@ public class MainTest  {
         }
         assertLog(runtime.lastLog(), ".*" + Pattern.quote("in flowA") + ".*");
 
-        String expected = "Call stack:\n" +
-                "(concord.yml) @ line: 13, col: 7, thread: 2, flow: flowB\n" +
-                "(concord.yml) @ line: 3, col: 7, thread: 2, flow: flowA";
+        String expected = "  Call stack:\n" +
+                "    (concord.yml) @ line: 13, col: 7, thread: 2, flow: flowB\n" +
+                "    (concord.yml) @ line: 3, col: 7, thread: 2, flow: flowA";
 
         String logString = new String(runtime.lastLog());
         assertTrue(logString.contains(expected), "expected log contains: " + expected + ", actual: " + logString);

--- a/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
+++ b/runtime/v2/runner-test/src/test/java/com/walmartlabs/concord/runtime/v2/runner/MainTest.java
@@ -211,10 +211,10 @@ public class MainTest  {
         }
 
         String expected = ".*Call stack:\n" +
-                "\\(concord.yml\\) @ line: 21, col: 7, thread: .*, flow: flowC\n" +
-                "\\(concord.yml\\) @ line: 11, col: 11, thread: 2, flow: flowB\n" +
-                "\\(concord.yml\\) @ line: 6, col: 7, thread: 0, flow: flowA\n" +
-                "\\(concord.yml\\) @ line: 3, col: 7, thread: 0, flow: flow0.*";
+                "\\s+\\(concord.yml\\) @ line: 21, col: 7, thread: .*, flow: flowC\n" +
+                "\\s+\\(concord.yml\\) @ line: 11, col: 11, thread: 2, flow: flowB\n" +
+                "\\s+\\(concord.yml\\) @ line: 6, col: 7, thread: 0, flow: flowA\n" +
+                "\\s+\\(concord.yml\\) @ line: 3, col: 7, thread: 0, flow: flow0.*";
         Pattern expectedPattern = Pattern.compile(expected, Pattern.MULTILINE|Pattern.DOTALL|Pattern.UNIX_LINES);
 
         String logString = new String(runtime.lastLog());

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ParallelExecutionException.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/ParallelExecutionException.java
@@ -26,7 +26,6 @@ import com.walmartlabs.concord.svm.ThreadError;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serial;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -54,9 +53,17 @@ public class ParallelExecutionException extends RuntimeException {
     }
 
     private static String toMessage(Collection<ThreadError> causes) {
-        return causes.stream()
-                .map(ParallelExecutionException::stacktraceToString)
-                .collect(Collectors.joining("\n"));
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        for (ThreadError item : causes) {
+            if (i > 0) {
+                sb.append("\n\n");
+            }
+            sb.append("[").append(i + 1).append("] ");
+            sb.append(stacktraceToString(item));
+            i++;
+        }
+        return sb.toString();
     }
 
     @Override
@@ -70,23 +77,32 @@ public class ParallelExecutionException extends RuntimeException {
     }
 
     private static String stacktraceToString(ThreadError e) {
-        StringWriter sw = new StringWriter();
-        sw.append(toString(e));
+        StringBuilder sb = new StringBuilder();
+        sb.append(toErrorHeader(e));
+        sb.append("\n  Error: ");
+        sb.append(indentContinuationLines(e.exception().toString(), "  "));
+
+        if (!e.callStack().isEmpty()) {
+            sb.append("\n  Call stack:\n");
+            sb.append(e.callStack().stream()
+                    .map(item -> "    " + item)
+                    .collect(Collectors.joining("\n")));
+        }
 
         StackTraceElement[] elements = e.getStackTrace();
         if (elements.length > 0) {
-            sw.append("\n");
+            sb.append("\n  Java stack trace:\n");
         }
 
         int maxElements = Math.min(elements.length, MAX_STACK_TRACE_ELEMENTS);
         for (int i = 0; i < maxElements; i++) {
             StackTraceElement element = elements[i];
-            sw.append("\tat ").append(element.toString()).append("\n");
+            sb.append("    at ").append(element.toString()).append("\n");
         }
         if (maxElements != elements.length) {
-            sw.append("\t...").append(String.valueOf(elements.length - maxElements)).append(" more\n");
+            sb.append("    ...").append(elements.length - maxElements).append(" more\n");
         }
-        return sw.toString();
+        return sb.toString();
     }
 
     @Override
@@ -99,11 +115,27 @@ public class ParallelExecutionException extends RuntimeException {
         return new StackTraceElement[0];
     }
 
-    private static String toString(ThreadError threadError) {
+    private static String toErrorHeader(ThreadError threadError) {
         String prefix = "";
         if (threadError.cmd() instanceof StepCommand<?> sc) {
             prefix = Location.toErrorPrefix(sc.getStep().getLocation()) + ", ";
         }
-        return prefix + "thread: " + threadError.threadId().id() + ": " + threadError.exception();
+        return prefix + "thread: " + threadError.threadId().id();
+    }
+
+    private static String indentContinuationLines(String s, String indent) {
+        return trimTrailingLineSeparators(s).lines().collect(Collectors.joining("\n" + indent));
+    }
+
+    private static String trimTrailingLineSeparators(String s) {
+        int end = s.length();
+        while (end > 0) {
+            char c = s.charAt(end - 1);
+            if (c != '\n' && c != '\r') {
+                break;
+            }
+            end--;
+        }
+        return end == s.length() ? s : s.substring(0, end);
     }
 }

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
@@ -107,10 +107,37 @@ public abstract class StepCommand<T extends Step> implements Command {
             log.error("{}", e.getMessage());
         }
 
+        if (isCallStackReportedByParent(state, threadId, e)) {
+            return;
+        }
+
         List<StackTraceItem> stackTrace = state.getStackTrace(threadId);
         if (!stackTrace.isEmpty()) {
             log.error("Call stack:\n{}", stackTrace.stream().map(StackTraceItem::toString).collect(Collectors.joining("\n")));
         }
+    }
+
+    private static boolean isCallStackReportedByParent(State state, ThreadId threadId, Exception e) {
+        if (e instanceof ParallelExecutionException) {
+            return true;
+        }
+
+        // Unhandled forked thread errors are collected by JoinCommand and reported as
+        // ParallelExecutionException, which includes the child's ThreadError call stack.
+        // Keep local call stack logging for errors that can be handled in the same thread.
+        if (threadId.equals(state.getRootThreadId())) {
+            return false;
+        }
+
+        // Filter out duplicate call stack logs for unhandled forked thread errors.
+        // The stack trace is captured in ThreadError and printed by the parent
+        // ParallelExecutionException after JoinCommand observes the failed child.
+        return !hasExceptionHandler(state, threadId);
+    }
+
+    private static boolean hasExceptionHandler(State state, ThreadId threadId) {
+        return state.getFrames(threadId).stream()
+                .anyMatch(f -> f.getExceptionHandler() != null);
     }
 
     protected abstract void execute(Runtime runtime, State state, ThreadId threadId);

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/vm/StepCommand.java
@@ -107,7 +107,7 @@ public abstract class StepCommand<T extends Step> implements Command {
             log.error("{}", e.getMessage());
         }
 
-        if (isCallStackReportedByParent(state, threadId, e)) {
+        if (shouldSkipCallStackLog(state, threadId, e)) {
             return;
         }
 
@@ -117,22 +117,21 @@ public abstract class StepCommand<T extends Step> implements Command {
         }
     }
 
-    private static boolean isCallStackReportedByParent(State state, ThreadId threadId, Exception e) {
+    private static boolean shouldSkipCallStackLog(State state, ThreadId threadId, Exception e) {
         if (e instanceof ParallelExecutionException) {
             return true;
         }
 
-        // Unhandled forked thread errors are collected by JoinCommand and reported as
-        // ParallelExecutionException, which includes the child's ThreadError call stack.
-        // Keep local call stack logging for errors that can be handled in the same thread.
         if (threadId.equals(state.getRootThreadId())) {
             return false;
         }
 
-        // Filter out duplicate call stack logs for unhandled forked thread errors.
-        // The stack trace is captured in ThreadError and printed by the parent
-        // ParallelExecutionException after JoinCommand observes the failed child.
-        return !hasExceptionHandler(state, threadId);
+        if (hasExceptionHandler(state, threadId)) {
+            return false;
+        }
+
+        // Unhandled forked thread errors are reported by JoinCommand's aggregate exception.
+        return true;
     }
 
     private static boolean hasExceptionHandler(State state, ThreadId threadId) {

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommandTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/vm/JoinCommandTest.java
@@ -101,6 +101,57 @@ public class JoinCommandTest {
     }
 
     @Test
+    public void testParallelExecutionExceptionShouldIncludeThreadCallStack() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child = state.nextThreadId();
+
+        state.setStatus(child, ThreadStatus.FAILED);
+        state.pushStackTraceItem(child, new StackTraceItem(null, child, "concord.yml", "myFlow", 5, 11));
+        state.pushStackTraceItem(child, new StackTraceItem(null, child, "concord.yml", "innerFlow", 12, 7));
+        state.setThreadError(child, new RuntimeException("boom"));
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child), null);
+
+        ParallelExecutionException exception = assertThrows(
+                ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        assertTrue(exception.getMessage().contains("[1] thread: 1\n" +
+                "  Error: java.lang.RuntimeException: boom\n" +
+                "  Call stack:\n" +
+                "    (concord.yml) @ line: 12, col: 7, thread: 1, flow: innerFlow\n" +
+                "    (concord.yml) @ line: 5, col: 11, thread: 1, flow: myFlow"));
+    }
+
+    @Test
+    public void testParallelExecutionExceptionShouldTrimTrailingLineSeparators() {
+        Frame rootFrame = Frame.builder().root().build();
+        InMemoryState state = new InMemoryState(rootFrame);
+
+        ThreadId parentThread = state.getRootThreadId();
+        ThreadId child = state.nextThreadId();
+
+        state.setStatus(child, ThreadStatus.FAILED);
+        state.pushStackTraceItem(child, new StackTraceItem(null, child, "concord.yml", "myFlow", 5, 11));
+        state.setThreadError(child, new RuntimeException("boom\n"));
+
+        JoinCommand<Step> joinCommand = new JoinCommand<>(List.of(child), null);
+
+        ParallelExecutionException exception = assertThrows(
+                ParallelExecutionException.class,
+                () -> joinCommand.execute(null, state, parentThread));
+
+        assertTrue(exception.getMessage().contains("  Error: java.lang.RuntimeException: boom\n" +
+                "  Call stack:"));
+        assertFalse(exception.getMessage().contains("  Error: java.lang.RuntimeException: boom\n" +
+                "  \n" +
+                "  Call stack:"));
+    }
+
+    @Test
     public void testFailedThreadWithNoErrorShouldBeFilteredOut() {
         Frame rootFrame = Frame.builder().root().build();
         InMemoryState state = new InMemoryState(rootFrame);
@@ -216,4 +267,5 @@ public class JoinCommandTest {
         assertSame(foreignError, state.getThreadError(foreignThread).exception(),
                 "Foreign thread's error should be untouched");
     }
+
 }

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/InMemoryState.java
@@ -221,7 +221,7 @@ public class InMemoryState implements Serializable, State {
     @Override
     public void setThreadError(ThreadId threadId, Command cmd, Exception error) {
         synchronized (this) {
-            threadErrors.put(threadId, new ThreadError(threadId, cmd, error));
+            threadErrors.put(threadId, new ThreadError(threadId, cmd, error, getStackTrace(threadId)));
         }
     }
 

--- a/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/ThreadError.java
+++ b/runtime/v2/vm/src/main/java/com/walmartlabs/concord/svm/ThreadError.java
@@ -22,11 +22,23 @@ package com.walmartlabs.concord.svm;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 
-public record ThreadError(ThreadId threadId, Command cmd, Exception exception) implements Serializable {
+public record ThreadError(ThreadId threadId,
+                          Command cmd,
+                          Exception exception,
+                          List<StackTraceItem> callStack) implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
+
+    public ThreadError {
+        callStack = callStack != null ? List.copyOf(callStack) : List.of();
+    }
+
+    public ThreadError(ThreadId threadId, Command cmd, Exception exception) {
+        this(threadId, cmd, exception, List.of());
+    }
 
     public StackTraceElement[] getStackTrace() {
         return exception.getStackTrace();


### PR DESCRIPTION
Include child thread call stacks in ParallelExecutionException so failed parallel branches can be identified when multiple branches call the same flow.

Avoid duplicate call stack logging for unhandled forked thread failures that are reported by the parent JoinCommand, while preserving local call stack logging for root-thread and handled errors.

before:
```
(concord.yml): Error @ line: 3, col: 7. Parallel execution errors:
(concord.yml): Error @ line: 15, col: 7, thread: 1: boom
(concord.yml): Error @ line: 15, col: 7, thread: 2: boom
```

after:
```
(concord.yml): Error @ line: 3, col: 7. Parallel execution errors:
[1] (concord.yml): Error @ line: 15, col: 7, thread: 1
  Error: boom
  Call stack:
    (concord.yml) @ line: 10, col: 7, thread: 1, flow: deployService
    (concord.yml) @ line: 4, col: 11, thread: 1, flow: deployApi

[2] (concord.yml): Error @ line: 15, col: 7, thread: 2
  Error: boom
  Call stack:
    (concord.yml) @ line: 12, col: 7, thread: 2, flow: deployService
    (concord.yml) @ line: 5, col: 11, thread: 2, flow: deployWorker
```