### PR TITLE
concord-server: assert access before process resume

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/SuspendIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/SuspendIT.java
@@ -20,9 +20,20 @@ package com.walmartlabs.concord.it.server;
  * =====
  */
 
+import com.walmartlabs.concord.client2.ApiException;
+import com.walmartlabs.concord.client2.ApiKeysApi;
+import com.walmartlabs.concord.client2.CreateApiKeyRequest;
+import com.walmartlabs.concord.client2.CreateApiKeyResponse;
+import com.walmartlabs.concord.client2.CreateUserRequest;
+import com.walmartlabs.concord.client2.CreateUserResponse;
+import com.walmartlabs.concord.client2.OrganizationEntry;
+import com.walmartlabs.concord.client2.OrganizationsApi;
 import com.walmartlabs.concord.client2.ProcessApi;
 import com.walmartlabs.concord.client2.ProcessEntry;
+import com.walmartlabs.concord.client2.ProjectEntry;
+import com.walmartlabs.concord.client2.ProjectsApi;
 import com.walmartlabs.concord.client2.StartProcessResponse;
+import com.walmartlabs.concord.client2.UsersApi;
 import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +43,9 @@ import java.util.regex.Pattern;
 
 import static com.walmartlabs.concord.it.common.ITUtils.archive;
 import static com.walmartlabs.concord.it.common.ServerClient.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SuspendIT extends AbstractServerIT {
 
@@ -115,4 +128,137 @@ public class SuspendIT extends AbstractServerIT {
 
         assertLog(".*task completed.*", ab);
     }
+
+    @Test
+    void resumeAssertPermission() throws Exception {
+
+        String orgName = "org_" + randomString();
+        OrganizationsApi orgApi = new OrganizationsApi(getApiClient());
+        orgApi.createOrUpdateOrg(new OrganizationEntry().name(orgName));
+
+        String projectName = "project_" + randomString();
+        ProjectsApi projectsApi = new ProjectsApi(getApiClient());
+        projectsApi.createOrUpdateProject(orgName, new ProjectEntry()
+                .name(projectName)
+                .rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE));
+
+        URI dir = SuspendIT.class.getResource("suspend").toURI();
+        byte[] payload = archive(dir);
+
+        // ---
+
+        ProcessApi processApi = new ProcessApi(getApiClient());
+
+        Map<String, Object> input = new HashMap<>();
+
+        input.put("org", orgName);
+        input.put("project", projectName);
+        input.put("archive", payload);
+
+        StartProcessResponse spr = start(input);
+
+        UsersApi usersApi = new UsersApi(getApiClient());
+
+        String userName = "user_" + randomString();
+        CreateUserResponse cur = usersApi.createOrUpdateUser(new CreateUserRequest()
+                .username(userName)
+                .type(CreateUserRequest.TypeEnum.LOCAL));
+
+        ApiKeysApi apiKeysApi = new ApiKeysApi(getApiClient());
+        CreateApiKeyResponse car = apiKeysApi.createUserApiKey(new CreateApiKeyRequest()
+                .userId(cur.getId()));
+
+        ProcessEntry pir = waitForStatus(getApiClient(), spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
+
+        // --- switch to non-project user
+
+        setApiKey(car.getKey());
+
+        // --- Expect resume call to be blocked by lack of permission
+
+        String testValue = "test#" + randomString();
+        Map<String, Object> args = Collections.singletonMap("testValue", testValue);
+        Map<String, Object> req = Collections.singletonMap(Constants.Request.ARGUMENTS_KEY, args);
+
+        ApiException ex = assertThrows(ApiException.class, () -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+
+        assertEquals(403, ex.getCode());
+        assertEquals("The current user (" + userName +") doesn't have the necessary access level (READER) to the project: " + projectName, ex.getResponseBody());
+
+
+        // --- back to test default user
+
+        resetApiKey();
+
+        // --- Resume should be allowed by process owner
+
+        assertDoesNotThrow(() -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+
+        pir = waitForCompletion(getApiClient(), spr.getInstanceId());
+        assertEquals(ProcessEntry.StatusEnum.FINISHED, pir.getStatus());
+
+        waitForLog(pir.getInstanceId(), ".*bbbb.*");
+        waitForLog(pir.getInstanceId(), ".*" + Pattern.quote(testValue) + ".*");
+    }
+
+    @Test
+    void resumeAssertPermissionNoProject() throws Exception {
+
+        URI dir = SuspendIT.class.getResource("suspend").toURI();
+        byte[] payload = archive(dir);
+
+        // ---
+
+        ProcessApi processApi = new ProcessApi(getApiClient());
+
+        Map<String, Object> input = new HashMap<>();
+
+        input.put("archive", payload);
+
+        StartProcessResponse spr = start(input);
+
+        UsersApi usersApi = new UsersApi(getApiClient());
+
+        String userName = "user_" + randomString();
+        CreateUserResponse cur = usersApi.createOrUpdateUser(new CreateUserRequest()
+                .username(userName)
+                .type(CreateUserRequest.TypeEnum.LOCAL));
+
+        ApiKeysApi apiKeysApi = new ApiKeysApi(getApiClient());
+        CreateApiKeyResponse car = apiKeysApi.createUserApiKey(new CreateApiKeyRequest()
+                .userId(cur.getId()));
+
+        ProcessEntry pir = waitForStatus(getApiClient(), spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
+
+        // --- switch to non-project user
+
+        setApiKey(car.getKey());
+
+        // --- Expect resume call to be blocked by lack of permission
+
+        String testValue = "test#" + randomString();
+        Map<String, Object> args = Collections.singletonMap("testValue", testValue);
+        Map<String, Object> req = Collections.singletonMap(Constants.Request.ARGUMENTS_KEY, args);
+
+        ApiException ex = assertThrows(ApiException.class, () -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+
+        assertEquals(403, ex.getCode());
+        assertEquals("The current user (" + userName +") doesn't have the necessary permissions to the download _suspend : " + pir.getInstanceId(), ex.getResponseBody());
+
+
+        // --- back to test default user
+
+        resetApiKey();
+
+        // --- Resume should be allowed by process owner
+
+        assertDoesNotThrow(() -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+
+        pir = waitForCompletion(getApiClient(), spr.getInstanceId());
+        assertEquals(ProcessEntry.StatusEnum.FINISHED, pir.getStatus());
+
+        waitForLog(pir.getInstanceId(), ".*bbbb.*");
+        waitForLog(pir.getInstanceId(), ".*" + Pattern.quote(testValue) + ".*");
+    }
+
 }

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/SuspendIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/SuspendIT.java
@@ -20,10 +20,12 @@ package com.walmartlabs.concord.it.server;
  * =====
  */
 
+import com.walmartlabs.concord.client2.ApiClient;
 import com.walmartlabs.concord.client2.ApiException;
 import com.walmartlabs.concord.client2.ApiKeysApi;
 import com.walmartlabs.concord.client2.CreateApiKeyRequest;
 import com.walmartlabs.concord.client2.CreateApiKeyResponse;
+import com.walmartlabs.concord.client2.CreateTeamResponse;
 import com.walmartlabs.concord.client2.CreateUserRequest;
 import com.walmartlabs.concord.client2.CreateUserResponse;
 import com.walmartlabs.concord.client2.OrganizationEntry;
@@ -32,7 +34,11 @@ import com.walmartlabs.concord.client2.ProcessApi;
 import com.walmartlabs.concord.client2.ProcessEntry;
 import com.walmartlabs.concord.client2.ProjectEntry;
 import com.walmartlabs.concord.client2.ProjectsApi;
+import com.walmartlabs.concord.client2.ResourceAccessEntry;
 import com.walmartlabs.concord.client2.StartProcessResponse;
+import com.walmartlabs.concord.client2.TeamEntry;
+import com.walmartlabs.concord.client2.TeamUserEntry;
+import com.walmartlabs.concord.client2.TeamsApi;
 import com.walmartlabs.concord.client2.UsersApi;
 import com.walmartlabs.concord.sdk.Constants;
 import org.junit.jupiter.api.Test;
@@ -141,13 +147,13 @@ public class SuspendIT extends AbstractServerIT {
         projectsApi.createOrUpdateProject(orgName, new ProjectEntry()
                 .name(projectName)
                 .rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE));
+        TeamsApi teamsApi = new TeamsApi(getApiClient()); // save for later with admin token
+
 
         URI dir = SuspendIT.class.getResource("suspend").toURI();
         byte[] payload = archive(dir);
 
-        // ---
-
-        ProcessApi processApi = new ProcessApi(getApiClient());
+        // ---  start process, wait for it to suspend for a resume event
 
         Map<String, Object> input = new HashMap<>();
 
@@ -168,11 +174,12 @@ public class SuspendIT extends AbstractServerIT {
         CreateApiKeyResponse car = apiKeysApi.createUserApiKey(new CreateApiKeyRequest()
                 .userId(cur.getId()));
 
-        ProcessEntry pir = waitForStatus(getApiClient(), spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
+        waitForStatus(getApiClient(), spr.getInstanceId(), ProcessEntry.StatusEnum.SUSPENDED);
 
-        // --- switch to non-project user
+        // --- try to resume with non-project member user
 
-        setApiKey(car.getKey());
+        ApiClient userClient = getApiClientForKey(car.getKey());
+        ProcessApi userProcessApi = new ProcessApi(userClient);
 
         // --- Expect resume call to be blocked by lack of permission
 
@@ -180,21 +187,27 @@ public class SuspendIT extends AbstractServerIT {
         Map<String, Object> args = Collections.singletonMap("testValue", testValue);
         Map<String, Object> req = Collections.singletonMap(Constants.Request.ARGUMENTS_KEY, args);
 
-        ApiException ex = assertThrows(ApiException.class, () -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+        ApiException ex = assertThrows(ApiException.class, () -> userProcessApi.resume(spr.getInstanceId(), "ev1", null, req));
 
         assertEquals(403, ex.getCode());
-        assertEquals("The current user (" + userName +") doesn't have the necessary access level (READER) to the project: " + projectName, ex.getResponseBody());
+        assertEquals("The current user (" + userName + ") doesn't have the necessary access level (WRITER) to the project: " + projectName, ex.getResponseBody());
 
+        // --- Add user to project team access
 
-        // --- back to test default user
+        CreateTeamResponse ctr = teamsApi.createOrUpdateTeam(orgName, new TeamEntry().name("writer_team"));
 
-        resetApiKey();
+        teamsApi.addUsersToTeam(orgName, "writer_team", true, List.of(new TeamUserEntry().userId(cur.getId())));
+        projectsApi.updateProjectAccessLevel(orgName, projectName, new ResourceAccessEntry()
+                .teamId(ctr.getId())
+                .orgName(orgName)
+                .teamName("writer_team")
+                .level(ResourceAccessEntry.LevelEnum.WRITER));
 
-        // --- Resume should be allowed by process owner
+        // --- should work now
 
-        assertDoesNotThrow(() -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+        assertDoesNotThrow(() -> userProcessApi.resume(spr.getInstanceId(), "ev1", null, req));
 
-        pir = waitForCompletion(getApiClient(), spr.getInstanceId());
+        ProcessEntry pir = waitForCompletion(getApiClient(), spr.getInstanceId());
         assertEquals(ProcessEntry.StatusEnum.FINISHED, pir.getStatus());
 
         waitForLog(pir.getInstanceId(), ".*bbbb.*");
@@ -209,7 +222,7 @@ public class SuspendIT extends AbstractServerIT {
 
         // ---
 
-        ProcessApi processApi = new ProcessApi(getApiClient());
+        ProcessApi ownerProcessApi = new ProcessApi(getApiClient());
 
         Map<String, Object> input = new HashMap<>();
 
@@ -232,7 +245,8 @@ public class SuspendIT extends AbstractServerIT {
 
         // --- switch to non-project user
 
-        setApiKey(car.getKey());
+        ApiClient userClient = getApiClientForKey(car.getKey());
+        ProcessApi userProcessApi = new ProcessApi(userClient);
 
         // --- Expect resume call to be blocked by lack of permission
 
@@ -240,7 +254,7 @@ public class SuspendIT extends AbstractServerIT {
         Map<String, Object> args = Collections.singletonMap("testValue", testValue);
         Map<String, Object> req = Collections.singletonMap(Constants.Request.ARGUMENTS_KEY, args);
 
-        ApiException ex = assertThrows(ApiException.class, () -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+        ApiException ex = assertThrows(ApiException.class, () -> userProcessApi.resume(spr.getInstanceId(), "ev1", null, req));
 
         assertEquals(403, ex.getCode());
         assertEquals("The current user (" + userName +") doesn't have the necessary permissions to the download _suspend : " + pir.getInstanceId(), ex.getResponseBody());
@@ -252,7 +266,7 @@ public class SuspendIT extends AbstractServerIT {
 
         // --- Resume should be allowed by process owner
 
-        assertDoesNotThrow(() -> processApi.resume(spr.getInstanceId(), "ev1", null, req));
+        assertDoesNotThrow(() -> ownerProcessApi.resume(spr.getInstanceId(), "ev1", null, req));
 
         pir = waitForCompletion(getApiClient(), spr.getInstanceId());
         assertEquals(ProcessEntry.StatusEnum.FINISHED, pir.getStatus());

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -329,7 +329,7 @@ public class ProcessResource implements Resource {
         ProcessEntry entry = assertProcess(PartialProcessKey.from(instanceId));
         ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
 
-        assertProcessAccess(entry, ResourceAccessLevel.READER, Constants.Files.SUSPEND_MARKER_FILE_NAME);
+        assertProcessAccess(entry, ResourceAccessLevel.WRITER, Constants.Files.SUSPEND_MARKER_FILE_NAME);
 
         processManager.assertResumeEvents(processKey, Set.of(eventName));
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/ProcessResource.java
@@ -326,7 +326,10 @@ public class ProcessResource implements Resource {
                                         @QueryParam("saveAs") String saveAs,
                                         Map<String, Object> req) {
 
-        ProcessKey processKey = assertProcessKey(instanceId);
+        ProcessEntry entry = assertProcess(PartialProcessKey.from(instanceId));
+        ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
+
+        assertProcessAccess(entry, ResourceAccessLevel.READER, Constants.Files.SUSPEND_MARKER_FILE_NAME);
 
         processManager.assertResumeEvents(processKey, Set.of(eventName));
 
@@ -538,7 +541,7 @@ public class ProcessResource implements Resource {
                                        @PathParam("name") @NotNull @Size(min = 1) String attachmentName) {
 
         ProcessEntry processEntry = processManager.assertProcess(instanceId);
-        assertProcessAccess(processEntry, "attachment");
+        assertProcessAccessOwner(processEntry, "attachment");
         PartialProcessKey processKey = new ProcessKey(processEntry.instanceId(), processEntry.createdAt());
 
         // TODO replace with javax.validation
@@ -587,7 +590,7 @@ public class ProcessResource implements Resource {
     public List<String> listAttachments(@PathParam("id") UUID instanceId) {
 
         ProcessEntry processEntry = processManager.assertProcess(instanceId);
-        assertProcessAccess(processEntry, "attachments");
+        assertProcessAccessOwner(processEntry, "attachments");
 
         PartialProcessKey processKey = new ProcessKey(processEntry.instanceId(), processEntry.createdAt());
 
@@ -749,7 +752,7 @@ public class ProcessResource implements Resource {
         ProcessEntry entry = assertProcess(PartialProcessKey.from(instanceId));
         ProcessKey processKey = new ProcessKey(entry.instanceId(), entry.createdAt());
 
-        assertProcessAccess(entry, "state");
+        assertProcessAccessOwner(entry, "state");
 
         StreamingOutput out = output -> {
             try (ZipArchiveOutputStream dst = new ZipArchiveOutputStream(output)) {
@@ -785,7 +788,7 @@ public class ProcessResource implements Resource {
         ProcessEntry p = assertProcess(PartialProcessKey.from(instanceId));
         ProcessKey processKey = new ProcessKey(p.instanceId(), p.createdAt());
 
-        assertProcessAccess(p, "state");
+        assertProcessAccessOwner(p, "state");
         assertResourceAccess(p, fileName);
 
         StreamingOutput out = output -> {
@@ -961,7 +964,11 @@ public class ProcessResource implements Resource {
         return processKey;
     }
 
-    private void assertProcessAccess(ProcessEntry pe, String downloadEntity) {
+    private void assertProcessAccessOwner(ProcessEntry pe, String downloadEntity) {
+        assertProcessAccess(pe, ResourceAccessLevel.OWNER, downloadEntity);
+    }
+
+    private void assertProcessAccess(ProcessEntry pe, ResourceAccessLevel accessLevel, String entity) {
         UserPrincipal principal = UserPrincipal.assertCurrent();
 
         UUID initiatorId = pe.initiatorId();
@@ -975,12 +982,12 @@ public class ProcessResource implements Resource {
         }
 
         if (pe.projectId() != null) {
-            projectAccessManager.assertAccess(pe.projectId(), ResourceAccessLevel.OWNER, true);
+            projectAccessManager.assertAccess(pe.projectId(), accessLevel, true);
             return;
         }
 
         throw new UnauthorizedException("The current user (" + principal.getUsername() + ") doesn't have " +
-                                        "the necessary permissions to the download " + downloadEntity + " : " + pe.instanceId());
+                "the necessary permissions to the download " + entity + " : " + pe.instanceId());
     }
 
     private void assertResourceAccess(ProcessEntry pe, String resource) {


### PR DESCRIPTION
Assert permission before resuming a process. User must be one of:

* The process owner (started the process)
* Member of Project with `WRITER` access or higher (ignored if process is not executed in a Project)
* An admin
* A global reader