### PR TITLE
server: require 'agentWebsocket' permission for websockets

### DIFF
--- a/it/agent-operator/src/test/java/com/walmartlabs/concord/it/agentoperator/AgentOperatorIT.java
+++ b/it/agent-operator/src/test/java/com/walmartlabs/concord/it/agentoperator/AgentOperatorIT.java
@@ -114,6 +114,7 @@ public class AgentOperatorIT {
                                 pollDelay = "250 milliseconds"
                             }
                         }
+                        websockets.requirePermission = false
                     }
                     concord-agent {
                         server.apiKey = "%s"

--- a/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
+++ b/it/common/src/main/java/com/walmartlabs/concord/it/common/ITUtils.java
@@ -20,6 +20,14 @@ package com.walmartlabs.concord.it.common;
  * =====
  */
 
+import com.walmartlabs.concord.client2.ApiClient;
+import com.walmartlabs.concord.client2.ApiException;
+import com.walmartlabs.concord.client2.ApiKeysV2Api;
+import com.walmartlabs.concord.client2.CreateApiKeyRequest;
+import com.walmartlabs.concord.client2.CreateUserRequest;
+import com.walmartlabs.concord.client2.RoleEntry;
+import com.walmartlabs.concord.client2.RolesApi;
+import com.walmartlabs.concord.client2.UsersApi;
 import com.walmartlabs.concord.common.PathUtils;
 import com.walmartlabs.concord.common.TemporaryPath;
 import com.walmartlabs.concord.common.ZipUtils;
@@ -129,6 +137,26 @@ public final class ITUtils {
         }
 
         return tmpDir;
+    }
+
+    public static void createAgentUser(ApiClient apiClient, String apiKey) throws ApiException {
+            new RolesApi(apiClient)
+                    .createOrUpdateRole(new RoleEntry()
+                            .name("agentWebsocket")
+                            .addpermissionsItem("agentWebsocket"));
+
+            var userApi = new UsersApi(apiClient);
+            var agentUser = userApi.createOrUpdateUser(new CreateUserRequest()
+                    .username("agent")
+                    .userType(CreateUserRequest.UserTypeEnum.LOCAL)
+                    .addrolesItem("agentWebsocket")
+            );
+
+            new ApiKeysV2Api(apiClient)
+                    .createOrUpdateUserApiKey(new CreateApiKeyRequest()
+                        .key(apiKey)
+                        .userType(CreateApiKeyRequest.UserTypeEnum.LOCAL)
+                        .userId(agentUser.getId()));
     }
 
     private ITUtils() {

--- a/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
+++ b/it/compat/src/test/java/com/walmartlabs/concord/it/compat/OldAgentIT.java
@@ -45,6 +45,7 @@ public class OldAgentIT {
     public final ConcordRule concord = new ConcordRule()
             .serverImage(System.getProperty("server.image", "walmartlabs/concord-server"))
             .agentImage(System.getProperty("agent.image", "walmartlabs/concord-agent"))
+            .extraConfigurationSupplier(() -> "concord-server { websockets { requirePermission = false } }")
             .pullPolicy(PullPolicy.defaultPolicy())
             .streamServerLogs(true)
             .streamAgentLogs(true);

--- a/it/console/src/test/resources/server.conf
+++ b/it/console/src/test/resources/server.conf
@@ -18,4 +18,8 @@ concord-server {
         secretStoreSalt = "aXRpdGl0"
         projectSecretSalt = "aXRpdGl0"
     }
+
+    websockets {
+        requirePermission = false
+    }
 }

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
@@ -29,7 +29,7 @@ import java.util.Base64;
 
 public final class ConcordConfiguration {
 
-    public static final String AGENT_API_KEY = Base64.getEncoder().encodeToString(ITUtils.randomString().getBytes(StandardCharsets.UTF_8));
+    public static final String agentApiKey = Base64.getEncoder().encodeToString(ITUtils.randomString().getBytes(StandardCharsets.UTF_8));
 
     public static ConcordRule configure() {
         ConcordRule concord = new ConcordRule()
@@ -62,7 +62,7 @@ public final class ConcordConfiguration {
                                 apiKey = "%%agentApiKey%%"
                             }
                         }
-                        """.replace("%%agentApiKey%%", AGENT_API_KEY));
+                        """.replace("%%agentApiKey%%", agentApiKey));
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ConcordConfiguration.java
@@ -21,9 +21,15 @@ package com.walmartlabs.concord.it.runtime.v1;
  */
 
 import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.walmartlabs.concord.it.common.ITUtils;
 import org.testcontainers.images.PullPolicy;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 public final class ConcordConfiguration {
+
+    public static final String AGENT_API_KEY = Base64.getEncoder().encodeToString(ITUtils.randomString().getBytes(StandardCharsets.UTF_8));
 
     public static ConcordRule configure() {
         ConcordRule concord = new ConcordRule()
@@ -52,8 +58,11 @@ public final class ConcordConfiguration {
                             prefork {
                                 enabled = true
                             }
+                            server {
+                                apiKey = "%%agentApiKey%%"
+                            }
                         }
-                        """);
+                        """.replace("%%agentApiKey%%", AGENT_API_KEY));
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -25,6 +25,7 @@ import ca.ibodrov.concord.testcontainers.Payload;
 import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.walmartlabs.concord.client2.ApiException;
 import com.walmartlabs.concord.client2.FormListEntry;
 import com.walmartlabs.concord.client2.FormSubmitResponse;
 import com.walmartlabs.concord.client2.ProcessApi;
@@ -33,12 +34,15 @@ import com.walmartlabs.concord.client2.ProcessEntry.StatusEnum;
 import com.walmartlabs.concord.client2.ProcessEventEntry;
 import com.walmartlabs.concord.client2.ProcessEventsApi;
 import com.walmartlabs.concord.client2.ProcessListFilter;
+import com.walmartlabs.concord.it.common.ITUtils;
 import com.walmartlabs.concord.it.common.JGitUtils;
 import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -59,10 +63,18 @@ public class ProcessIT {
 
     @RegisterExtension
     public static final ConcordRule concord = ConcordConfiguration.configure();
+    private static final Logger log = LoggerFactory.getLogger(ProcessIT.class);
 
     @BeforeAll
     public static void init() {
         JGitUtils.applyWorkarounds();
+
+        try {
+            ITUtils.createAgentUser(concord.apiClient(), ConcordConfiguration.AGENT_API_KEY);
+        } catch (ApiException e) {
+            log.error("init -> error", e);
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
+++ b/it/runtime-v1/src/test/java/com/walmartlabs/concord/it/runtime/v1/ProcessIT.java
@@ -70,7 +70,7 @@ public class ProcessIT {
         JGitUtils.applyWorkarounds();
 
         try {
-            ITUtils.createAgentUser(concord.apiClient(), ConcordConfiguration.AGENT_API_KEY);
+            ITUtils.createAgentUser(concord.apiClient(), ConcordConfiguration.agentApiKey);
         } catch (ApiException e) {
             log.error("init -> error", e);
             throw new RuntimeException(e);

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ConcordConfiguration.java
@@ -21,9 +21,11 @@ package com.walmartlabs.concord.it.runtime.v2;
  */
 
 import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.walmartlabs.concord.it.common.ITUtils;
 import org.testcontainers.images.PullPolicy;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,6 +35,7 @@ import java.util.Base64;
 
 public final class ConcordConfiguration {
 
+    public static final String AGENT_API_KEY = Base64.getEncoder().encodeToString(ITUtils.randomString().getBytes(StandardCharsets.UTF_8));
     private static final String DEPENDENCY_RESOLVE_TIMEOUT = System.getProperty("it.runtime.v2.dependencyResolveTimeout", "2 minutes");
 
     private static final Path sharedDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve("concord-it");
@@ -76,6 +79,10 @@ public final class ConcordConfiguration {
                         process {
                             signingKeyPath = "%%sharedDir%%/signing.pem"
                         }
+                        websockets {
+                            # TODO set to true, uncomment agent api token, and create agent user + token like runtime-v1 ITs
+                            requirePermission = false
+                        }
                     }
                     concord-agent {
                         dependencyResolveTimeout = "%%dependencyResolveTimeout%%"
@@ -84,10 +91,14 @@ public final class ConcordConfiguration {
                         prefork {
                             enabled = true
                         }
+                        server {
+                            #apiKey = "%%agentApiKey%%"
+                        }
                     }
                     """
                         .replace("%%sharedDir%%", sharedDir().toString())
-                        .replace("%%dependencyResolveTimeout%%", DEPENDENCY_RESOLVE_TIMEOUT));
+                        .replace("%%dependencyResolveTimeout%%", DEPENDENCY_RESOLVE_TIMEOUT)
+                        .replace("%%agentApiKey%%", AGENT_API_KEY));
 
         boolean localMode = Boolean.parseBoolean(System.getProperty("it.local.mode"));
         if (localMode) {

--- a/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
+++ b/it/runtime-v2/src/test/java/com/walmartlabs/concord/it/runtime/v2/ImportsIT.java
@@ -41,8 +41,13 @@ public class ImportsIT extends AbstractTest {
 
     @RegisterExtension
     public static final ConcordRule concord = ConcordConfiguration.configure()
-            .extraConfigurationSupplier(() -> "concord-server { imports { disabledProcessors = [] } }\n" +
-                    "concord-agent { imports { disabledProcessors = [] } }");
+            .extraConfigurationSupplier(() -> """
+                    concord-server {
+                        imports { disabledProcessors = [] }
+                        websockets { requirePermission = false }
+                    }
+                    concord-agent { imports { disabledProcessors = [] } }
+                    """);
 
     @Test
     public void testDir() throws Exception {

--- a/it/server/src/test/resources/server.conf
+++ b/it/server/src/test/resources/server.conf
@@ -39,4 +39,8 @@ concord-server {
     process {
         checkLogPermissions = true
     }
+
+    websockets {
+        requirePermission = false
+    }
 }

--- a/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
+++ b/it/testing-server/src/main/java/com/walmartlabs/concord/it/testingserver/TestingConcordServer.java
@@ -151,8 +151,13 @@ public class TestingConcordServer implements AutoCloseable {
      * Just an example.
      */
     public static void main(String[] args) throws Exception {
+        var config = Map.<String, Object>of(
+                "process.watchdogPeriod", "10 seconds",
+                "websockets.requirePermission", false
+        );
+
         try (var db = new PostgreSQLContainer<>("postgres:15-alpine");
-             var server = new TestingConcordServer(db, 8001, Map.of("process.watchdogPeriod", "10 seconds"), List.of())) {
+             var server = new TestingConcordServer(db, 8001, config, List.of())) {
             db.start();
             server.start();
             System.out.printf("""

--- a/it/testing-server/src/test/java/com/walmartlabs/concord/it/testingserver/TestingConcordIT.java
+++ b/it/testing-server/src/test/java/com/walmartlabs/concord/it/testingserver/TestingConcordIT.java
@@ -54,7 +54,7 @@ public class TestingConcordIT {
         db.start();
 
         int apiPort = getFreePort();
-        concordServer = new TestingConcordServer(db, apiPort, Map.of(), List.of());
+        concordServer = new TestingConcordServer(db, apiPort, Map.of("websockets.requirePermission", false), List.of());
         concordServer.start();
 
         concordAgent = new TestingConcordAgent(concordServer);

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/liquibase.xml
@@ -120,4 +120,5 @@
     <include file="v2.23.0.xml" relativeToChangelogFile="true"/>
     <include file="v2.31.0.xml" relativeToChangelogFile="true"/>
     <include file="v2.35.0.xml" relativeToChangelogFile="true"/>
+    <include file="v2.45.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.45.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.45.0.xml
@@ -6,7 +6,7 @@
 
     <property name="agentWebsocketPermissionId" value="2aaf4dbb-9a59-41e7-9748-1e9928a8bc04"/>
 
-    <changeSet id="2450000" author="ibodrov@gmail.com">
+    <changeSet id="2450000" author="benjamin.broadaway@walmart.com">
         <insert tableName="PERMISSIONS">
             <column name="PERMISSION_ID" value="${agentWebsocketPermissionId}"/>
             <column name="PERMISSION_NAME" value="agentWebsocket"/>

--- a/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.45.0.xml
+++ b/server/db/src/main/resources/com/walmartlabs/concord/server/db/v2.45.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <property name="agentWebsocketPermissionId" value="2aaf4dbb-9a59-41e7-9748-1e9928a8bc04"/>
+
+    <changeSet id="2450000" author="ibodrov@gmail.com">
+        <insert tableName="PERMISSIONS">
+            <column name="PERMISSION_ID" value="${agentWebsocketPermissionId}"/>
+            <column name="PERMISSION_NAME" value="agentWebsocket"/>
+            <column name="DESCRIPTION" value="Allows users to connect websockets"/>
+        </insert>
+
+        <sql>
+            insert into ROLE_PERMISSIONS values (
+                (select ROLE_ID from ROLES where ROLE_NAME = 'concordAdmin'),
+                '${agentWebsocketPermissionId}'
+            )
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -755,6 +755,10 @@ concord-server {
         }
     }
 
+    websockets {
+        requirePermission = true
+    }
+
     workerMetrics {
         # property in worker "capabilities" which is used to group up the available workers
         groupByCapabilitiesProperty = "flavor"

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/ApiServerModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/ApiServerModule.java
@@ -28,13 +28,11 @@ import com.walmartlabs.concord.server.boot.resteasy.ResteasyModule;
 import com.walmartlabs.concord.server.boot.servlets.FormServletHolder;
 import com.walmartlabs.concord.server.boot.statics.StaticResourcesConfigurator;
 import com.walmartlabs.concord.server.boot.validation.ValidationModule;
-import com.walmartlabs.concord.server.agent.websocket.ConcordWebSocketServlet;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.eclipse.jetty.ee8.servlet.FilterHolder;
 
 import javax.servlet.ServletContextListener;
-import javax.servlet.http.HttpServlet;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/ConcordWebSocketServlet.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/ConcordWebSocketServlet.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.server.agent.websocket;
  */
 
 import com.walmartlabs.concord.server.message.MessageChannelManager;
+import com.walmartlabs.concord.server.security.UserSecurityContext;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyDao;
 import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServletFactory;
@@ -37,16 +38,25 @@ public class ConcordWebSocketServlet extends JettyWebSocketServlet {
 
     private final MessageChannelManager channelManager;
     private final ApiKeyDao apiKeyDao;
+    private final UserSecurityContext userSecurityContext;
+    private final WebsocketsConfiguration cfg;
 
     @Inject
-    public ConcordWebSocketServlet(MessageChannelManager channelManager, ApiKeyDao apiKeyDao) {
+    public ConcordWebSocketServlet(
+            MessageChannelManager channelManager,
+            ApiKeyDao apiKeyDao,
+            WebsocketsConfiguration cfg,
+            UserSecurityContext userSecurityContext
+    ) {
         this.channelManager = channelManager;
         this.apiKeyDao = apiKeyDao;
+        this.cfg = cfg;
+        this.userSecurityContext = userSecurityContext;
     }
 
     @Override
     public void configure(JettyWebSocketServletFactory factory) {
-        factory.setCreator(new WebSocketCreator(channelManager, apiKeyDao));
+        factory.setCreator(new WebSocketCreator(channelManager, apiKeyDao, cfg, userSecurityContext));
     }
 
     @Override

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebSocketCreator.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebSocketCreator.java
@@ -26,7 +26,6 @@ import com.walmartlabs.concord.server.security.Permission;
 import com.walmartlabs.concord.server.security.UserSecurityContext;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyDao;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyEntry;
-import org.apache.shiro.authz.AuthorizationException;
 import org.eclipse.jetty.ee8.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.ee8.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketCreator;
@@ -84,7 +83,7 @@ public class WebSocketCreator implements JettyWebSocketCreator {
             return null;
         }
 
-        if (cfg.isRequirePermission() && !hasPermission(apiKey.getUserId())) {
+        if (cfg.isRequirePermission() && !userSecurityContext.isPermitted(apiKey.getUserId(), Permission.AGENT_WEBSOCKET)) {
             sendError(HttpServletResponse.SC_FORBIDDEN, "Permission denied", resp);
             return null;
         }
@@ -93,27 +92,6 @@ public class WebSocketCreator implements JettyWebSocketCreator {
         String agentId = req.getHeader(QueueClient.AGENT_ID);
         String userAgent = req.getHeader(QueueClient.AGENT_UA);
         return new WebSocketListener(channelManager, channelId, agentId, userAgent);
-    }
-
-    private boolean hasPermission(UUID userId) {
-        try {
-            return userSecurityContext.runAs(userId, () -> {
-                assertPermission(Permission.AGENT_WEBSOCKET);
-                return true;
-            });
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    private static void assertPermission(Permission p) {
-        if (p.isPermitted()) {
-            return;
-        }
-
-        throw new AuthorizationException(
-                String.format("Only roles with '%s' permission are allowed to connect websockets", p.getKey())
-        );
     }
 
     private static boolean invalidApiKey(String s) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebSocketCreator.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebSocketCreator.java
@@ -22,8 +22,11 @@ package com.walmartlabs.concord.server.agent.websocket;
 
 import com.walmartlabs.concord.server.message.MessageChannelManager;
 import com.walmartlabs.concord.server.queueclient.QueueClient;
+import com.walmartlabs.concord.server.security.Permission;
+import com.walmartlabs.concord.server.security.UserSecurityContext;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyDao;
 import com.walmartlabs.concord.server.security.apikey.ApiKeyEntry;
+import org.apache.shiro.authz.AuthorizationException;
 import org.eclipse.jetty.ee8.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.ee8.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketCreator;
@@ -42,10 +45,19 @@ public class WebSocketCreator implements JettyWebSocketCreator {
 
     private final MessageChannelManager channelManager;
     private final ApiKeyDao apiKeyDao;
+    private final WebsocketsConfiguration cfg;
+    private final UserSecurityContext userSecurityContext;
 
-    public WebSocketCreator(MessageChannelManager channelManager, ApiKeyDao apiKeyDao) {
+    public WebSocketCreator(
+            MessageChannelManager channelManager,
+            ApiKeyDao apiKeyDao,
+            WebsocketsConfiguration cfg,
+            UserSecurityContext userSecurityContext
+    ) {
         this.channelManager = channelManager;
         this.apiKeyDao = apiKeyDao;
+        this.cfg = cfg;
+        this.userSecurityContext = userSecurityContext;
     }
 
     @Override
@@ -72,10 +84,36 @@ public class WebSocketCreator implements JettyWebSocketCreator {
             return null;
         }
 
+        if (cfg.isRequirePermission() && !hasPermission(apiKey.getUserId())) {
+            sendError(HttpServletResponse.SC_FORBIDDEN, "Permission denied", resp);
+            return null;
+        }
+
         String channelId = "ws-" + UUID.randomUUID();
         String agentId = req.getHeader(QueueClient.AGENT_ID);
         String userAgent = req.getHeader(QueueClient.AGENT_UA);
         return new WebSocketListener(channelManager, channelId, agentId, userAgent);
+    }
+
+    private boolean hasPermission(UUID userId) {
+        try {
+            return userSecurityContext.runAs(userId, () -> {
+                assertPermission(Permission.AGENT_WEBSOCKET);
+                return true;
+            });
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void assertPermission(Permission p) {
+        if (p.isPermitted()) {
+            return;
+        }
+
+        throw new AuthorizationException(
+                String.format("Only roles with '%s' permission are allowed to connect websockets", p.getKey())
+        );
     }
 
     private static boolean invalidApiKey(String s) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebsocketsConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/agent/websocket/WebsocketsConfiguration.java
@@ -1,0 +1,37 @@
+package com.walmartlabs.concord.server.agent.websocket;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.config.Config;
+
+import javax.inject.Inject;
+
+public class WebsocketsConfiguration {
+
+    @Inject
+    @Config("websockets.requirePermission")
+    private boolean requirePermission;
+
+    public boolean isRequirePermission() {
+        return requirePermission;
+    }
+
+}

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ConfigurationModule.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/ConfigurationModule.java
@@ -27,6 +27,7 @@ import com.walmartlabs.concord.common.cfg.OauthTokenConfig;
 import com.walmartlabs.concord.common.cfg.UnzipLimits;
 import com.walmartlabs.concord.config.ConfigModule;
 import com.walmartlabs.concord.github.appinstallation.cfg.GitHubAppInstallationConfig;
+import com.walmartlabs.concord.server.agent.websocket.WebsocketsConfiguration;
 
 import static com.google.inject.Scopes.SINGLETON;
 
@@ -76,5 +77,6 @@ public class ConfigurationModule implements Module {
         binder.bind(TriggersConfiguration.class).in(SINGLETON);
         binder.bind(UnzipLimits.class).to(UnzipLimitsConfiguration.class).in(SINGLETON);
         binder.bind(WorkerMetricsConfiguration.class).in(SINGLETON);
+        binder.bind(WebsocketsConfiguration.class).in(SINGLETON);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/Permission.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/Permission.java
@@ -46,7 +46,11 @@ public enum Permission {
      * <p>
      * As in {@code com/walmartlabs/concord/server/db/v2.31.0.xml}
      */
-    API_KEY_SPECIFY_VALUE("apiKeySpecifyValue");
+    API_KEY_SPECIFY_VALUE("apiKeySpecifyValue"),
+    /**
+     * Permission to connect a websocket as an agent
+     */
+    AGENT_WEBSOCKET("agentWebsocket"),;
 
     private final String key;
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserSecurityContext.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/security/UserSecurityContext.java
@@ -72,4 +72,16 @@ public class UserSecurityContext {
             ThreadContext.unbindSecurityManager();
         }
     }
+
+    public boolean isPermitted(UUID userId, Permission permission) {
+        var user = userManager.get(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+
+        var principal = new UserPrincipal(InternalRealm.REALM_NAME, user);
+        var principals = new SimplePrincipalCollection(principal, InternalRealm.REALM_NAME);
+
+        return securityManager.isPermitted(principals, permission.getKey());
+    }
 }


### PR DESCRIPTION
This will be a breaking change if an instance relies on the default (no user) token for agent websocket connections. You can disable the requirement with a server config. Not recommened though.

```
    websockets {
        requirePermission = false
    }
```

This makes the integration tests a little trickier to kick off. We may ought to rethink the default token (no user) approach. runtime-v1's ITs create a dedicated agent user and grant it permission, while the other ITs disable the check. There's a util method `ITUtils.createAgentUser()` to handle the creation, it just needs to be fed an api client at the right time. That can be reused for the other ITs, or it may be more appropriate for testcontainers-concord to handle that functionality.