### PR TITLE
project: update central-publishing-plugin, wait for upload instead of validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,10 +218,12 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.11.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>
+                        <!-- validation may take quite a while, check central console for status -->
+                        <waitUntil>uploaded</waitUntil>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
https://central.sonatype.org/publish/publish-portal-maven/#waituntil

Default config waits for the release to be `validated`. This can take a considerable, any varying, amount of time and usually times out. We could extend the timeout with `waitMaxTime`, but it's probably better to just stop polling once it's `uploaded` and take it from there manually. 