### PR TITLE
server, repository: sanitize user-provided git parameters

### DIFF
--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -217,7 +217,7 @@ public class GitClient {
         exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("checkout", "-q", "-f", rev)
+                .addArgs("checkout", "-q", "-f", "--", rev)
                 .build());
     }
 
@@ -225,7 +225,7 @@ public class GitClient {
         exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("reset", "--hard", rev)
+                .addArgs("reset", "--hard", "--", rev)
                 .build());
     }
 
@@ -241,7 +241,7 @@ public class GitClient {
         String result = exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("rev-parse", rev)
+                .addArgs("rev-parse", "--", rev)
                 .build());
         String line = result.trim();
         if (line.isEmpty()) {
@@ -254,7 +254,7 @@ public class GitClient {
         String result = execWithCredentials(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("ls-remote", "--symref", "origin", version)
+                .addArgs("ls-remote", "--symref", "--", "origin", version)
                 .build(), secret);
 
         List<Ref> refs = new ArrayList<>();
@@ -624,7 +624,7 @@ public class GitClient {
     private Path createUnixGitSSH(Path key) throws IOException {
         Path ssh = PathUtils.createTempFile("ssh", ".sh");
 
-        try (PrintWriter w = new PrintWriter(ssh.toFile(), Charset.defaultCharset().toString())) {
+        try (PrintWriter w = new PrintWriter(ssh.toFile(), Charset.defaultCharset())) {
             w.println("#!/bin/sh");
             // ${SSH_ASKPASS} might be ignored if ${DISPLAY} is not set
             w.println("if [ -z \"${DISPLAY}\" ]; then");
@@ -647,7 +647,7 @@ public class GitClient {
 
     private static Path createUnixStandardAskpass(UsernamePassword creds) throws IOException {
         Path askpass = PathUtils.createTempFile("pass", ".sh");
-        try (PrintWriter w = new PrintWriter(askpass.toFile(), Charset.defaultCharset().toString())) {
+        try (PrintWriter w = new PrintWriter(askpass.toFile(), Charset.defaultCharset())) {
             w.println("#!/bin/sh");
             w.println("case \"$1\" in");
             w.println("Username*) echo '" + quoteUnixCredentials(creds.getUsername()) + "' ;;");

--- a/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
+++ b/repository/src/main/java/com/walmartlabs/concord/repository/GitClient.java
@@ -217,7 +217,7 @@ public class GitClient {
         exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("checkout", "-q", "-f", "--", rev)
+                .addArgs("checkout", "-q", "-f", rev)
                 .build());
     }
 
@@ -225,7 +225,7 @@ public class GitClient {
         exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("reset", "--hard", "--", rev)
+                .addArgs("reset", "--hard", rev)
                 .build());
     }
 
@@ -241,7 +241,7 @@ public class GitClient {
         String result = exec(Command.builder()
                 .workDir(workDir)
                 .timeout(cfg.defaultOperationTimeout())
-                .addArgs("rev-parse", "--", rev)
+                .addArgs("rev-parse", rev)
                 .build());
         String line = result.trim();
         if (line.isEmpty()) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/console/ConsoleService.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/console/ConsoleService.java
@@ -57,6 +57,7 @@ import com.walmartlabs.concord.server.user.UserManager;
 import org.jooq.Configuration;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import javax.ws.rs.*;
 import javax.ws.rs.core.HttpHeaders;
@@ -295,8 +296,9 @@ public class ConsoleService implements Resource {
     @Path("/repository/test")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @Validate
     @WithTimer
-    public boolean testRepository(RepositoryTestRequest req) {
+    public boolean testRepository(@Valid RepositoryTestRequest req) {
         OrganizationEntry org = orgManager.assertAccess(null, req.getOrgName(), false);
         ProjectEntry project = projectAccessManager.assertAccess(org.getId(), null, req.getProjectName(), ResourceAccessLevel.READER, false);
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/console/RepositoryTestRequest.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/console/RepositoryTestRequest.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.walmartlabs.concord.common.validation.ConcordKey;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -46,7 +48,15 @@ public class RepositoryTestRequest implements Serializable {
     @NotNull
     private final String url;
 
+    @Size(max = 255)
+    // Enforce git check-ref-format rules: no ASCII control chars, no whitespace,
+    // no DEL (0x7F), and none of the characters git explicitly forbids: ~ ^ : ? * [ \
+    @Pattern(regexp = "^[^\\x00-\\x20\\x7F~^:?*\\[\\\\]+$",
+            message = "Branch must be a valid git ref name (no whitespace or special characters ~^:?*[\\)")
     private final String branch;
+
+    @Size(max = 64)
+    @Pattern(regexp = "^[0-9a-fA-F]+$", message = "Commit ID must be a hexadecimal SHA value")
     private final String commitId;
     private final String path;
     private final UUID secretId;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryEntry.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/org/project/RepositoryEntry.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.walmartlabs.concord.common.validation.ConcordKey;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.Map;
@@ -47,9 +48,14 @@ public class RepositoryEntry implements Serializable {
     private final String url;
 
     @Size(max = 255)
+    // Enforce git check-ref-format rules: no ASCII control chars, no whitespace,
+    // no DEL (0x7F), and none of the characters git explicitly forbids: ~ ^ : ? * [ \
+    @Pattern(regexp = "^[^\\x00-\\x20\\x7F~^:?*\\[\\\\]+$",
+             message = "Branch must be a valid git ref name (no whitespace or special characters ~^:?*[\\)")
     private final String branch;
 
     @Size(max = 64)
+    @Pattern(regexp = "^[0-9a-fA-F]+$", message = "Commit ID must be a hexadecimal SHA value")
     private final String commitId;
 
     @Size(max = 2048)


### PR DESCRIPTION
* branches staring with a dash `-` are valid, but can cause issues without the "end-of-options" flag `--`.
* Further sanitize the inputs upstream before getting to the fetch request.