### PR TITLE
concord-server: only allow server to update serialized current user, delete checkpoints when user changes

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/RunAsIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/RunAsIT.java
@@ -24,7 +24,6 @@ import com.walmartlabs.concord.client2.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.*;
@@ -72,14 +71,17 @@ public class RunAsIT extends AbstractServerIT {
         input.put("archive", payload);
         input.put("org", orgName);
         input.put("project", projectName);
+        input.put("arguments.runAsUser", "admin");
 
         StartProcessResponse p = start(input);
-        ProcessApi processApi = new ProcessApi(getApiClient());
         ProcessEntry pe = waitForStatus(getApiClient(), p.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
 
         byte[] ab = getLog(pe.getInstanceId());
         // assume Concord forces all user/domain names to lower case
         assertLog(".*username=" + userAName.toLowerCase() + ".*==.*username=" + userAName.toLowerCase() + ".*", ab);
+
+        CheckpointV3Api checkpointV3Api = new CheckpointV3Api(getApiClient());
+        assertEquals(1, checkpointV3Api.pageCheckpoints(p.getInstanceId(), 0, 5).size());
 
         String formName = findForm(p.getInstanceId());
 
@@ -89,12 +91,11 @@ public class RunAsIT extends AbstractServerIT {
 
         // try submit as a wrong user
 
-        try {
-            formsApi.submitForm(p.getInstanceId(), formName, data);
-            fail("exception expected");
-        } catch (ApiException e) {
-            // ignore
-        }
+        assertThrows(
+                ApiException.class,
+                () -> formsApi.submitForm(p.getInstanceId(), formName, data),
+                "exception expected"
+        );
 
         // submit as the proper user
 
@@ -108,6 +109,82 @@ public class RunAsIT extends AbstractServerIT {
 
         ab = getLog(pe.getInstanceId());
         assertLog(".*Now we are running as admin. Initiator: " + userAName.toLowerCase() + ".*", ab);
+
+        // switching users invalidates checkpoints created before the user switch
+        assertEquals(0, checkpointV3Api.pageCheckpoints(p.getInstanceId(), 0, 5).size());
+    }
+
+    @Test
+    public void testKeepSameUser() throws Exception {
+        // create a new org
+
+        String orgName = "org_" + randomString();
+        createOrg(orgName);
+
+        // add the user A
+
+        String userAName = "userA_" + randomString();
+        CreateApiKeyResponse apiKeyA = addUser(userAName);
+
+        // create the user A's team
+
+        String teamName = "team_" + randomString();
+        UUID teamId = createTeam(orgName, teamName, userAName);
+
+        // switch to the user A and create a new project
+
+        setApiKey(apiKeyA.getKey());
+
+        String projectName = "project_" + randomString();
+        createProject(orgName, projectName);
+
+        // grant the team access to the project
+
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+        projectsApi.updateProjectAccessLevel(orgName, projectName, new ResourceAccessEntry()
+                .teamId(teamId)
+                .orgName(orgName)
+                .teamName(teamName)
+                .level(ResourceAccessEntry.LevelEnum.READER));
+
+        // Start a process
+
+        byte[] payload = archive(RunAsIT.class.getResource("runas").toURI());
+        Map<String, Object> input = new HashMap<>();
+        input.put("archive", payload);
+        input.put("org", orgName);
+        input.put("project", projectName);
+        input.put("arguments.runAsUser", userAName.toLowerCase());
+
+        StartProcessResponse p = start(input);
+        ProcessEntry pe = waitForStatus(getApiClient(), p.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
+
+        byte[] ab = getLog(pe.getInstanceId());
+        // assume Concord forces all user/domain names to lower case
+        assertLog(".*username=" + userAName.toLowerCase() + ".*==.*username=" + userAName.toLowerCase() + ".*", ab);
+
+        CheckpointV3Api checkpointV3Api = new CheckpointV3Api(getApiClient());
+        assertEquals(1, checkpointV3Api.pageCheckpoints(p.getInstanceId(), 0, 5).size());
+
+        String formName = findForm(p.getInstanceId());
+
+        ProcessFormsApi formsApi = new ProcessFormsApi(getApiClient());
+
+        Map<String, Object> data = Collections.singletonMap("firstName", "xxx");
+
+        // submit with same user
+
+        FormSubmitResponse fsr = formsApi.submitForm(p.getInstanceId(), formName, data);
+        assertTrue(fsr.getOk());
+
+        pe = waitForCompletion(getApiClient(), p.getInstanceId());
+        assertEquals(ProcessEntry.StatusEnum.FINISHED, pe.getStatus());
+
+        ab = getLog(pe.getInstanceId());
+        assertLog(".*Now we are running as " + userAName.toLowerCase() +". Initiator: " + userAName.toLowerCase() + ".*", ab);
+
+        // we didn't actually switch, so checkpoints should still exist
+        assertEquals(1, checkpointV3Api.pageCheckpoints(p.getInstanceId(), 0, 5).size());
     }
 
     @Test
@@ -158,7 +235,6 @@ public class RunAsIT extends AbstractServerIT {
         input.put("arguments.testUser", userBName.toLowerCase());
 
         StartProcessResponse p = start(input);
-        ProcessApi processApi = new ProcessApi(getApiClient());
         ProcessEntry pe = waitForStatus(getApiClient(), p.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
 
         byte[] ab = getLog(pe.getInstanceId());
@@ -276,7 +352,7 @@ public class RunAsIT extends AbstractServerIT {
                 .map(u -> new TeamUserEntry()
                         .username(u)
                         .role(TeamUserEntry.RoleEnum.MEMBER))
-                .collect(Collectors.toList()));
+                .toList());
 
         return ctr.getId();
     }

--- a/it/server/src/test/resources/com/walmartlabs/concord/it/server/runas/concord.yml
+++ b/it/server/src/test/resources/com/walmartlabs/concord/it/server/runas/concord.yml
@@ -1,9 +1,10 @@
 flows:
   default:
+    - checkpoint: init
     - log: "${initiator} == ${currentUser}"        # currentUser is the initiator
     - form: myForm
       runAs:
-        username: "admin"                        # optional
+        username: "${runAsUser}"                    # optional
   #      ldap:                                      # optional
   #        group: "CN=Admin,DN=Concord"
         keep: true                                 # continue the execution as the specified user

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessSecurityContext.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessSecurityContext.java
@@ -26,6 +26,7 @@ import com.walmartlabs.concord.server.process.state.ProcessStateManager;
 import com.walmartlabs.concord.server.sdk.PartialProcessKey;
 import com.walmartlabs.concord.server.sdk.ProcessKey;
 import com.walmartlabs.concord.server.security.SecurityUtils;
+import com.walmartlabs.concord.server.security.UserPrincipal;
 import com.walmartlabs.concord.server.security.sessionkey.SessionKeyPrincipal;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.PrincipalCollection;
@@ -35,6 +36,7 @@ import org.apache.shiro.util.ThreadContext;
 
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +72,24 @@ public class ProcessSecurityContext {
             }
         }
         return SecurityUtils.serialize(dst);
+    }
+
+    /**
+     * Compares current security principal to last-saved principal for the
+     * specified process. If they are different, it means that the user has changed.
+     */
+    public boolean hasChanged(ProcessKey processKey) {
+        UserPrincipal current = SecurityUtils.getSubject().getPrincipals().oneByType(UserPrincipal.class);
+        UserPrincipal previous = getPrincipals(processKey).oneByType(UserPrincipal.class);
+
+        if (current == null || previous == null) {
+            return true; // something's funky if either is null. should we throw an exception?
+        }
+
+        UUID currentUserId = current.getUser().getId();
+        UUID previousUserId = previous.getUser().getId();
+
+        return !previousUserId.equals(currentUserId);
     }
 
     // TODO: invalidate cache for processKey?

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ChangeUserProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/ChangeUserProcessor.java
@@ -25,6 +25,7 @@ import com.walmartlabs.concord.sdk.MapUtils;
 import com.walmartlabs.concord.server.process.Payload;
 import com.walmartlabs.concord.server.process.ProcessSecurityContext;
 import com.walmartlabs.concord.server.process.form.FormServiceV1;
+import com.walmartlabs.concord.server.process.state.ProcessCheckpointManager;
 
 import javax.inject.Inject;
 import java.util.Map;
@@ -37,12 +38,15 @@ public class ChangeUserProcessor implements PayloadProcessor {
 
     private final ProcessSecurityContext securityContext;
     private final CurrentUserInfoProcessor currentUserInfoProcessor;
+    private final ProcessCheckpointManager checkpointManager;
 
     @Inject
     public ChangeUserProcessor(ProcessSecurityContext securityContext,
-                               CurrentUserInfoProcessor currentUserInfoProcessor) {
+                               CurrentUserInfoProcessor currentUserInfoProcessor,
+                               ProcessCheckpointManager checkpointManager) {
         this.securityContext = securityContext;
         this.currentUserInfoProcessor = currentUserInfoProcessor;
+        this.checkpointManager = checkpointManager;
     }
 
     @Override
@@ -59,7 +63,13 @@ public class ChangeUserProcessor implements PayloadProcessor {
 
         boolean keep = MapUtils.getBoolean(runAsParams, Constants.Forms.RUN_AS_KEEP_KEY, false);
         if (keep) {
-            securityContext.storeCurrentSubject(payload.getProcessKey());
+            if (securityContext.hasChanged(payload.getProcessKey())) {
+                securityContext.storeCurrentSubject(payload.getProcessKey());
+                // Changing current user loses previous principal data from process state.
+                // Don't allow restoring previously-created checkpoints
+                checkpointManager.deleteAllCheckpoints(payload.getProcessKey());
+            }
+
             return currentUserInfoProcessor.process(chain, payload);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointDao.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointDao.java
@@ -99,6 +99,7 @@ public class ProcessCheckpointDao extends AbstractDao {
                     ps.setObject(3, checkpointId);
                     ps.setString(4, checkpointName);
                     ps.setTimestamp(5, new Timestamp(new Date().getTime()));
+                    // TODO filter archive contents here (or earlier) before adding to DB
                     try (InputStream in = Files.newInputStream(data)) {
                         ps.setBinaryStream(6, in);
                     }
@@ -138,6 +139,13 @@ public class ProcessCheckpointDao extends AbstractDao {
                 }
             });
         });
+    }
+
+    public void deleteAll(ProcessKey processKey) {
+        tx(tx -> tx.deleteFrom(PROCESS_CHECKPOINTS)
+                .where(PROCESS_CHECKPOINTS.INSTANCE_ID.eq(processKey.getInstanceId())
+                        .and(PROCESS_CHECKPOINTS.INSTANCE_CREATED_AT.eq(processKey.getCreatedAt())))
+                .execute());
     }
 
     private static ProcessCheckpointEntry toEntry(Record r) {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessCheckpointManager.java
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.walmartlabs.concord.sdk.Constants.Files.CHECKPOINT_META_FILE_NAME;
@@ -55,6 +56,7 @@ public class ProcessCheckpointManager {
     private final ProcessStateManager stateManager;
     private final ProjectAccessManager projectAccessManager;
     private final ZipService zipService;
+    private final Set<String> ignoreRestorePaths = Set.of(".concord/current_user");
 
     @Inject
     protected ProcessCheckpointManager(ProcessCheckpointDao checkpointDao,
@@ -104,9 +106,10 @@ public class ProcessCheckpointManager {
                 String eventName = readCheckpointEventName(extractedDir.path());
 
                 stateManager.tx(tx -> {
-                    stateManager.deleteDirectory(tx, processKey, Constants.Files.CONCORD_SYSTEM_DIR_NAME);
+                    stateManager.deleteDirectory(tx, processKey, Constants.Files.CONCORD_SYSTEM_DIR_NAME, ignoreRestorePaths);
                     stateManager.deleteDirectory(tx, processKey, Constants.Files.JOB_ATTACHMENTS_DIR_NAME);
-                    stateManager.importPath(tx, processKey, null, extractedDir.path(), (p, attrs) -> true);
+                    stateManager.importPath(tx, processKey, null, extractedDir.path(),
+                            (p, attrs) -> !ignoreRestorePaths.contains(p.getFileName().toString()));
                 });
 
                 Map<String, Object> out = OutVariablesUtils.read(extractedDir.path().resolve(Constants.Files.JOB_ATTACHMENTS_DIR_NAME));
@@ -121,6 +124,10 @@ public class ProcessCheckpointManager {
         } catch (Exception e) {
             throw new RuntimeException("Restore checkpoint '" + checkpointId + "' error", e);
         }
+    }
+
+    public void deleteAllCheckpoints(ProcessKey processKey) {
+        checkpointDao.deleteAll(processKey);
     }
 
     /**

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessStateManager.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/state/ProcessStateManager.java
@@ -268,13 +268,21 @@ public class ProcessStateManager extends AbstractDao {
     /**
      * Remove a directory and all content from it.
      */
-    @WithTimer
     public void deleteDirectory(DSLContext tx, ProcessKey processKey, String path) {
+        deleteDirectory(tx, processKey, path, Set.of());
+    }
+
+    /**
+     * Remove a directory and all content from it, excluding specified paths.
+     */
+    @WithTimer
+    public void deleteDirectory(DSLContext tx, ProcessKey processKey, String path, Set<String> excludePaths) {
         tx.deleteFrom(PROCESS_STATE)
                 .where(PROCESS_STATE.INSTANCE_ID.eq(processKey.getInstanceId())
                         .and(PROCESS_STATE.INSTANCE_CREATED_AT.eq(processKey.getCreatedAt())))
                 .and(PROCESS_STATE.ITEM_PATH.eq(path)
-                        .or(PROCESS_STATE.ITEM_PATH.startsWith(fixPath(path))))
+                        .or(PROCESS_STATE.ITEM_PATH.startsWith(fixPath(path)))
+                        .and(PROCESS_STATE.ITEM_PATH.notIn(excludePaths)))
                 .execute();
     }
 


### PR DESCRIPTION
## Don't allow a user-provided `.concord/current_user` context to be put into active process state

It can exist within a checkpoint, but is ignored upon restore. Ideally would be better to sanitize incoming checkpoint zip and never let it in

##  Delete checkpoints when current user changes

e.g. when a form uses `runAs.keep: true`. Since this updates the `.concord/current_user` in process_state. we can't restore a checkpoint and trust the `.concord/current_user` within it since it came from <something that isn't the server>.

Demonstration of the issue: run this flow as a non-`admin` user, submit the form as `admin`, then restore the checkpoint as the original user before the fix.
```yaml
flows:
  default:
    - checkpoint: hello
    - log: "Hello initiator, ${initiator.username}!"
    - log: "Hello current user, ${currentUser.username}!"

    - form: myForm
      saveSubmittedBy: true
      fields:
        - name: { type: string, label: "Your Name", value: "Concord" }
      runAs:
        username: "admin"
        keep: true

    - log: "Goodbye initiator, ${initiator.username}!"
    - log: "Goodbye current user, ${currentUser.username}!"
```

```
# start
11:44:52 [INFO ] checkpoint hello ('de42e628-3781-414c-bc7a-9a1409790797')
11:44:52 [INFO ] Hello initiator, usera!
11:44:52 [INFO ] Hello current user, usera!

# after submit form
11:44:59 [INFO ] Goodbye initiator, usera!
11:44:59 [INFO ] Goodbye current user, admin!

# restore checkpoint
11:45:11 [INFO ] Hello initiator, usera!
11:45:11 [INFO ] Hello current user, admin! 
```

After the fix, there is no longer a checkpoint to restore with the opportunity to mix up the current user.

An alternative, but slightly more complicated approach may also work:
* Filter incoming checkpoint archives and ignore anything that might conflict. Then re-write server-controlled  `.concord/current_user` (session principle creating the checkpoint) into the archive
  * requires extracting the archive and re-compressing it