### PR TITLE
concord-server: config option to enable template UI sources with scheme allow-list

### DIFF
--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
@@ -144,7 +144,7 @@ public class TemplateIT extends AbstractServerIT {
     @Test
     void testInvalidScheme() throws Exception {
         Map<String, Object> input = new HashMap<>();
-        input.put("template", "file:///etc/passwd");
+        input.put("template", "http://example.local/insecure.yml");
         StartProcessResponse spr = start(input);
 
         // ---
@@ -155,7 +155,7 @@ public class TemplateIT extends AbstractServerIT {
         // ---
 
         byte[] ab = getLog(pir.getInstanceId());
-        assertLog(".*Invalid template scheme: file.*", ab);
+        assertLog(".*Invalid template scheme: http.*", ab);
     }
 
     @Test

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
@@ -155,7 +155,7 @@ public class TemplateIT extends AbstractServerIT {
         // ---
 
         byte[] ab = getLog(pir.getInstanceId());
-        assertLog(".*Invalid template scheme: http.*", ab);
+        assertLog(".*Invalid template scheme: 'http'.*", ab);
     }
 
     @Test

--- a/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
+++ b/it/server/src/test/java/com/walmartlabs/concord/it/server/TemplateIT.java
@@ -142,6 +142,23 @@ public class TemplateIT extends AbstractServerIT {
     }
 
     @Test
+    void testInvalidScheme() throws Exception {
+        Map<String, Object> input = new HashMap<>();
+        input.put("template", "file:///etc/passwd");
+        StartProcessResponse spr = start(input);
+
+        // ---
+
+        ProcessEntry pir = waitForCompletion(getApiClient(), spr.getInstanceId());
+        assertEquals(ProcessEntry.StatusEnum.FAILED, pir.getStatus());
+
+        // ---
+
+        byte[] ab = getLog(pir.getInstanceId());
+        assertLog(".*Invalid template scheme: file.*", ab);
+    }
+
+    @Test
     public void testEntryPointReference() throws Exception {
         final String processYml = "fromTemplate:\n- log: \"hello!\"";
         Path templatePath = createTemplate(processYml, null);

--- a/it/server/src/test/resources/server.conf
+++ b/it/server/src/test/resources/server.conf
@@ -40,6 +40,10 @@ concord-server {
         checkLogPermissions = true
     }
 
+    templates {
+        allowedUriSchemes = [ "https", "file" ]
+    }
+
     websockets {
         requirePermission = false
     }

--- a/runtime/v1/impl/src/test/java/com/walmartlabs/concord/runner/engine/DockerServiceTest.java
+++ b/runtime/v1/impl/src/test/java/com/walmartlabs/concord/runner/engine/DockerServiceTest.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.runner.engine;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/DockerServiceTest.java
+++ b/runtime/v2/runner/src/test/java/com/walmartlabs/concord/runtime/v2/runner/DockerServiceTest.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.runtime.v2.runner;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -297,7 +297,7 @@ concord-server {
     templates {
         allowScripting = true
         allowUriSource = true
-        allowedUriSchemes = [ "https" ]
+        allowedUriSchemes = [ "https", "mvn" ]
     }
 
     imports {

--- a/server/dist/src/main/resources/concord-server.conf
+++ b/server/dist/src/main/resources/concord-server.conf
@@ -296,6 +296,8 @@ concord-server {
 
     templates {
         allowScripting = true
+        allowUriSource = true
+        allowedUriSchemes = [ "https" ]
     }
 
     imports {

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/TemplatesConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/TemplatesConfiguration.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.server.cfg;
 import com.walmartlabs.concord.config.Config;
 
 import javax.inject.Inject;
+import java.util.List;
 
 public class TemplatesConfiguration {
 
@@ -30,8 +31,23 @@ public class TemplatesConfiguration {
     @Config("templates.allowScripting")
     private boolean allowScripting;
 
+    @Inject
+    @Config("templates.allowUriSource")
+    private boolean allowUriSource;
+
+    @Inject
+    @Config("templates.allowedUriSchemes")
+    private List<String> allowedUriSchemes;
+
     public boolean isAllowScripting() {
         return allowScripting;
     }
 
+    public boolean isAllowUriSource() {
+        return allowUriSource;
+    }
+
+    public List<String> getAllowedUriScheme() {
+        return allowedUriSchemes;
+    }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/TemplatesConfiguration.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/cfg/TemplatesConfiguration.java
@@ -24,6 +24,7 @@ import com.walmartlabs.concord.config.Config;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Set;
 
 public class TemplatesConfiguration {
 
@@ -47,7 +48,7 @@ public class TemplatesConfiguration {
         return allowUriSource;
     }
 
-    public List<String> getAllowedUriScheme() {
-        return allowedUriSchemes;
+    public Set<String> getAllowedUriSchemes() {
+        return Set.copyOf(allowedUriSchemes);
     }
 }

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/TemplateFilesProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/TemplateFilesProcessor.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.server.process.pipelines.processors;
 import com.walmartlabs.concord.common.ZipService;
 import com.walmartlabs.concord.dependencymanager.DependencyManager;
 import com.walmartlabs.concord.sdk.Constants;
+import com.walmartlabs.concord.server.cfg.TemplatesConfiguration;
 import com.walmartlabs.concord.server.process.Payload;
 import com.walmartlabs.concord.server.process.ProcessException;
 import com.walmartlabs.concord.server.process.logs.ProcessLogManager;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -46,17 +48,20 @@ public class TemplateFilesProcessor implements PayloadProcessor {
     private final ProcessLogManager logManager;
     private final DependencyManager dependencyManager;
     private final TemplateAliasDao aliasDao;
+    private final TemplatesConfiguration templatesConfiguration;
     private final ZipService zipService;
 
     @Inject
     public TemplateFilesProcessor(DependencyManager dependencyManager,
                                   ProcessLogManager logManager,
                                   TemplateAliasDao aliasDao,
+                                  TemplatesConfiguration templatesConfiguration,
                                   ZipService zipService) {
 
         this.logManager = logManager;
         this.aliasDao = aliasDao;
         this.dependencyManager = dependencyManager;
+        this.templatesConfiguration = templatesConfiguration;
         this.zipService = zipService;
     }
 
@@ -92,6 +97,14 @@ public class TemplateFilesProcessor implements PayloadProcessor {
                 return getByAlias(processKey, template);
             }
 
+            if (!templatesConfiguration.isAllowUriSource()) {
+                throw new IllegalArgumentException("Templates must be configured through an alias.");
+            }
+
+            if (!templatesConfiguration.getAllowedUriScheme().contains(scheme)) {
+                throw new IllegalArgumentException("Invalid template scheme: " + scheme);
+            }
+
             return u;
         } catch (URISyntaxException e) {
             return getByAlias(processKey, template);
@@ -100,7 +113,7 @@ public class TemplateFilesProcessor implements PayloadProcessor {
 
     private URI getByAlias(PartialProcessKey processKey, String s) throws URISyntaxException {
         Optional<String> o = aliasDao.get(s);
-        if (!o.isPresent()) {
+        if (o.isEmpty()) {
             throw new ProcessException(processKey, "Invalid template URL or alias: " + s);
         }
 

--- a/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/TemplateFilesProcessor.java
+++ b/server/impl/src/main/java/com/walmartlabs/concord/server/process/pipelines/processors/TemplateFilesProcessor.java
@@ -36,9 +36,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Extracts template files into the workspace.
@@ -101,13 +101,23 @@ public class TemplateFilesProcessor implements PayloadProcessor {
                 throw new IllegalArgumentException("Templates must be configured through an alias.");
             }
 
-            if (!templatesConfiguration.getAllowedUriScheme().contains(scheme)) {
-                throw new IllegalArgumentException("Invalid template scheme: " + scheme);
-            }
+            assertAllowedScheme(scheme);
 
             return u;
         } catch (URISyntaxException e) {
             return getByAlias(processKey, template);
+        }
+    }
+
+    private void assertAllowedScheme(String scheme) {
+        Set<String> allowedSchemes = templatesConfiguration.getAllowedUriSchemes();
+
+        if (allowedSchemes.isEmpty()) {
+            return; // allow all
+        }
+
+        if (!allowedSchemes.contains(scheme)) {
+            throw new IllegalArgumentException("Invalid template scheme: '" + scheme + "'. Allowed schemes: " + String.join(", ", allowedSchemes));
         }
     }
 


### PR DESCRIPTION
Better control over template sources. Production instances should generally only allow templates from admin-configured aliases.