### PR TITLE
console2: fix process list refresh in OrganizationActivity

### DIFF
--- a/console2/src/components/organisms/OrganizationActivity/OrganizationProcesses.tsx
+++ b/console2/src/components/organisms/OrganizationActivity/OrganizationProcesses.tsx
@@ -62,10 +62,17 @@ const OrganizationProcesses = ({ orgName, forceRefresh }: ExternalProps) => {
                 orgName={orgName}
                 columns={data.meta.ui.processList}
                 usePagination={true}
+                forceRefresh={forceRefresh}
             />
         );
     } else {
-        return <ProcessListActivity orgName={orgName} usePagination={true} />;
+        return (
+            <ProcessListActivity
+                orgName={orgName}
+                usePagination={true}
+                forceRefresh={forceRefresh}
+            />
+        );
     }
 };
 


### PR DESCRIPTION
This has been broken for a while (never worked?). The refresh button/icon in `OrganizationActivity` loads data when clicked, but doesn't actually update the list.