### PR TITLE
server, agent: restore usage of config's git.oauth settings

### DIFF
--- a/agent/src/main/java/com/walmartlabs/concord/agent/RepositoryManager.java
+++ b/agent/src/main/java/com/walmartlabs/concord/agent/RepositoryManager.java
@@ -57,6 +57,9 @@ public class RepositoryManager {
         this.gitCfg = gitCfg;
 
         GitClientConfiguration clientCfg = GitClientConfiguration.builder()
+                .oauthToken(gitCfg.getOauthToken())
+                .oauthUsername(gitCfg.getOauthUsername())
+                .oauthUrlPattern(gitCfg.getOauthUrlPattern())
                 .defaultOperationTimeout(gitCfg.getDefaultOperationTimeout())
                 .fetchTimeout(gitCfg.getFetchTimeout())
                 .httpLowSpeedLimit(gitCfg.getHttpLowSpeedLimit())

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import java.io.*;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/repository/RepositoryManager.java
@@ -68,6 +68,9 @@ public class RepositoryManager {
                              AuthTokenProvider authProvider) throws IOException {
 
         GitClientConfiguration gitCliCfg = GitClientConfiguration.builder()
+                .oauthToken(gitCfg.getOauthToken())
+                .oauthUsername(gitCfg.getOauthUsername())
+                .oauthUrlPattern(gitCfg.getOauthUrlPattern())
                 .defaultOperationTimeout(gitCfg.getDefaultOperationTimeout())
                 .fetchTimeout(gitCfg.getFetchTimeout())
                 .httpLowSpeedLimit(gitCfg.getHttpLowSpeedLimit())


### PR DESCRIPTION
Makes sense for this to still work for instances want to provide default auth for a non-github source. Doesn't affect repository configs with custom auth.