### PR TITLE
server: paginate list checkpoints API, omit checkpoint data from retrieval

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/CheckpointsIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/CheckpointsIT.java
@@ -287,12 +287,18 @@ public class CheckpointsIT extends AbstractServerIT {
 
     private void restoreFromCheckpoint(UUID instanceId, String name) throws ApiException {
         CheckpointApi checkpointApi = new CheckpointApi(getApiClient());
+        CheckpointV3Api checkpointV3Api = new CheckpointV3Api(getApiClient());
         ProcessEventsApi eventsApi = new ProcessEventsApi(getApiClient());
         List<ProcessEventEntry> processEvents = eventsApi.listProcessEvents(instanceId, null, null, null, null, null, true, null);
         assertNotNull(processEvents);
 
         // restore from ONE checkpoint
         String checkpointId = assertCheckpoint(name, processEvents);
+
+        checkpointV3Api.pageCheckpoints(instanceId, 0, 10).stream()
+                .filter(c -> c.getId().toString().equals(checkpointId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("can't find checkpoint with id: " + checkpointId));
 
         ResumeProcessResponse resp = checkpointApi.restore(instanceId,
                 new RestoreCheckpointRequest().id(UUID.fromString(checkpointId)));

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessModule.java
@@ -28,6 +28,7 @@ import com.walmartlabs.concord.runtime.v1.ProjectLoaderV1;
 import com.walmartlabs.concord.runtime.v2.ProjectLoaderV2;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointResource;
 import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV2Resource;
+import com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV3Resource;
 import com.walmartlabs.concord.server.process.event.ProcessEventDao;
 import com.walmartlabs.concord.server.process.event.ProcessEventManager;
 import com.walmartlabs.concord.server.process.event.ProcessEventResource;
@@ -112,6 +113,7 @@ public class ProcessModule implements Module {
 
         bindJaxRsResource(binder, ProcessCheckpointResource.class);
         bindJaxRsResource(binder, ProcessCheckpointV2Resource.class);
+        bindJaxRsResource(binder, ProcessCheckpointV3Resource.class);
         bindJaxRsResource(binder, ProcessEventResource.class);
         bindJaxRsResource(binder, ProcessHeartbeatResource.class);
         bindJaxRsResource(binder, ProcessKvResource.class);

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
@@ -43,8 +43,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -70,16 +72,32 @@ public class ProcessCheckpointResource implements Resource {
         this.checkpointManager = checkpointManager;
     }
 
+    /**
+     * @deprecated Use {@link com.walmartlabs.concord.server.process.checkpoint.ProcessCheckpointV3Resource#list(UUID, int, int)}
+     */
     @GET
     @Path("{id}/checkpoint")
     @Produces(MediaType.APPLICATION_JSON)
     @WithTimer
     @Operation(description = "List the process checkpoints", operationId = "listCheckpoints")
+    @Deprecated(since = "2.44.0")
     public List<ProcessCheckpointEntry> list(@PathParam("id") UUID instanceId,
-                                             @QueryParam("offset") @DefaultValue("0") int offset,
-                                             @QueryParam("limit") @DefaultValue("15") int limit) {
+                                             @Context HttpServletRequest request) {
+
         ProcessEntry entry = processManager.assertProcess(instanceId);
         ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
+        int limit = 50;
+        int offset = 0;
+
+        String limitParam = request.getParameter("limit");
+        if (limitParam != null && !limitParam.isBlank()) {
+            limit = Integer.parseInt(limitParam);
+        }
+
+        String offsetParam = request.getParameter("offset");
+        if (offsetParam != null && !offsetParam.isBlank()) {
+            offset = Integer.parseInt(offsetParam);
+        }
 
         checkpointManager.assertProcessAccess(entry);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointResource.java
@@ -75,13 +75,15 @@ public class ProcessCheckpointResource implements Resource {
     @Produces(MediaType.APPLICATION_JSON)
     @WithTimer
     @Operation(description = "List the process checkpoints", operationId = "listCheckpoints")
-    public List<ProcessCheckpointEntry> list(@PathParam("id") UUID instanceId) {
+    public List<ProcessCheckpointEntry> list(@PathParam("id") UUID instanceId,
+                                             @QueryParam("offset") @DefaultValue("0") int offset,
+                                             @QueryParam("limit") @DefaultValue("15") int limit) {
         ProcessEntry entry = processManager.assertProcess(instanceId);
         ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
 
         checkpointManager.assertProcessAccess(entry);
 
-        return checkpointManager.list(processKey);
+        return checkpointManager.list(processKey, offset, limit);
     }
 
     @POST

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointV3Resource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/checkpoint/ProcessCheckpointV3Resource.java
@@ -1,0 +1,77 @@
+package com.walmartlabs.concord.server.process.checkpoint;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.server.process.ProcessEntry;
+import com.walmartlabs.concord.server.process.ProcessManager;
+import com.walmartlabs.concord.server.process.state.ProcessCheckpointManager;
+import com.walmartlabs.concord.server.sdk.ProcessKey;
+import com.walmartlabs.concord.server.sdk.metrics.WithTimer;
+import com.walmartlabs.concord.server.sdk.rest.Resource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.UUID;
+
+@Path("/api/v3/process")
+@Tag(name = "CheckpointV3")
+public class ProcessCheckpointV3Resource implements Resource {
+
+    private final ProcessManager processManager;
+    private final ProcessCheckpointManager checkpointManager;
+
+    @Inject
+    public ProcessCheckpointV3Resource(ProcessManager processManager,
+                                       ProcessCheckpointManager checkpointManager) {
+
+        this.processManager = processManager;
+        this.checkpointManager = checkpointManager;
+    }
+
+    @GET
+    @Path("{id}/checkpoint")
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithTimer
+    @Operation(description = "List the process checkpoints with pagination", operationId = "pageCheckpoints")
+    public List<ProcessEntry.ProcessCheckpointEntry> page(
+            @PathParam("id") UUID instanceId,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("10") int limit
+    ) {
+
+        ProcessEntry entry = processManager.assertProcess(instanceId);
+        ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
+
+        checkpointManager.assertProcessAccess(entry);
+
+        return checkpointManager.list(processKey, offset, limit);
+    }
+
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointDao.java
@@ -50,11 +50,18 @@ public class ProcessCheckpointDao extends AbstractDao {
         super(cfg);
     }
 
-    public List<ProcessCheckpointEntry> list(ProcessKey processKey) {
-        return txResult(tx -> tx.select()
+    public List<ProcessCheckpointEntry> list(ProcessKey processKey, int offset, int limit) {
+        return txResult(tx -> tx.select(
+                        PROCESS_CHECKPOINTS.CHECKPOINT_ID,
+                        PROCESS_CHECKPOINTS.CHECKPOINT_NAME,
+                        PROCESS_CHECKPOINTS.CHECKPOINT_DATE,
+                        PROCESS_CHECKPOINTS.CORRELATION_ID)
                 .from(PROCESS_CHECKPOINTS)
                 .where(PROCESS_CHECKPOINTS.INSTANCE_ID.eq(processKey.getInstanceId())
                         .and(PROCESS_CHECKPOINTS.INSTANCE_CREATED_AT.eq(processKey.getCreatedAt())))
+                .orderBy(PROCESS_CHECKPOINTS.CHECKPOINT_DATE.desc())
+                .offset(offset)
+                .limit(limit)
                 .fetch(ProcessCheckpointDao::toEntry));
     }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointManager.java
@@ -123,8 +123,8 @@ public class ProcessCheckpointManager {
     /**
      * List checkpoints of a given instanceId
      */
-    public List<ProcessCheckpointEntry> list(ProcessKey processKey) {
-        return checkpointDao.list(processKey);
+    public List<ProcessCheckpointEntry> list(ProcessKey processKey, int offset, int limit) {
+        return checkpointDao.list(processKey, offset, limit);
     }
 
     public void assertProcessAccess(ProcessEntry e) {


### PR DESCRIPTION
* Paginate the API for listing checkpoints for a process
* Exclude actual checkpoint data from the DB query when it's not necessary

The first part is less necessary when the second part is in place, but probably wise anyway. Turns out the server will OOM at listing ~1000 checkpoints for a process. Depends on checkpoint size and other activity + JVM settings, but this shouldn't be such a risky API.

Further TODO: limit max number of checkpoints per process