### PR TITLE
runtime-v1, runtime-v2: containerd retry compat for refused connection

### DIFF
--- a/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/DockerServiceImpl.java
+++ b/runtime/v1/impl/src/main/java/com/walmartlabs/concord/runner/engine/DockerServiceImpl.java
@@ -49,7 +49,7 @@ public class DockerServiceImpl implements DockerService {
 
     private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
             Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
-            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*(Get|Head).*connection refused.*"),
             Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
     };
 

--- a/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultDockerService.java
+++ b/runtime/v2/runner/src/main/java/com/walmartlabs/concord/runtime/v2/runner/DefaultDockerService.java
@@ -51,7 +51,7 @@ public class DefaultDockerService implements DockerService {
 
     private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
             Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
-            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*(Get|Head).*connection refused.*"),
             Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
     };
 


### PR DESCRIPTION
A minor but important error message difference affects deciding to retry

```
# dockerd
Error response from daemon: Get "http://localhost:12345/v2/": dial tcp 127.0.0.1:12345: connect: connection refused
                            ^^^
# containerd
Error response from daemon: failed to resolve reference "localhost:12345/non-existing:latest": failed to do request: Head "https://localhost:12345/v2/non-existing/manifests/latest": dial tcp 127.0.0.1:12345: connect: connection refused
                                                                                                                     ^^^^
```