### PR TITLE
server: fix jetty metrics integration for prometheus

### DIFF
--- a/server/impl/src/main/java/com/walmartlabs/concord/server/boot/HttpServer.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/boot/HttpServer.java
@@ -50,10 +50,11 @@ import java.util.Set;
 
 public class HttpServer {
 
-    private static final Logger log = LoggerFactory.getLogger(HttpServlet.class);
+    private static final Logger log = LoggerFactory.getLogger(HttpServer.class);
 
     private final Server server;
     private final int port;
+    private final StatisticsHandler statisticsHandler;
 
     @Inject
     public HttpServer(ServerConfiguration cfg,
@@ -197,11 +198,15 @@ public class HttpServer {
             configurator.configure(contextHandlerCollection);
         });
 
-        StatisticsHandler statisticsHandler = new StatisticsHandler();
-        statisticsHandler.setHandler(contextHandlerCollection);
-        server.setHandler(statisticsHandler);
+        this.statisticsHandler = new StatisticsHandler();
+        this.statisticsHandler.setHandler(contextHandlerCollection);
+        server.setHandler(this.statisticsHandler);
 
         this.server = server;
+    }
+
+    public StatisticsHandler getStatisticsHandler() {
+        return statisticsHandler;
     }
 
     public void start() throws Exception {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/JettyStatisticsModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/metrics/JettyStatisticsModule.java
@@ -22,56 +22,64 @@ package com.walmartlabs.concord.server.metrics;
 
 import com.codahale.metrics.Gauge;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
 import com.google.inject.multibindings.Multibinder;
+import com.walmartlabs.concord.server.boot.HttpServer;
 import com.walmartlabs.concord.server.sdk.metrics.GaugeProvider;
 
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-import java.lang.management.ManagementFactory;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
 
 public class JettyStatisticsModule extends AbstractModule {
 
-    private static final String[] ATTRIBUTES = {
-            "responses1xx",
-            "responses2xx",
-            "responses3xx",
-            "responses4xx",
-            "responses5xx",
-
-            "requestsActive",
-            "requestTimeMax",
-            "requestTimeMean"
-    };
-
     @Override
     protected void configure() {
+        Provider<HttpServer> provider = getProvider(HttpServer.class);
+
         Multibinder<GaugeProvider> tasks = Multibinder.newSetBinder(binder(), GaugeProvider.class);
-        for (String a : ATTRIBUTES) {
-            tasks.addBinding().toInstance(attribute(a));
-        }
+        tasks.addBinding().toInstance(longAttribute("responses1xx", provider, StatisticsHandler::getResponses1xx));
+        tasks.addBinding().toInstance(longAttribute("responses2xx", provider, StatisticsHandler::getResponses2xx));
+        tasks.addBinding().toInstance(longAttribute("responses3xx", provider, StatisticsHandler::getResponses3xx));
+        tasks.addBinding().toInstance(longAttribute("responses4xx", provider, StatisticsHandler::getResponses4xx));
+        tasks.addBinding().toInstance(longAttribute("responses5xx", provider, StatisticsHandler::getResponses5xx));
+
+        tasks.addBinding().toInstance(longAttribute("requestsActive", provider, StatisticsHandler::getRequestsActive));
+        tasks.addBinding().toInstance(longAttribute("requestTimeMax", provider, StatisticsHandler::getRequestTimeMax));
+        tasks.addBinding().toInstance(doubleAttribute("requestTimeMean", provider, StatisticsHandler::getRequestTimeMean));
     }
 
-    @SuppressWarnings("unchecked")
-    private static <T> GaugeProvider<T> attribute(String attribute) {
-        return new GaugeProvider<T>() {
+    private static GaugeProvider<Long> longAttribute(String attribute,
+                                                     Provider<HttpServer> provider,
+                                                     ToLongFunction<StatisticsHandler> value) {
+        return new GaugeProvider<>() {
             @Override
             public String name() {
                 return "jetty-" + attribute;
             }
 
             @Override
-            public Gauge<T> gauge() {
-                return () -> (T) getAttribute(attribute);
+            public Gauge<Long> gauge() {
+                StatisticsHandler statistics = provider.get().getStatisticsHandler();
+                return () -> value.applyAsLong(statistics);
             }
         };
     }
 
-    private static Object getAttribute(String attribute) {
-        try {
-            MBeanServer mBeans = ManagementFactory.getPlatformMBeanServer();
-            return mBeans.getAttribute(new ObjectName("org.eclipse.jetty.server.handler:type=statisticshandler,id=0"), attribute);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private static GaugeProvider<Double> doubleAttribute(String attribute,
+                                                         Provider<HttpServer> provider,
+                                                         ToDoubleFunction<StatisticsHandler> value) {
+        return new GaugeProvider<>() {
+            @Override
+            public String name() {
+                return "jetty-" + attribute;
+            }
+
+            @Override
+            public Gauge<Double> gauge() {
+                StatisticsHandler statistics = provider.get().getStatisticsHandler();
+                return () -> value.applyAsDouble(statistics);
+            }
+        };
     }
 }


### PR DESCRIPTION
Jetty 11 -> 12 migration changes how metric internals are accessed. Fixes this exception:
```
15:54:36.709 [qtp172106640-33] [WARN ] [] o.e.jetty.ee8.nested.HttpChannel - /metrics
javax.servlet.ServletException: Filtered request failed.
	at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:396)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:156)
	at org.eclipse.jetty.ee8.servlet.FilterHolder.doFilter(FilterHolder.java:171)
	at org.eclipse.jetty.ee8.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1348)
	at ca.ibodrov.concord.webapp.WebappFilter.doFilter(WebappFilter.java:72)
	at javax.servlet.http.HttpFilter.doFilter(HttpFilter.java:127)
        ...
Caused by: java.lang.RuntimeException: javax.management.InstanceNotFoundException: org.eclipse.jetty.server.handler:type=statisticshandler,id=0
	at com.walmartlabs.concord.server.metrics.JettyStatisticsModule.getAttribute(JettyStatisticsModule.java:74)
	at com.walmartlabs.concord.server.metrics.JettyStatisticsModule$1.lambda$gauge$0(JettyStatisticsModule.java:64)
	at io.prometheus.client.dropwizard.DropwizardExports.fromGauge(DropwizardExports.java:96)
	at io.prometheus.client.dropwizard.DropwizardExports.collect(DropwizardExports.java:166)
	at io.prometheus.client.Collector.collect(Collector.java:45)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:204)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:219)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:152)
	at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:71)
	at io.prometheus.client.exporter.common.TextFormat.writeFormat(TextFormat.java:53)
	at io.prometheus.client.servlet.common.exporter.Exporter.doGet(Exporter.java:75)
	at io.prometheus.client.exporter.MetricsServlet.doGet(MetricsServlet.java:53)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:645)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
	at org.eclipse.jetty.ee8.servlet.ServletHolder.handle(ServletHolder.java:651)
	at org.eclipse.jetty.ee8.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1374)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:463)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.lambda$doFilterInternal$0(AbstractShiroFilter.java:378)
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:91)
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:84)
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:389)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:376)
	... 43 common frames omitted
Caused by: javax.management.InstanceNotFoundException: org.eclipse.jetty.server.handler:type=statisticshandler,id=0
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1088)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttribute(DefaultMBeanServerInterceptor.java:640)
	at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.getAttribute(JmxMBeanServer.java:679)
	at com.walmartlabs.concord.server.metrics.JettyStatisticsModule.getAttribute(JettyStatisticsModule.java:72)
	... 64 common frames omitted
```